### PR TITLE
Fix homepage redirect for unauthenticated users

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,9 +2,9 @@ import type { PageServerLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { userId } = locals.auth();
+        const auth = locals.auth();
 
-	if (userId) {
-		return redirect(307, '/classes');
-	}
+        if (auth?.userId) {
+                return redirect(307, '/classes');
+        }
 };


### PR DESCRIPTION
## Summary
- Prevent root page crash for logged-out visitors by guarding auth check and only redirecting when a user ID exists

## Testing
- `npm run lint` *(fails: Code style issues found in 66 files)*
- `npm run check` *(fails: svelte-check found 15 errors in 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_68971351bc9883269144f791f313a5b0