### PR TITLE
Ensure matching answers shuffle differs from prompt order

### DIFF
--- a/src/lib/components/Matching.svelte
+++ b/src/lib/components/Matching.svelte
@@ -26,11 +26,26 @@
 
     $effect(() => {
         const answerOpts = answers();
+        if (answerOpts.length <= 1) {
+            shuffledAnswers = answerOpts;
+            return;
+        }
+
+        const answersInPromptOrder = prompts()
+            .map((prompt) => correctAnswerIdForPrompt(prompt.id))
+            .map((answerId) => answerOpts.find((opt) => opt.id === answerId))
+            .filter((opt): opt is Option => Boolean(opt));
+
         let out = fisherYates(answerOpts);
-        const sameOrder = out.length === answerOpts.length && out.every((o, i) => o.id === answerOpts[i].id);
-        if (sameOrder && out.length > 1) {
+
+        const matchesOriginalOrder = out.length === answerOpts.length && out.every((o, i) => o.id === answerOpts[i].id);
+        const matchesPromptOrder =
+            answersInPromptOrder.length === out.length && out.every((o, i) => o.id === answersInPromptOrder[i].id);
+
+        if ((matchesOriginalOrder || matchesPromptOrder) && out.length > 1) {
             out = [...out.slice(1), out[0]];
         }
+
         shuffledAnswers = out;
     });
 


### PR DESCRIPTION
## Summary
- ensure matching question answers are shuffled and never mirror the prompt ordering
- guard against trivial cases with a single answer option

## Testing
- npm run lint *(fails: existing Prettier formatting issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e3e853f08326953f67075b9dfe39