### PR TITLE
explanation rationale migration

### DIFF
--- a/questions_convex.json
+++ b/questions_convex.json
@@ -2,7 +2,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2c3616e9"],
-		"explanation": "Pharmacodynamics refers to the biological and physiological effects of drugs on the body, essentially what the drug does to the body. Option A describes pharmacokinetics, option C is a general definition of pharmacology, option D describes the therapeutic window, and option E refers to affinity.",
+		"rationale": "Pharmacodynamics refers to the biological and physiological effects of drugs on the body, essentially what the drug does to the body. Option A describes pharmacokinetics, option C is a general definition of pharmacology, option D describes the therapeutic window, and option E refers to affinity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -36,7 +36,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dafe0903"],
-		"explanation": "The therapeutic window is the range of drug concentrations between the minimum effective concentration and the minimum toxic concentration. Option B describes the therapeutic index, option C describes efficacy, option D describes affinity, and option E describes selectivity.",
+		"rationale": "The therapeutic window is the range of drug concentrations between the minimum effective concentration and the minimum toxic concentration. Option B describes the therapeutic index, option C describes efficacy, option D describes affinity, and option E describes selectivity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -70,7 +70,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6e4e5084"],
-		"explanation": "Orphan drugs are intended for the diagnosis, prevention, or treatment of rare diseases. Option A is incorrect as they are not for common diseases, option C is not necessarily true, option D is incorrect as they are not always biologics, and option E is incorrect as they can be expensive to develop.",
+		"rationale": "Orphan drugs are intended for the diagnosis, prevention, or treatment of rare diseases. Option A is incorrect as they are not for common diseases, option C is not necessarily true, option D is incorrect as they are not always biologics, and option E is incorrect as they can be expensive to develop.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -104,7 +104,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5006531d"],
-		"explanation": "Efficacy refers to the maximum effect a drug can produce. Option B describes affinity, option C describes the therapeutic window, option D describes selectivity, and option E is related to pharmacokinetics.",
+		"rationale": "Efficacy refers to the maximum effect a drug can produce. Option B describes affinity, option C describes the therapeutic window, option D describes selectivity, and option E is related to pharmacokinetics.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -138,7 +138,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5f2fe97d"],
-		"explanation": "NSAIDs block cyclooxygenase, which is an example of enzyme inhibition. Option A describes ion transport disruption, option C describes ion transport, option D describes nucleic acid targeting, and option E describes receptor binding.",
+		"rationale": "NSAIDs block cyclooxygenase, which is an example of enzyme inhibition. Option A describes ion transport disruption, option C describes ion transport, option D describes nucleic acid targeting, and option E describes receptor binding.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -172,7 +172,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b23caaf4"],
-		"explanation": "Covalent bonds are the strongest type of bond in drug-receptor interactions. Electrostatic bonds, hydrogen bonds, Van der Waals interactions, and hydrophobic interactions are weaker than covalent bonds.",
+		"rationale": "Covalent bonds are the strongest type of bond in drug-receptor interactions. Electrostatic bonds, hydrogen bonds, Van der Waals interactions, and hydrophobic interactions are weaker than covalent bonds.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -206,7 +206,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["93fb04bc"],
-		"explanation": "A therapeutic index greater than 5 indicates that the drug is considered safe. Option A refers to potency, option B refers to efficacy, option D is incorrect as a high TI indicates a wide therapeutic window, and option E refers to affinity.",
+		"rationale": "A therapeutic index greater than 5 indicates that the drug is considered safe. Option A refers to potency, option B refers to efficacy, option D is incorrect as a high TI indicates a wide therapeutic window, and option E refers to affinity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -240,7 +240,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["caa6c208"],
-		"explanation": "Proton pump inhibitors exert their effect by blocking hydrogen/potassium ATPase. Option A describes receptor binding, option C describes enzyme inhibition by NSAIDs, option D describes nucleic acid targeting, and option E describes intracellular protein interaction.",
+		"rationale": "Proton pump inhibitors exert their effect by blocking hydrogen/potassium ATPase. Option A describes receptor binding, option C describes enzyme inhibition by NSAIDs, option D describes nucleic acid targeting, and option E describes intracellular protein interaction.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -274,7 +274,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["74aa43bd"],
-		"explanation": "Selectivity refers to the separation between desired and undesired effects of a drug. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E is related to pharmacokinetics.",
+		"rationale": "Selectivity refers to the separation between desired and undesired effects of a drug. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E is related to pharmacokinetics.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -308,7 +308,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["63d9cec7"],
-		"explanation": "Affinity refers to the strength of binding between a drug and its receptor. Option A describes efficacy, option C describes selectivity, option D describes the therapeutic window, and option E is related to pharmacokinetics",
+		"rationale": "Affinity refers to the strength of binding between a drug and its receptor. Option A describes efficacy, option C describes selectivity, option D describes the therapeutic window, and option E is related to pharmacokinetics",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -342,7 +342,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["787e1a25"],
-		"explanation": "Diuretics affect the body by pulling sodium ions across membranes, which is an example of ion transport disruption. Option A describes proton pump inhibition, option B describes enzyme inhibition, option D describes nucleic acid targeting, and option E describes receptor binding.",
+		"rationale": "Diuretics affect the body by pulling sodium ions across membranes, which is an example of ion transport disruption. Option A describes proton pump inhibition, option B describes enzyme inhibition, option D describes nucleic acid targeting, and option E describes receptor binding.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -376,7 +376,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3e963bc5"],
-		"explanation": "Dose-response curves show the relationship between drug dose and the maximum effect produced. Option A describes affinity, option C describes the therapeutic window, option D describes selectivity, and option E is related to pharmacokinetics.",
+		"rationale": "Dose-response curves show the relationship between drug dose and the maximum effect produced. Option A describes affinity, option C describes the therapeutic window, option D describes selectivity, and option E is related to pharmacokinetics.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -410,7 +410,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ff56b9e8"],
-		"explanation": "5-fluorouracil acts as a counterfeit substitute for uracil, which is an example of nucleic acid targeting. Option A describes proton pump inhibition, option B describes enzyme inhibition, option C describes ion transport disruption, and option E describes receptor binding.",
+		"rationale": "5-fluorouracil acts as a counterfeit substitute for uracil, which is an example of nucleic acid targeting. Option A describes proton pump inhibition, option B describes enzyme inhibition, option C describes ion transport disruption, and option E describes receptor binding.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -444,7 +444,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a2fad535"],
-		"explanation": "Potency refers to the amount of drug needed to produce a given effect. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E describes selectivity.",
+		"rationale": "Potency refers to the amount of drug needed to produce a given effect. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E describes selectivity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -478,7 +478,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8c9d5b13"],
-		"explanation": "Covalent bonds are strong and often irreversible in drug-receptor interactions. Option A is incorrect as they are the strongest type of bond, option B is incorrect as they are often irreversible, and options D and E are incorrect as covalent bonds are stronger than hydrogen bonds and Van der Waals interactions.",
+		"rationale": "Covalent bonds are strong and often irreversible in drug-receptor interactions. Option A is incorrect as they are the strongest type of bond, option B is incorrect as they are often irreversible, and options D and E are incorrect as covalent bonds are stronger than hydrogen bonds and Van der Waals interactions.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -512,7 +512,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3633490c"],
-		"explanation": "Chirality refers to the existence of mirror image forms of a drug molecule, where one enantiomer may be effective and another may be inactive or toxic. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E describes selectivity.",
+		"rationale": "Chirality refers to the existence of mirror image forms of a drug molecule, where one enantiomer may be effective and another may be inactive or toxic. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E describes selectivity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -546,7 +546,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7dc85a67"],
-		"explanation": "Drugs that cause a change in cell physiology through intracellular proteins are examples of intracellular protein interaction. Option A describes proton pump inhibition, option B describes enzyme inhibition, option C describes ion transport disruption, and option D describes nucleic acid targeting.",
+		"rationale": "Drugs that cause a change in cell physiology through intracellular proteins are examples of intracellular protein interaction. Option A describes proton pump inhibition, option B describes enzyme inhibition, option C describes ion transport disruption, and option D describes nucleic acid targeting.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -580,7 +580,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2a691c96"],
-		"explanation": "A drug-receptor complex refers to the reversible interaction between a drug and its receptor leading to an effect. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E describes selectivity.",
+		"rationale": "A drug-receptor complex refers to the reversible interaction between a drug and its receptor leading to an effect. Option A describes efficacy, option B describes affinity, option D describes the therapeutic window, and option E describes selectivity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -614,7 +614,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bf943dd4"],
-		"explanation": "The therapeutic index can also be calculated using the lethal dose (LD50) instead of the toxic dose (TD50). Option A is incorrect as it is the ratio of the toxic dose to the effective dose, option B is incorrect as a TI less than 2 indicates an unsafe drug, option C is incorrect as a TI greater than 5 indicates a safe drug, and option E describes affinity.",
+		"rationale": "The therapeutic index can also be calculated using the lethal dose (LD50) instead of the toxic dose (TD50). Option A is incorrect as it is the ratio of the toxic dose to the effective dose, option B is incorrect as a TI less than 2 indicates an unsafe drug, option C is incorrect as a TI greater than 5 indicates a safe drug, and option E describes affinity.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -648,7 +648,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fde37131"],
-		"explanation": "Agonists binding to cell receptors is an example of a drug affecting the body by receptor binding. Option A describes proton pump inhibition, option B describes enzyme inhibition, option C describes ion transport disruption, and option D describes nucleic acid targeting.",
+		"rationale": "Agonists binding to cell receptors is an example of a drug affecting the body by receptor binding. Option A describes proton pump inhibition, option B describes enzyme inhibition, option C describes ion transport disruption, and option D describes nucleic acid targeting.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -682,7 +682,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1d65b560"],
-		"explanation": "An antagonist binds to a receptor and blocks its activation, preventing the natural ligand from eliciting a response. Option A describes an agonist, C and D describe potential effects of agonists or allosteric modulators, and E is not a typical mechanism of drug action.",
+		"rationale": "An antagonist binds to a receptor and blocks its activation, preventing the natural ligand from eliciting a response. Option A describes an agonist, C and D describe potential effects of agonists or allosteric modulators, and E is not a typical mechanism of drug action.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -716,7 +716,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8f063c00"],
-		"explanation": "NSAIDs inhibit the cyclooxygenase enzyme to reduce pain and inflammation. Diuretics work by ion transport disruption, not enzyme inhibition. Proton Pump Inhibitors block hydrogen/potassium ATPase, which is not ion transport disruption. Statins inhibit HMG-CoA reductase, not receptor agonism. Antimetabolites target nucleic acids, not ion transport.",
+		"rationale": "NSAIDs inhibit the cyclooxygenase enzyme to reduce pain and inflammation. Diuretics work by ion transport disruption, not enzyme inhibition. Proton Pump Inhibitors block hydrogen/potassium ATPase, which is not ion transport disruption. Statins inhibit HMG-CoA reductase, not receptor agonism. Antimetabolites target nucleic acids, not ion transport.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -750,7 +750,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["730fc911"],
-		"explanation": "5-fluorouracil acts as a counterfeit substitute for uracil, becoming incorporated into faulty mRNA. It does not inhibit cyclooxygenase (A), block hydrogen/potassium ATPase (C), enhance protein synthesis (D), or act as a receptor antagonist (E).",
+		"rationale": "5-fluorouracil acts as a counterfeit substitute for uracil, becoming incorporated into faulty mRNA. It does not inhibit cyclooxygenase (A), block hydrogen/potassium ATPase (C), enhance protein synthesis (D), or act as a receptor antagonist (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -784,7 +784,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c3b266a4"],
-		"explanation": "Covalent bonds are the strongest and often irreversible, forming a stable carbon-carbon connection. Electrostatic (A), hydrophobic interactions (B), hydrogen bonds (C), and Van der Waals (D) are non-covalent and reversible, with varying strengths.",
+		"rationale": "Covalent bonds are the strongest and often irreversible, forming a stable carbon-carbon connection. Electrostatic (A), hydrophobic interactions (B), hydrogen bonds (C), and Van der Waals (D) are non-covalent and reversible, with varying strengths.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -818,7 +818,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["05bbfed6"],
-		"explanation": "Enantiomers are mirror images of a drug molecule, and one may be inactive or toxic while the other is effective. They do not have identical effects (A), can be separated (D), and significantly impact drug efficacy (E).",
+		"rationale": "Enantiomers are mirror images of a drug molecule, and one may be inactive or toxic while the other is effective. They do not have identical effects (A), can be separated (D), and significantly impact drug efficacy (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -852,7 +852,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["77d55c3f"],
-		"explanation": "Intracellular proteins can be targets for drugs, leading to changes in cell physiology. They are not the primary targets for all drugs (A), not exclusively targeted by biologics (C), not primarily responsible for drug metabolism (D), and are involved in pharmacodynamics (E).",
+		"rationale": "Intracellular proteins can be targets for drugs, leading to changes in cell physiology. They are not the primary targets for all drugs (A), not exclusively targeted by biologics (C), not primarily responsible for drug metabolism (D), and are involved in pharmacodynamics (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -886,7 +886,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a45753b"],
-		"explanation": "The formation of a drug-receptor complex initiates the effect of the drug, which is represented on the dose-response curve. The curve's position (A, B) and slope (D) are influenced by other factors, and the complex formation is crucial for drug action (E).",
+		"rationale": "The formation of a drug-receptor complex initiates the effect of the drug, which is represented on the dose-response curve. The curve's position (A, B) and slope (D) are influenced by other factors, and the complex formation is crucial for drug action (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -920,7 +920,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["39ebc3f9"],
-		"explanation": "Proton pump inhibitors block hydrogen/potassium ATPase, reducing acid secretion in the stomach. They do not enhance acid secretion (A), act as receptor agonists (C), inhibit cyclooxygenase (D), or increase sodium ion transport (E).",
+		"rationale": "Proton pump inhibitors block hydrogen/potassium ATPase, reducing acid secretion in the stomach. They do not enhance acid secretion (A), act as receptor agonists (C), inhibit cyclooxygenase (D), or increase sodium ion transport (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -954,7 +954,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["be0cc74d"],
-		"explanation": "Dose-response curves illustrate the relationship between drug dose and its effect, helping to understand the drug's efficacy and potency. They do not measure metabolism (A), determine structure (C), predict side effects (D), or assess distribution (E).",
+		"rationale": "Dose-response curves illustrate the relationship between drug dose and its effect, helping to understand the drug's efficacy and potency. They do not measure metabolism (A), determine structure (C), predict side effects (D), or assess distribution (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -988,7 +988,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8f2539a7"],
-		"explanation": "Ion transport disruption involves the movement of ions across membranes, often affecting water movement. It is not used by all antibiotics (A), is related to water movement (C), is not the primary action of NSAIDs (D), and is involved in diuretics' action (E).",
+		"rationale": "Ion transport disruption involves the movement of ions across membranes, often affecting water movement. It is not used by all antibiotics (A), is related to water movement (C), is not the primary action of NSAIDs (D), and is involved in diuretics' action (E).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1022,7 +1022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["98ccb8ed"],
-		"explanation": "In dose-response curves, the X-axis represents the concentration, and the Y-axis represents the response. Potency is indicated by the position of the curve along the X-axis, with a leftward shift indicating higher potency. Maximal efficacy is indicated by the plateau of the curve, not the slope, and the curve is typically sigmoidal, not linear.",
+		"rationale": "In dose-response curves, the X-axis represents the concentration, and the Y-axis represents the response. Potency is indicated by the position of the curve along the X-axis, with a leftward shift indicating higher potency. Maximal efficacy is indicated by the plateau of the curve, not the slope, and the curve is typically sigmoidal, not linear.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1056,7 +1056,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["df4e490c"],
-		"explanation": "A leftward shift of the dose-response curve indicates increased potency, meaning a lower concentration of the drug is needed to achieve the same effect. It does not necessarily affect maximal efficacy or the slope of the curve.",
+		"rationale": "A leftward shift of the dose-response curve indicates increased potency, meaning a lower concentration of the drug is needed to achieve the same effect. It does not necessarily affect maximal efficacy or the slope of the curve.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1090,7 +1090,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a397e87a"],
-		"explanation": "Potency is a pharmacodynamic parameter that describes the amount of drug needed to produce a given effect. Absorption, distribution, metabolism, and excretion are pharmacokinetic parameters.",
+		"rationale": "Potency is a pharmacodynamic parameter that describes the amount of drug needed to produce a given effect. Absorption, distribution, metabolism, and excretion are pharmacokinetic parameters.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1124,7 +1124,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5dcc732f"],
-		"explanation": "A steep slope in a dose-response curve indicates that small changes in dose result in large changes in effect, suggesting a narrow therapeutic window. It does not necessarily imply high maximal efficacy or potency.",
+		"rationale": "A steep slope in a dose-response curve indicates that small changes in dose result in large changes in effect, suggesting a narrow therapeutic window. It does not necessarily imply high maximal efficacy or potency.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1158,7 +1158,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7b504520"],
-		"explanation": "Variation in dose-response curves can be caused by population differences, patient-related factors, measurement methodologies, and drug formulation, among other factors.",
+		"rationale": "Variation in dose-response curves can be caused by population differences, patient-related factors, measurement methodologies, and drug formulation, among other factors.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1192,7 +1192,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["744c2eb4"],
-		"explanation": "Maximal efficacy refers to the greatest response attainable by the drug, represented by the plateau of the dose-response curve. It is not related to the lowest dose, safety, steepness, or position on the X-axis.",
+		"rationale": "Maximal efficacy refers to the greatest response attainable by the drug, represented by the plateau of the dose-response curve. It is not related to the lowest dose, safety, steepness, or position on the X-axis.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1226,7 +1226,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["36deb9d5"],
-		"explanation": "The ceiling effect refers to the point at which increasing the dose no longer increases the effect, indicating that maximal efficacy has been reached. It is not related to potency, the lowest dose, metabolism, or the steepest part of the curve.",
+		"rationale": "The ceiling effect refers to the point at which increasing the dose no longer increases the effect, indicating that maximal efficacy has been reached. It is not related to potency, the lowest dose, metabolism, or the steepest part of the curve.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1260,7 +1260,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f4e1cea0"],
-		"explanation": "Repeated measurements under identical conditions can help establish a consistent dose-response relationship, which is crucial for evaluating a drug's pharmacologic profile. They cannot eliminate all variability, determine the exact mechanism of action, predict all side effects, or identify the therapeutic index on their own.",
+		"rationale": "Repeated measurements under identical conditions can help establish a consistent dose-response relationship, which is crucial for evaluating a drug's pharmacologic profile. They cannot eliminate all variability, determine the exact mechanism of action, predict all side effects, or identify the therapeutic index on their own.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1294,7 +1294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e66ce631"],
-		"explanation": "Pharmacodynamics describes the relationship between drug concentration at the site of action and its effect. Pharmacokinetics involves the movement of drugs within the body, bioavailability refers to the proportion of a drug that enters circulation, the therapeutic index is the ratio of toxic to therapeutic dose, and half-life is the time taken for the drug's concentration to reduce by half.",
+		"rationale": "Pharmacodynamics describes the relationship between drug concentration at the site of action and its effect. Pharmacokinetics involves the movement of drugs within the body, bioavailability refers to the proportion of a drug that enters circulation, the therapeutic index is the ratio of toxic to therapeutic dose, and half-life is the time taken for the drug's concentration to reduce by half.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1328,7 +1328,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ad3835e4"],
-		"explanation": "Intravenous (IV) administration delivers 100% of the drug to the circulation, providing the highest bioavailability. Other routes like IM, sublingual, and rectal have lower or variable bioavailability.",
+		"rationale": "Intravenous (IV) administration delivers 100% of the drug to the circulation, providing the highest bioavailability. Other routes like IM, sublingual, and rectal have lower or variable bioavailability.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1362,7 +1362,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["42dfae20"],
-		"explanation": "Sublingual administration provides high bioavailability (90-100%) and fast action, bypassing first-pass metabolism, unlike oral administration which is subject to significant first-pass effect.",
+		"rationale": "Sublingual administration provides high bioavailability (90-100%) and fast action, bypassing first-pass metabolism, unlike oral administration which is subject to significant first-pass effect.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1396,7 +1396,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f3243556"],
-		"explanation": "IM administration can cause more pain and tissue necrosis compared to other methods. It does not allow for large volumes, has faster absorption than Sub Q, does not provide 100% bioavailability, and is not the fastest route (IV is).",
+		"rationale": "IM administration can cause more pain and tissue necrosis compared to other methods. It does not allow for large volumes, has faster absorption than Sub Q, does not provide 100% bioavailability, and is not the fastest route (IV is).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1430,7 +1430,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e050a92b"],
-		"explanation": "Oral administration is highly pH-dependent due to the drug's ionization state affecting absorption. Other routes like IV, sublingual, topical, and inhalation are less affected by pH.",
+		"rationale": "Oral administration is highly pH-dependent due to the drug's ionization state affecting absorption. Other routes like IV, sublingual, topical, and inhalation are less affected by pH.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1464,7 +1464,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c5ccf6c0", "898080f5"],
-		"explanation": "A low $K_D$ indicates high potency and high receptor affinity, meaning a lower concentration of the drug is needed to achieve a significant effect. It does not relate to the speed of onset.",
+		"rationale": "A low $K_D$ indicates high potency and high receptor affinity, meaning a lower concentration of the drug is needed to achieve a significant effect. It does not relate to the speed of onset.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1498,7 +1498,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["852aa7b6"],
-		"explanation": "Subcutaneous administration allows for a slow, sustained release of medication, unlike IV (fast), oral (variable), inhalation (fast), and rectal (erratic).",
+		"rationale": "Subcutaneous administration allows for a slow, sustained release of medication, unlike IV (fast), oral (variable), inhalation (fast), and rectal (erratic).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1532,7 +1532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a5cd2e82"],
-		"explanation": "Topical administration concentrates drug action at the site of application, reducing systemic side effects compared to systemic routes like IV, oral, sublingual, and IM.",
+		"rationale": "Topical administration concentrates drug action at the site of application, reducing systemic side effects compared to systemic routes like IV, oral, sublingual, and IM.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1566,7 +1566,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["21da854d", "5fdffaf9"],
-		"explanation": "Oral administration may be compromised by vomiting, and rectal administration can be erratic and poorly absorbed, especially if nausea is present. IV, sublingual, and inhalation are not affected by these symptoms.",
+		"rationale": "Oral administration may be compromised by vomiting, and rectal administration can be erratic and poorly absorbed, especially if nausea is present. IV, sublingual, and inhalation are not affected by these symptoms.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1600,7 +1600,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["05a24261"],
-		"explanation": "Inhalation is the preferred route for bronchodilators as it delivers the drug directly to the lungs, providing rapid action and minimizing systemic effects.",
+		"rationale": "Inhalation is the preferred route for bronchodilators as it delivers the drug directly to the lungs, providing rapid action and minimizing systemic effects.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1634,7 +1634,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["65153a8d"],
-		"explanation": "Volume of distribution ($V_d$) is a pharmacokinetic parameter that does not directly affect oral bioavailability. First-pass metabolism, pH, formulation, and ionization state significantly influence oral drug absorption and bioavailability.",
+		"rationale": "Volume of distribution ($V_d$) is a pharmacokinetic parameter that does not directly affect oral bioavailability. First-pass metabolism, pH, formulation, and ionization state significantly influence oral drug absorption and bioavailability.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1668,7 +1668,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c167e695"],
-		"explanation": "Volume of distribution (V_d) is calculated as dose divided by plasma concentration and represents a drug's propensity to remain in the plasma or redistribute to other tissue compartments. A high V_d indicates extensive distribution into tissues, while a low V_d suggests the drug remains primarily in the plasma.",
+		"rationale": "Volume of distribution (V_d) is calculated as dose divided by plasma concentration and represents a drug's propensity to remain in the plasma or redistribute to other tissue compartments. A high V_d indicates extensive distribution into tissues, while a low V_d suggests the drug remains primarily in the plasma.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1702,7 +1702,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a7efe7d"],
-		"explanation": "First-order elimination kinetics involve a constant proportion of drug being eliminated per unit time, making it a concentration-dependent process. In contrast, zero-order kinetics involve a constant amount of drug being eliminated per unit time, independent of concentration.",
+		"rationale": "First-order elimination kinetics involve a constant proportion of drug being eliminated per unit time, making it a concentration-dependent process. In contrast, zero-order kinetics involve a constant amount of drug being eliminated per unit time, independent of concentration.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1736,7 +1736,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3b314776"],
-		"explanation": "The therapeutic window is the range between the minimum effective concentration and the maximum safe concentration, where most safe and effective treatment occurs. It is crucial for determining the appropriate dosing of a drug.",
+		"rationale": "The therapeutic window is the range between the minimum effective concentration and the maximum safe concentration, where most safe and effective treatment occurs. It is crucial for determining the appropriate dosing of a drug.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1770,7 +1770,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1087aa31"],
-		"explanation": "Half-life is the time required for 50% of the drug to be eliminated. It is dependent on both the drug's clearance rate and volume of distribution, and is relevant for drugs with first-order kinetics.",
+		"rationale": "Half-life is the time required for 50% of the drug to be eliminated. It is dependent on both the drug's clearance rate and volume of distribution, and is relevant for drugs with first-order kinetics.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1804,7 +1804,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["035c0d7e"],
-		"explanation": "The steady state concentration of a drug is affected by its half-life, loading dose, volume of distribution, and the rate of drug administration. These factors influence how quickly and effectively a drug reaches and maintains its therapeutic concentration.",
+		"rationale": "The steady state concentration of a drug is affected by its half-life, loading dose, volume of distribution, and the rate of drug administration. These factors influence how quickly and effectively a drug reaches and maintains its therapeutic concentration.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1838,7 +1838,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d9421ee5"],
-		"explanation": "Zero-order elimination kinetics involve a constant amount of drug being eliminated per unit time, independent of concentration. This is typically seen with drugs that saturate metabolic pathways, such as alcohol.",
+		"rationale": "Zero-order elimination kinetics involve a constant amount of drug being eliminated per unit time, independent of concentration. This is typically seen with drugs that saturate metabolic pathways, such as alcohol.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1872,7 +1872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["789339e7"],
-		"explanation": "Pharmacodynamics involves the effects of a drug on the body, while pharmacokinetics involves the processes of absorption, distribution, metabolism, and excretion of a drug.",
+		"rationale": "Pharmacodynamics involves the effects of a drug on the body, while pharmacokinetics involves the processes of absorption, distribution, metabolism, and excretion of a drug.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1906,7 +1906,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["31f777c7"],
-		"explanation": "Orphan drugs are medicinal products intended for the diagnosis, prevention, or treatment of rare diseases. They are regulated by health authorities and may vary in efficacy and therapeutic index.",
+		"rationale": "Orphan drugs are medicinal products intended for the diagnosis, prevention, or treatment of rare diseases. They are regulated by health authorities and may vary in efficacy and therapeutic index.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1940,7 +1940,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9484928f"],
-		"explanation": "Selectivity refers to the separation between desired and undesired effects of a drug. Ideally, a selective drug will have a high therapeutic effect with minimal side effects.",
+		"rationale": "Selectivity refers to the separation between desired and undesired effects of a drug. Ideally, a selective drug will have a high therapeutic effect with minimal side effects.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -1974,7 +1974,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["49784187"],
-		"explanation": "Efficacy is the maximum effect of which a drug is capable. It is distinct from potency, which refers to the concentration of drug required to achieve a specific effect.",
+		"rationale": "Efficacy is the maximum effect of which a drug is capable. It is distinct from potency, which refers to the concentration of drug required to achieve a specific effect.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2008,7 +2008,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["545f94e2"],
-		"explanation": "The minimum effective concentration (MEC) of a drug can be influenced by factors such as the patient's age, drug formulation, route of administration, and metabolic rate, as these factors affect drug absorption, distribution, and metabolism.",
+		"rationale": "The minimum effective concentration (MEC) of a drug can be influenced by factors such as the patient's age, drug formulation, route of administration, and metabolic rate, as these factors affect drug absorption, distribution, and metabolism.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2042,7 +2042,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0a5c69ab"],
-		"explanation": "Clearance is the volume of plasma from which the drug is completely removed per unit time. It is a key factor in determining the appropriate dosing regimen for a drug.",
+		"rationale": "Clearance is the volume of plasma from which the drug is completely removed per unit time. It is a key factor in determining the appropriate dosing regimen for a drug.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2076,7 +2076,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f6f1e36"],
-		"explanation": "A loading dose is an initial higher dose of a drug given to rapidly achieve therapeutic concentration, especially important for drugs with a long half-life.",
+		"rationale": "A loading dose is an initial higher dose of a drug given to rapidly achieve therapeutic concentration, especially important for drugs with a long half-life.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2110,7 +2110,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["749f4566"],
-		"explanation": "Affinity refers to the strength of binding between a drug and its receptor, which influences the drug's potency and efficacy.",
+		"rationale": "Affinity refers to the strength of binding between a drug and its receptor, which influences the drug's potency and efficacy.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2144,7 +2144,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["099880cc"],
-		"explanation": "The therapeutic index (TI) is the ratio of the toxic dose (TD50) to the effective dose (ED50). A TI > 5 indicates a safe drug, while a TI < 2 indicates an unsafe drug.",
+		"rationale": "The therapeutic index (TI) is the ratio of the toxic dose (TD50) to the effective dose (ED50). A TI > 5 indicates a safe drug, while a TI < 2 indicates an unsafe drug.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2178,7 +2178,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9e51dfc2"],
-		"explanation": "High drug concentration can saturate metabolic pathways, shifting drug metabolism from first-order (concentration-dependent) to zero-order (concentration-independent) kinetics.",
+		"rationale": "High drug concentration can saturate metabolic pathways, shifting drug metabolism from first-order (concentration-dependent) to zero-order (concentration-independent) kinetics.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2212,7 +2212,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7a0cfb4e"],
-		"explanation": "Steady state is achieved when the rate of drug administration equals the rate of elimination, resulting in a constant drug concentration in the body.",
+		"rationale": "Steady state is achieved when the rate of drug administration equals the rate of elimination, resulting in a constant drug concentration in the body.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2246,7 +2246,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d0cd34e8"],
-		"explanation": "Pharmacodynamics involves the biological and physiological effects of a drug, studying what the drug does to the body, in contrast to pharmacokinetics, which studies what the body does to the drug.",
+		"rationale": "Pharmacodynamics involves the biological and physiological effects of a drug, studying what the drug does to the body, in contrast to pharmacokinetics, which studies what the body does to the drug.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2280,7 +2280,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4f8559ba"],
-		"explanation": "Potency is the concentration of drug required to achieve a specific effect. It is distinct from efficacy, which is the maximum effect of which the drug is capable.",
+		"rationale": "Potency is the concentration of drug required to achieve a specific effect. It is distinct from efficacy, which is the maximum effect of which the drug is capable.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2314,7 +2314,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3c8715ef"],
-		"explanation": "The clearance of a drug can be influenced by factors such as liver and kidney function, drug interactions, and the patient's age, as these factors affect the rate of drug elimination.",
+		"rationale": "The clearance of a drug can be influenced by factors such as liver and kidney function, drug interactions, and the patient's age, as these factors affect the rate of drug elimination.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2348,7 +2348,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5e9fd3df", "ab45fcd5"],
-		"explanation": "The liver is the main site of drug metabolism, and prodrugs are designed to become active after metabolism. Drug metabolism does not always inactivate drugs, as some metabolites are active. Metabolism rates vary among patients due to genetic and environmental factors. Conjugation reactions are synthetic, not nonsynthetic.",
+		"rationale": "The liver is the main site of drug metabolism, and prodrugs are designed to become active after metabolism. Drug metabolism does not always inactivate drugs, as some metabolites are active. Metabolism rates vary among patients due to genetic and environmental factors. Conjugation reactions are synthetic, not nonsynthetic.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2382,7 +2382,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0be25e82", "9954eb98"],
-		"explanation": "Phase I reactions involve oxidation and hydrolysis, which are nonsynthetic processes. Conjugation, glucuronidation, and glycine conjugation are phase II reactions, which are synthetic.",
+		"rationale": "Phase I reactions involve oxidation and hydrolysis, which are nonsynthetic processes. Conjugation, glucuronidation, and glycine conjugation are phase II reactions, which are synthetic.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2416,7 +2416,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["39e6a20f"],
-		"explanation": "Aging reduces the liver's capacity for metabolism through the CYP450 enzyme system by ≥ 30% due to decreased hepatic volume and blood flow. This results in higher drug levels and prolonged half-lives, not decreased ones.",
+		"rationale": "Aging reduces the liver's capacity for metabolism through the CYP450 enzyme system by ≥ 30% due to decreased hepatic volume and blood flow. This results in higher drug levels and prolonged half-lives, not decreased ones.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2450,7 +2450,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["890e958e"],
-		"explanation": "CYP450 enzymes can be induced or inhibited by drugs, affecting drug interactions. They are involved in phase I metabolism, not phase II, and are found in many tissues, not just the liver. They catalyze oxidation reactions, not reduction.",
+		"rationale": "CYP450 enzymes can be induced or inhibited by drugs, affecting drug interactions. They are involved in phase I metabolism, not phase II, and are found in many tissues, not just the liver. They catalyze oxidation reactions, not reduction.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2484,7 +2484,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fac757b3"],
-		"explanation": "Individual drug metabolism rates are influenced by genetic factors, coexisting disorders, drug interactions, and age, among other factors.",
+		"rationale": "Individual drug metabolism rates are influenced by genetic factors, coexisting disorders, drug interactions, and age, among other factors.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2518,7 +2518,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["59eb7e8a"],
-		"explanation": "The primary goal of drug metabolism is to make drugs easier to excrete by converting them into more water-soluble forms.",
+		"rationale": "The primary goal of drug metabolism is to make drugs easier to excrete by converting them into more water-soluble forms.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2552,7 +2552,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["85478a71"],
-		"explanation": "Phase II metabolism produces more polar metabolites, making them easier to excrete. It involves synthetic reactions, such as conjugation, and can occur in various tissues, not just the liver. Aging affects some phase II reactions, but not all.",
+		"rationale": "Phase II metabolism produces more polar metabolites, making them easier to excrete. It involves synthetic reactions, such as conjugation, and can occur in various tissues, not just the liver. Aging affects some phase II reactions, but not all.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2586,7 +2586,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bd3274a5", "3d3062a7"],
-		"explanation": "Glucuronidation is a phase II reaction that occurs in the liver microsomal enzyme system and is unaffected by aging. It is the most common phase II reaction and produces more soluble metabolites.",
+		"rationale": "Glucuronidation is a phase II reaction that occurs in the liver microsomal enzyme system and is unaffected by aging. It is the most common phase II reaction and produces more soluble metabolites.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2620,7 +2620,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b8afa107", "fd7e8fc0"],
-		"explanation": "Drug interactions involving CYP450 enzymes can lead to inhibition or induction of metabolism, affecting drug levels and efficacy. Synergism, potentiation, and antagonism describe different types of drug interactions not specific to CYP450.",
+		"rationale": "Drug interactions involving CYP450 enzymes can lead to inhibition or induction of metabolism, affecting drug levels and efficacy. Synergism, potentiation, and antagonism describe different types of drug interactions not specific to CYP450.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2654,7 +2654,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["396500a1"],
-		"explanation": "In neonates, drug metabolism may be slower due to partially developed hepatic microsomal enzyme systems, leading to slower conversion to active or inactive metabolites.",
+		"rationale": "In neonates, drug metabolism may be slower due to partially developed hepatic microsomal enzyme systems, leading to slower conversion to active or inactive metabolites.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2688,7 +2688,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["95576ce9", "1f52df04"],
-		"explanation": "CYP450 enzymes are involved in phase I metabolism, not phase II (A is incorrect). They can be induced or inhibited by drugs, affecting drug interactions (B is correct). The activity of CYP450 enzymes decreases with age due to reduced hepatic volume and blood flow (C is incorrect). Grapefruit juice inhibits CYP450, particularly CYP3A4 (D is incorrect). CYP450 enzymes catalyze the oxidation of many drugs (E is correct).",
+		"rationale": "CYP450 enzymes are involved in phase I metabolism, not phase II (A is incorrect). They can be induced or inhibited by drugs, affecting drug interactions (B is correct). The activity of CYP450 enzymes decreases with age due to reduced hepatic volume and blood flow (C is incorrect). Grapefruit juice inhibits CYP450, particularly CYP3A4 (D is incorrect). CYP450 enzymes catalyze the oxidation of many drugs (E is correct).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2722,7 +2722,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bab04059"],
-		"explanation": "Grapefruit juice primarily interacts with medications by inhibiting CYP3A4 enzymes, which can alter drug metabolism and bioavailability (B is correct). It does not induce CYP450 enzymes (A is incorrect), activate prodrugs (C is incorrect), enhance drug solubility (D is incorrect), or inhibit glucuronidation (E is incorrect).",
+		"rationale": "Grapefruit juice primarily interacts with medications by inhibiting CYP3A4 enzymes, which can alter drug metabolism and bioavailability (B is correct). It does not induce CYP450 enzymes (A is incorrect), activate prodrugs (C is incorrect), enhance drug solubility (D is incorrect), or inhibit glucuronidation (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2756,7 +2756,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["90e4c1ca"],
-		"explanation": "Fexofenadine is known to have reduced bioavailability when taken with grapefruit juice (B is correct). Clopidogrel is a prodrug activated by CYP3A4, and its activation can be affected by grapefruit juice (A is incorrect). Erythromycin, indinavir, and ranolazine interact with grapefruit juice but are not specifically known for reduced bioavailability (C, D, E are incorrect).",
+		"rationale": "Fexofenadine is known to have reduced bioavailability when taken with grapefruit juice (B is correct). Clopidogrel is a prodrug activated by CYP3A4, and its activation can be affected by grapefruit juice (A is incorrect). Erythromycin, indinavir, and ranolazine interact with grapefruit juice but are not specifically known for reduced bioavailability (C, D, E are incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2790,7 +2790,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3d2012e2"],
-		"explanation": "In elderly patients, reduced CYP450 activity leads to prolonged drug half-life due to decreased metabolism (D is correct). Drug clearance is decreased, not increased (A is incorrect). Drug half-life is prolonged, not decreased (B is incorrect). Bioavailability is not necessarily increased (C is incorrect). Drug metabolism is reduced, not enhanced (E is incorrect).",
+		"rationale": "In elderly patients, reduced CYP450 activity leads to prolonged drug half-life due to decreased metabolism (D is correct). Drug clearance is decreased, not increased (A is incorrect). Drug half-life is prolonged, not decreased (B is incorrect). Bioavailability is not necessarily increased (C is incorrect). Drug metabolism is reduced, not enhanced (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2824,7 +2824,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["445f60f0"],
-		"explanation": "Neonates have partially developed hepatic microsomal enzyme systems, leading to difficulty in drug metabolism (C is correct). Their enzyme systems are not fully developed (A is incorrect), and they metabolize drugs slower than adults (B is incorrect). Glucuronidation is slow in neonates (D is incorrect), and drug clearance is not increased (E is incorrect).",
+		"rationale": "Neonates have partially developed hepatic microsomal enzyme systems, leading to difficulty in drug metabolism (C is correct). Their enzyme systems are not fully developed (A is incorrect), and they metabolize drugs slower than adults (B is incorrect). Glucuronidation is slow in neonates (D is incorrect), and drug clearance is not increased (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2858,7 +2858,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["81c96494"],
-		"explanation": "Glucuronidation is a phase II reaction that occurs in the liver microsomal enzyme system (D is correct). Oxidation, reduction, and hydrolysis are phase I reactions (A, B, C are incorrect). Acetylation is a phase II reaction but does not occur in the liver microsomal enzyme system (E is incorrect).",
+		"rationale": "Glucuronidation is a phase II reaction that occurs in the liver microsomal enzyme system (D is correct). Oxidation, reduction, and hydrolysis are phase I reactions (A, B, C are incorrect). Acetylation is a phase II reaction but does not occur in the liver microsomal enzyme system (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2892,7 +2892,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1dbadae7"],
-		"explanation": "Drug antagonism occurs when one drug inhibits the effect of another (B is correct). Two drugs increasing a single response is synergism (A is incorrect). Two drugs competing for metabolism is inhibition (C is incorrect). Metabolism increasing the effective dose of a drug is induction (D is incorrect). A drug having an effect with another drug it cannot have by itself is potentiation (E is incorrect).",
+		"rationale": "Drug antagonism occurs when one drug inhibits the effect of another (B is correct). Two drugs increasing a single response is synergism (A is incorrect). Two drugs competing for metabolism is inhibition (C is incorrect). Metabolism increasing the effective dose of a drug is induction (D is incorrect). A drug having an effect with another drug it cannot have by itself is potentiation (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2926,7 +2926,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c4f602d4"],
-		"explanation": "Clopidogrel is a prodrug that is activated by CYP3A4 metabolism (A is correct). Fexofenadine, erythromycin, indinavir, and ranolazine are not prodrugs activated by CYP3A4 (B, C, D, E are incorrect).",
+		"rationale": "Clopidogrel is a prodrug that is activated by CYP3A4 metabolism (A is correct). Fexofenadine, erythromycin, indinavir, and ranolazine are not prodrugs activated by CYP3A4 (B, C, D, E are incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2960,7 +2960,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aef0962a"],
-		"explanation": "Glucuronidation is a phase II reaction that occurs in the liver microsomal enzyme system (C is correct). It is not a phase I reaction (A is incorrect). Aging does not affect glucuronidation (B is incorrect). It increases drug solubility, aiding in excretion (D is incorrect). It is slow in neonates (E is incorrect).",
+		"rationale": "Glucuronidation is a phase II reaction that occurs in the liver microsomal enzyme system (C is correct). It is not a phase I reaction (A is incorrect). Aging does not affect glucuronidation (B is incorrect). It increases drug solubility, aiding in excretion (D is incorrect). It is slow in neonates (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -2994,7 +2994,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["31e02d81"],
-		"explanation": "Fexofenadine is known to have its therapeutic effect diminished when taken with grapefruit juice due to reduced bioavailability (B is correct). Clopidogrel, erythromycin, indinavir, and ranolazine interact with grapefruit juice but are not specifically known for diminished therapeutic effects (A, C, D, E are incorrect).",
+		"rationale": "Fexofenadine is known to have its therapeutic effect diminished when taken with grapefruit juice due to reduced bioavailability (B is correct). Clopidogrel, erythromycin, indinavir, and ranolazine interact with grapefruit juice but are not specifically known for diminished therapeutic effects (A, C, D, E are incorrect).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3028,7 +3028,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b6e3ebdf"],
-		"explanation": "Urine pH affects the ionization state of weak acids and bases, influencing their reabsorption and excretion. Polar metabolites are not reabsorbed unless specific transport mechanisms exist. Drugs bound to plasma proteins are not filtered by the glomerulus. Renal excretion decreases with age.",
+		"rationale": "Urine pH affects the ionization state of weak acids and bases, influencing their reabsorption and excretion. Polar metabolites are not reabsorbed unless specific transport mechanisms exist. Drugs bound to plasma proteins are not filtered by the glomerulus. Renal excretion decreases with age.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3062,7 +3062,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e4a74c60"],
-		"explanation": "The biliary system primarily excretes drugs with both polar and lipophilic groups, especially those with a molecular weight > 300 g/mol. It does not excrete all drugs, nor does it ensure complete elimination due to enterohepatic cycling.",
+		"rationale": "The biliary system primarily excretes drugs with both polar and lipophilic groups, especially those with a molecular weight > 300 g/mol. It does not excrete all drugs, nor does it ensure complete elimination due to enterohepatic cycling.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3096,7 +3096,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b08eff7c"],
-		"explanation": "Aging decreases renal drug clearance, typically reducing it to half by age 80 compared to age 30. This is due to decreased renal function with age.",
+		"rationale": "Aging decreases renal drug clearance, typically reducing it to half by age 80 compared to age 30. This is due to decreased renal function with age.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3130,7 +3130,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aa29cf15"],
-		"explanation": "Alkalinization of urine enhances the excretion of weak acids by increasing their ionization, preventing reabsorption. Acidification would enhance reabsorption of weak acids.",
+		"rationale": "Alkalinization of urine enhances the excretion of weak acids by increasing their ionization, preventing reabsorption. Acidification would enhance reabsorption of weak acids.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3164,7 +3164,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["989c886b"],
-		"explanation": "The transport maximum is the upper limit of drug concentration that can be actively secreted by the renal tubules. It does not apply to passive diffusion or biliary excretion.",
+		"rationale": "The transport maximum is the upper limit of drug concentration that can be actively secreted by the renal tubules. It does not apply to passive diffusion or biliary excretion.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3198,7 +3198,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a218f050", "04d54f11"],
-		"explanation": "The apparent volume of distribution is influenced by the drug's affinity for tissues (e.g., adipose) and its plasma protein binding, which affects how much drug remains in circulation versus distributed to tissues.",
+		"rationale": "The apparent volume of distribution is influenced by the drug's affinity for tissues (e.g., adipose) and its plasma protein binding, which affects how much drug remains in circulation versus distributed to tissues.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3232,7 +3232,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d60cd03d"],
-		"explanation": "Probenecid blocks the tubular secretion of penicillin, increasing its plasma concentration. It does not have the same effect on the other drugs listed.",
+		"rationale": "Probenecid blocks the tubular secretion of penicillin, increasing its plasma concentration. It does not have the same effect on the other drugs listed.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3266,7 +3266,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a7b2c5fa"],
-		"explanation": "Tissue perfusion primarily determines drug distribution to interstitial fluid. Poorly perfused tissues, like adipose, have slower distribution rates.",
+		"rationale": "Tissue perfusion primarily determines drug distribution to interstitial fluid. Poorly perfused tissues, like adipose, have slower distribution rates.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3300,7 +3300,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["07360ea8"],
-		"explanation": "Enterohepatic cycling involves the reabsorption of drugs secreted in bile back into circulation from the intestine, potentially prolonging the drug's presence in the body.",
+		"rationale": "Enterohepatic cycling involves the reabsorption of drugs secreted in bile back into circulation from the intestine, potentially prolonging the drug's presence in the body.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3334,7 +3334,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["28217676"],
-		"explanation": "Cimetidine can inhibit the active tubular secretion of cations, affecting the excretion of drugs that are organic bases. It does not affect passive diffusion, biliary excretion, or glomerular filtration.",
+		"rationale": "Cimetidine can inhibit the active tubular secretion of cations, affecting the excretion of drugs that are organic bases. It does not affect passive diffusion, biliary excretion, or glomerular filtration.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3368,7 +3368,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["813e4dee"],
-		"explanation": "\"p.o.\" stands for \"by mouth; orally,\" derived from Latin \"per os.\" \"a.c.\" means \"before meals,\" \"q.i.d.\" means \"4 times a day,\" \"OU\" means \"both eyes,\" and \"p.m.\" means \"evening; after noon.\"",
+		"rationale": "\"p.o.\" stands for \"by mouth; orally,\" derived from Latin \"per os.\" \"a.c.\" means \"before meals,\" \"q.i.d.\" means \"4 times a day,\" \"OU\" means \"both eyes,\" and \"p.m.\" means \"evening; after noon.\"",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3402,7 +3402,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e1352af3"],
-		"explanation": "\"b.i.d.\" stands for \"twice a day,\" derived from Latin \"bis in die.\"",
+		"rationale": "\"b.i.d.\" stands for \"twice a day,\" derived from Latin \"bis in die.\"",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3436,7 +3436,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["efc4d769"],
-		"explanation": "Pharmacokinetics involves the study of drug absorption, distribution, metabolism, and excretion. It is distinct from pharmacodynamics, which describes the effects of a drug on the body.",
+		"rationale": "Pharmacokinetics involves the study of drug absorption, distribution, metabolism, and excretion. It is distinct from pharmacodynamics, which describes the effects of a drug on the body.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3470,7 +3470,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9a4bce23"],
-		"explanation": "\"q.h.s.\" stands for \"every day at bedtime,\" derived from Latin \"quaque hora somni.\"",
+		"rationale": "\"q.h.s.\" stands for \"every day at bedtime,\" derived from Latin \"quaque hora somni.\"",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3504,7 +3504,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["47d1e169"],
-		"explanation": "\"OTC\" stands for \"over the counter,\" indicating the medication is available without a prescription.",
+		"rationale": "\"OTC\" stands for \"over the counter,\" indicating the medication is available without a prescription.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3538,7 +3538,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4328d827"],
-		"explanation": "Orphan drugs are medicinal products intended for the diagnosis, prevention, or treatment of rare diseases.",
+		"rationale": "Orphan drugs are medicinal products intended for the diagnosis, prevention, or treatment of rare diseases.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3572,7 +3572,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cb07137f"],
-		"explanation": "\"s.\" stands for \"without,\" derived from Latin \"sine.\"",
+		"rationale": "\"s.\" stands for \"without,\" derived from Latin \"sine.\"",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3606,7 +3606,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44f97e44"],
-		"explanation": "Pharmacodynamics refers to the biological, chemical, and physiological effects of a drug on the body.",
+		"rationale": "Pharmacodynamics refers to the biological, chemical, and physiological effects of a drug on the body.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3640,7 +3640,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2318bef1"],
-		"explanation": "\"p.c.\" stands for \"after meals,\" derived from Latin \"post cibum.\"",
+		"rationale": "\"p.c.\" stands for \"after meals,\" derived from Latin \"post cibum.\"",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3674,7 +3674,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1393534b"],
-		"explanation": "\"p.o.\" stands for \"by mouth; orally,\" derived from Latin \"per os.\"",
+		"rationale": "\"p.o.\" stands for \"by mouth; orally,\" derived from Latin \"per os.\"",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3708,7 +3708,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d217c6c5"],
-		"explanation": "Category X drugs have demonstrated positive evidence of fetal abnormalities and are contraindicated in women who are or may become pregnant. Category A indicates no risk, Category B involves no harm in animal studies, Category C involves potential adverse effects, and Category D involves known risks but potential benefits.",
+		"rationale": "Category X drugs have demonstrated positive evidence of fetal abnormalities and are contraindicated in women who are or may become pregnant. Category A indicates no risk, Category B involves no harm in animal studies, Category C involves potential adverse effects, and Category D involves known risks but potential benefits.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3742,7 +3742,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4500237e"],
-		"explanation": "Category C indicates that animal studies have shown adverse effects, but there are no adequate and well-controlled studies in pregnant women. Category A involves no risk in human studies, Category B involves no harm in animal studies, Category D involves known risks in human studies, and Category X involves contraindication due to fetal abnormalities.",
+		"rationale": "Category C indicates that animal studies have shown adverse effects, but there are no adequate and well-controlled studies in pregnant women. Category A involves no risk in human studies, Category B involves no harm in animal studies, Category D involves known risks in human studies, and Category X involves contraindication due to fetal abnormalities.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3776,7 +3776,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f1476929"],
-		"explanation": "Category A is assigned to drugs where adequate, well-controlled studies in pregnant women have not shown an increased risk of fetal abnormalities. Category B involves no harm in animal studies, Category C involves potential adverse effects, Category D involves known risks but potential benefits, and Category X involves contraindication due to fetal abnormalities.",
+		"rationale": "Category A is assigned to drugs where adequate, well-controlled studies in pregnant women have not shown an increased risk of fetal abnormalities. Category B involves no harm in animal studies, Category C involves potential adverse effects, Category D involves known risks but potential benefits, and Category X involves contraindication due to fetal abnormalities.",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3810,7 +3810,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ba4bb767"],
-		"explanation": "Cyclic AMP is a signaling molecule that increases in parathyroid gland cells, leading to the release of parathyroid hormone (PTH).",
+		"rationale": "Cyclic AMP is a signaling molecule that increases in parathyroid gland cells, leading to the release of parathyroid hormone (PTH).",
 		"metadata": {},
 		"moduleId": "js72w7ch277z1ffz7vgag7n7y97m8q2z",
 		"options": [
@@ -3840,7 +3840,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["31872010"],
-		"explanation": "Dexamethasone is used in combination with tobramycin in ophthalmic suspensions like TobraDex. It is not ester-based (C is incorrect), and it is not used for its mineralocorticoid effects (D is incorrect). It is more potent than prednisone (E is incorrect).",
+		"rationale": "Dexamethasone is used in combination with tobramycin in ophthalmic suspensions like TobraDex. It is not ester-based (C is incorrect), and it is not used for its mineralocorticoid effects (D is incorrect). It is more potent than prednisone (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -3874,7 +3874,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44649019"],
-		"explanation": "Prednisone must be converted by liver enzymes to prednisolone to become active. Prednisolone is already in its active form (B is incorrect), and methylprednisolone does not require conversion (C is incorrect). Loteprednol and difluprednate are not related to this conversion process (D and E are incorrect).",
+		"rationale": "Prednisone must be converted by liver enzymes to prednisolone to become active. Prednisolone is already in its active form (B is incorrect), and methylprednisolone does not require conversion (C is incorrect). Loteprednol and difluprednate are not related to this conversion process (D and E are incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -3908,7 +3908,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["05d073fa"],
-		"explanation": "Increased potency of glucocorticoids is associated with increased side effects. Potency is not solely determined by circulating half-life (B is incorrect), and fluoridation does not increase the potency of oral glucocorticoids (E is incorrect).",
+		"rationale": "Increased potency of glucocorticoids is associated with increased side effects. Potency is not solely determined by circulating half-life (B is incorrect), and fluoridation does not increase the potency of oral glucocorticoids (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -3942,7 +3942,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b88387e"],
-		"explanation": "Loteprednol is ester-based and is metabolized by esterases, reducing the chance of an increase in intraocular pressure. The other steroids are ketone-based and more likely to cause increased intraocular pressure.",
+		"rationale": "Loteprednol is ester-based and is metabolized by esterases, reducing the chance of an increase in intraocular pressure. The other steroids are ketone-based and more likely to cause increased intraocular pressure.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -3976,7 +3976,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c8a0b765", "08f7e341"],
-		"explanation": "Fluoridation increases the potency of topical and ophthalmic steroids but may decrease the potency of oral steroids. It does not universally increase the potency of all steroids (A is incorrect).",
+		"rationale": "Fluoridation increases the potency of topical and ophthalmic steroids but may decrease the potency of oral steroids. It does not universally increase the potency of all steroids (A is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4010,7 +4010,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1d26389c", "c7dcfaae"],
-		"explanation": "Glucocorticoids can be used to treat Addison's disease and help diagnose Cushing's syndrome. They are not used to treat glaucoma, diabetes mellitus, or hypertension directly (C, D, and E are incorrect).",
+		"rationale": "Glucocorticoids can be used to treat Addison's disease and help diagnose Cushing's syndrome. They are not used to treat glaucoma, diabetes mellitus, or hypertension directly (C, D, and E are incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4044,7 +4044,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a055ebba"],
-		"explanation": "Loteprednol is metabolized by esterases in the cornea and anterior chamber, reducing systemic side effects. It is ester-based, not ketone-based (C is incorrect), and is used in ophthalmic formulations (E is incorrect).",
+		"rationale": "Loteprednol is metabolized by esterases in the cornea and anterior chamber, reducing systemic side effects. It is ester-based, not ketone-based (C is incorrect), and is used in ophthalmic formulations (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4078,7 +4078,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c0e59f66"],
-		"explanation": "Difluprednate is considered the most potent ophthalmic steroid due to its fluoridation. The other options are less potent in ophthalmic formulations.",
+		"rationale": "Difluprednate is considered the most potent ophthalmic steroid due to its fluoridation. The other options are less potent in ophthalmic formulations.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4112,7 +4112,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["94454385"],
-		"explanation": "The relationship between circulating half-life and glucocorticoid potency is imprecise. Half-life is not the sole factor determining potency (E is incorrect).",
+		"rationale": "The relationship between circulating half-life and glucocorticoid potency is imprecise. Half-life is not the sole factor determining potency (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4146,7 +4146,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ab6bdd0a", "4276a3cc", "32c85f2d"],
-		"explanation": "Glucocorticoids inhibit the leukotriene, prostaglandin, and thromboxane pathways, contributing to their anti-inflammatory effects. They do not directly inhibit the histamine or serotonin pathways (D and E are incorrect).",
+		"rationale": "Glucocorticoids inhibit the leukotriene, prostaglandin, and thromboxane pathways, contributing to their anti-inflammatory effects. They do not directly inhibit the histamine or serotonin pathways (D and E are incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4180,7 +4180,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["48c7c733", "b3b675c9", "f1d9d2e4"],
-		"explanation": "The hypothalamus releases CRH in response to stress, which stimulates the pituitary gland to release ACTH. ACTH then acts on the adrenal glands to produce glucocorticoids like cortisol and mineralocorticoids like aldosterone. The pituitary gland does not produce glucocorticoids or mineralocorticoids.",
+		"rationale": "The hypothalamus releases CRH in response to stress, which stimulates the pituitary gland to release ACTH. ACTH then acts on the adrenal glands to produce glucocorticoids like cortisol and mineralocorticoids like aldosterone. The pituitary gland does not produce glucocorticoids or mineralocorticoids.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4214,7 +4214,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9cce96ce", "460617d7"],
-		"explanation": "Ketone-based steroids can increase intraocular pressure by blocking aqueous outflow, contributing to steroid-induced glaucoma. Loteprednol is an ester-based steroid, metabolized by esterases in the cornea, which reduces but does not eliminate the risk of increased intraocular pressure. Steroid-induced glaucoma can be caused by other factors and is not limited to ophthalmic steroids.",
+		"rationale": "Ketone-based steroids can increase intraocular pressure by blocking aqueous outflow, contributing to steroid-induced glaucoma. Loteprednol is an ester-based steroid, metabolized by esterases in the cornea, which reduces but does not eliminate the risk of increased intraocular pressure. Steroid-induced glaucoma can be caused by other factors and is not limited to ophthalmic steroids.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4248,7 +4248,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["88b4afaf", "5de5edd5", "f828ee3b"],
-		"explanation": "Fluoridation increases the potency of topical and ophthalmic steroids, such as difluprednate, which is highly potent due to its fluorination. However, fluoridation does not increase the potency of oral/systemic steroids and may even decrease it. Prednisolone is not more potent than difluprednate due to fluoridation.",
+		"rationale": "Fluoridation increases the potency of topical and ophthalmic steroids, such as difluprednate, which is highly potent due to its fluorination. However, fluoridation does not increase the potency of oral/systemic steroids and may even decrease it. Prednisolone is not more potent than difluprednate due to fluoridation.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4282,7 +4282,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["83b6d520", "7ea0ceb8", "44104fc4"],
-		"explanation": "Dexamethasone is used in ophthalmic suspensions like TobraDex. Prednisone is the most common oral steroid formulation. Methylprednisolone is a stronger formulation than prednisone and can be given orally or intravenously. Prednisone must be converted to prednisolone to be active, not the other way around.",
+		"rationale": "Dexamethasone is used in ophthalmic suspensions like TobraDex. Prednisone is the most common oral steroid formulation. Methylprednisolone is a stronger formulation than prednisone and can be given orally or intravenously. Prednisone must be converted to prednisolone to be active, not the other way around.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4316,7 +4316,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c54a646a", "d810b1dd", "3cf59dd8", "10ae4480"],
-		"explanation": "Glucocorticoids inhibit inflammation by decreasing the production of inflammatory cytokines and bind to cytoplasmic receptor proteins to affect gene regulation. They have anti-proliferative and vasoconstrictive effects and are involved in carbohydrate, fat, and protein metabolism. Mineralocorticoids, not glucocorticoids, primarily regulate electrolyte and water balance.",
+		"rationale": "Glucocorticoids inhibit inflammation by decreasing the production of inflammatory cytokines and bind to cytoplasmic receptor proteins to affect gene regulation. They have anti-proliferative and vasoconstrictive effects and are involved in carbohydrate, fat, and protein metabolism. Mineralocorticoids, not glucocorticoids, primarily regulate electrolyte and water balance.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4350,7 +4350,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5b4ef32b", "0e868f2c"],
-		"explanation": "Mineralocorticoids like aldosterone are primarily involved in regulating electrolyte and water balance. Glucocorticoids have anti-inflammatory effects and affect metabolism. Mineralocorticoids do not significantly impact carbohydrate metabolism, and glucocorticoids act by binding to cytoplasmic receptors, not cell surface receptors. The potency of mineralocorticoids and glucocorticoids in regulating electrolyte balance is not the same.",
+		"rationale": "Mineralocorticoids like aldosterone are primarily involved in regulating electrolyte and water balance. Glucocorticoids have anti-inflammatory effects and affect metabolism. Mineralocorticoids do not significantly impact carbohydrate metabolism, and glucocorticoids act by binding to cytoplasmic receptors, not cell surface receptors. The potency of mineralocorticoids and glucocorticoids in regulating electrolyte balance is not the same.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4384,7 +4384,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dfe552a7"],
-		"explanation": "Dexamethasone has the longest biologic half-life (36–54 hours) and the highest glucocorticoid potency (30) among the listed drugs. Cortisol, prednisone, and methylprednisolone have shorter biologic half-lives and lower glucocorticoid potencies. Loteprednol is not included in the table for comparison.",
+		"rationale": "Dexamethasone has the longest biologic half-life (36–54 hours) and the highest glucocorticoid potency (30) among the listed drugs. Cortisol, prednisone, and methylprednisolone have shorter biologic half-lives and lower glucocorticoid potencies. Loteprednol is not included in the table for comparison.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4418,7 +4418,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a131f597", "940a6ec3", "773267f2"],
-		"explanation": "The HPA axis involves the hypothalamus releasing CRH in response to stress, which stimulates the pituitary gland to release ACTH. ACTH then stimulates the adrenal glands to produce glucocorticoids and mineralocorticoids. The HPA axis is crucial for regulating endogenous steroid production, including cortisol.",
+		"rationale": "The HPA axis involves the hypothalamus releasing CRH in response to stress, which stimulates the pituitary gland to release ACTH. ACTH then stimulates the adrenal glands to produce glucocorticoids and mineralocorticoids. The HPA axis is crucial for regulating endogenous steroid production, including cortisol.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4452,7 +4452,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8fa54fcf", "a2f4999b", "cecf7b55"],
-		"explanation": "Ketone-based steroids can increase intraocular pressure by blocking aqueous outflow, leading to steroid-induced glaucoma. Loteprednol is ester-based, reducing the risk of IOP spikes. Difluprednate is potent due to fluoridation. Fluoridation increases the potency of ophthalmic steroids but does not apply to systemic steroids.",
+		"rationale": "Ketone-based steroids can increase intraocular pressure by blocking aqueous outflow, leading to steroid-induced glaucoma. Loteprednol is ester-based, reducing the risk of IOP spikes. Difluprednate is potent due to fluoridation. Fluoridation increases the potency of ophthalmic steroids but does not apply to systemic steroids.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4486,7 +4486,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d54d6dfe", "418ad615", "8ef005b3"],
-		"explanation": "Prednisone, methylprednisolone, and dexamethasone have no mineralocorticoid activity. Cortisol has mineralocorticoid activity, and loteprednol is not included in the table for comparison of mineralocorticoid activity.",
+		"rationale": "Prednisone, methylprednisolone, and dexamethasone have no mineralocorticoid activity. Cortisol has mineralocorticoid activity, and loteprednol is not included in the table for comparison of mineralocorticoid activity.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4520,7 +4520,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c57ce267", "d4db7202"],
-		"explanation": "Glucocorticoids inhibit inflammation by affecting eicosanoid pathways and bind to cytoplasmic receptors to regulate genes. They do affect carbohydrate metabolism and are effective in treating autoimmune conditions.",
+		"rationale": "Glucocorticoids inhibit inflammation by affecting eicosanoid pathways and bind to cytoplasmic receptors to regulate genes. They do affect carbohydrate metabolism and are effective in treating autoimmune conditions.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4554,7 +4554,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8ad29781"],
-		"explanation": "Dexamethasone has the highest glucocorticoid potency with a value of 30, compared to the other options.",
+		"rationale": "Dexamethasone has the highest glucocorticoid potency with a value of 30, compared to the other options.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4588,7 +4588,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4e3ed352", "e51b186e"],
-		"explanation": "Increased glucocorticoid potency can lead to immunosuppression (increased infection risk) and bone density loss (osteoporosis). Hyperkalemia and hypoglycemia are not typical side effects.",
+		"rationale": "Increased glucocorticoid potency can lead to immunosuppression (increased infection risk) and bone density loss (osteoporosis). Hyperkalemia and hypoglycemia are not typical side effects.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4622,7 +4622,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["65a40c7f"],
-		"explanation": "Dexamethasone has the longest biologic half-life of 36–54 hours.",
+		"rationale": "Dexamethasone has the longest biologic half-life of 36–54 hours.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4656,7 +4656,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c479677e"],
-		"explanation": "Methylprednisolone has a relatively short plasma half-life and high potency, making it suitable for short-term effects.",
+		"rationale": "Methylprednisolone has a relatively short plasma half-life and high potency, making it suitable for short-term effects.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4690,7 +4690,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cc493fcd", "ccf3ddbd", "73080acf"],
-		"explanation": "Glucocorticoids inhibit leukocyte infiltration, stabilize lysosomal membranes, and decrease capillary permeability, contributing to their anti-inflammatory effects.",
+		"rationale": "Glucocorticoids inhibit leukocyte infiltration, stabilize lysosomal membranes, and decrease capillary permeability, contributing to their anti-inflammatory effects.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4724,7 +4724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["927c11a9"],
-		"explanation": "Dexamethasone is often used in the dexamethasone suppression test to diagnose Cushing's syndrome.",
+		"rationale": "Dexamethasone is often used in the dexamethasone suppression test to diagnose Cushing's syndrome.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4758,7 +4758,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["36a75120"],
-		"explanation": "With increased glucocorticoid potency, there is an increased risk of side effects.",
+		"rationale": "With increased glucocorticoid potency, there is an increased risk of side effects.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4792,7 +4792,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9cdb155b", "e425209f", "fb8d3dd8"],
-		"explanation": "Prednisone, Methylprednisolone, and Dexamethasone have no mineralocorticoid activity and are less likely to affect electrolyte and water balance compared to Cortisol and Aldosterone.",
+		"rationale": "Prednisone, Methylprednisolone, and Dexamethasone have no mineralocorticoid activity and are less likely to affect electrolyte and water balance compared to Cortisol and Aldosterone.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4826,7 +4826,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["65b55c69", "82fcf472", "d415ab09"],
-		"explanation": "Prednisone is the most common oral steroid and should be taken with food to prevent stomach upset. It requires tapering if used for more than a week to avoid withdrawal symptoms. Prednisone must be converted to prednisolone to be active, and it should not be taken at bedtime due to potential insomnia.",
+		"rationale": "Prednisone is the most common oral steroid and should be taken with food to prevent stomach upset. It requires tapering if used for more than a week to avoid withdrawal symptoms. Prednisone must be converted to prednisolone to be active, and it should not be taken at bedtime due to potential insomnia.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4860,7 +4860,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f0b9713b", "695e8dfb"],
-		"explanation": "Long-term use of oral steroids can lead to rebound inflammation and adrenal suppression, which is why tapering is necessary. Increased intraocular pressure is more associated with ophthalmic steroids, insomnia is a side effect but not a reason for tapering, and gastric ulcers are a risk but not directly related to tapering.",
+		"rationale": "Long-term use of oral steroids can lead to rebound inflammation and adrenal suppression, which is why tapering is necessary. Increased intraocular pressure is more associated with ophthalmic steroids, insomnia is a side effect but not a reason for tapering, and gastric ulcers are a risk but not directly related to tapering.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4894,7 +4894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7c203bf2", "e4020afe", "ffcba1d3"],
-		"explanation": "Steroid-induced glaucoma is primarily associated with ketone-based steroids. Loteprednol, being ester-based, is less likely to cause an IOP spike due to metabolism by esterases. Fluoridation increases potency but not necessarily the risk of glaucoma, and not all ophthalmic steroids cause glaucoma.",
+		"rationale": "Steroid-induced glaucoma is primarily associated with ketone-based steroids. Loteprednol, being ester-based, is less likely to cause an IOP spike due to metabolism by esterases. Fluoridation increases potency but not necessarily the risk of glaucoma, and not all ophthalmic steroids cause glaucoma.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4928,7 +4928,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9407b851", "4e3de519", "2c68414d"],
-		"explanation": "Increased potency of glucocorticoids is associated with more side effects, and their potency is related to receptor affinity. They are used to diagnose Cushing's syndrome. Fluoridation does not increase the potency of oral glucocorticoids, and the relationship between duration of action and half-life is imprecise.",
+		"rationale": "Increased potency of glucocorticoids is associated with more side effects, and their potency is related to receptor affinity. They are used to diagnose Cushing's syndrome. Fluoridation does not increase the potency of oral glucocorticoids, and the relationship between duration of action and half-life is imprecise.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4962,7 +4962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f879411f", "7d4b9bd0"],
-		"explanation": "H2 blockers or PPIs are recommended for gastric protection when prescribing high doses of oral steroids or for extended use to prevent stomach upset. They do not enhance the anti-inflammatory effect and are not necessary for all doses or only short-term use.",
+		"rationale": "H2 blockers or PPIs are recommended for gastric protection when prescribing high doses of oral steroids or for extended use to prevent stomach upset. They do not enhance the anti-inflammatory effect and are not necessary for all doses or only short-term use.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -4996,7 +4996,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a1c604d5", "83ce7a25", "30f7496f"],
-		"explanation": "Oral steroids should be taken in the morning, and the total daily dose can be divided into multiple doses. The onset of action is within +/- 4 hours. The last dose should not be taken at bedtime due to insomnia risk, and they should be taken with food to prevent stomach upset.",
+		"rationale": "Oral steroids should be taken in the morning, and the total daily dose can be divided into multiple doses. The onset of action is within +/- 4 hours. The last dose should not be taken at bedtime due to insomnia risk, and they should be taken with food to prevent stomach upset.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5030,7 +5030,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["69128249", "492f0426", "cedc85c7"],
-		"explanation": "Symptoms of steroid withdrawal include joint and muscle pain, nausea, and fever. Hypertension and weight gain are not typical symptoms of withdrawal; instead, hypotension and weight loss are more common.",
+		"rationale": "Symptoms of steroid withdrawal include joint and muscle pain, nausea, and fever. Hypertension and weight gain are not typical symptoms of withdrawal; instead, hypotension and weight loss are more common.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5064,7 +5064,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c7951bf4", "e6e6702c"],
-		"explanation": "Methylprednisolone is a stronger formulation than prednisone and can be administered orally or intravenously. It does not require conversion to prednisolone to be active and is not primarily used in ophthalmic medications.",
+		"rationale": "Methylprednisolone is a stronger formulation than prednisone and can be administered orally or intravenously. It does not require conversion to prednisolone to be active and is not primarily used in ophthalmic medications.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5098,7 +5098,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8f3a74ba"],
-		"explanation": "NSAIDs inhibit cyclooxygenase (COX) enzymes but do not inhibit lipoxygenase. They do not directly target immune cells, and only aspirin forms an irreversible bond with COX enzymes.",
+		"rationale": "NSAIDs inhibit cyclooxygenase (COX) enzymes but do not inhibit lipoxygenase. They do not directly target immune cells, and only aspirin forms an irreversible bond with COX enzymes.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5128,7 +5128,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9bd9918b"],
-		"explanation": "Piroxicam has a long half-life of approximately 50 hours, making it the NSAID with the longest half-life among the options provided.",
+		"rationale": "Piroxicam has a long half-life of approximately 50 hours, making it the NSAID with the longest half-life among the options provided.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5158,7 +5158,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["28ac039f"],
-		"explanation": "Ibuprofen is noted as the most renal-toxic NSAID among the propionic acids.",
+		"rationale": "Ibuprofen is noted as the most renal-toxic NSAID among the propionic acids.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5188,7 +5188,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["177be2f0"],
-		"explanation": "Ketoprofen is noted for causing the most gastrointestinal upset among the propionic acid class of NSAIDs.",
+		"rationale": "Ketoprofen is noted for causing the most gastrointestinal upset among the propionic acid class of NSAIDs.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5218,7 +5218,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c4b4d310"],
-		"explanation": "Aspirin forms an irreversible, covalent bond with COX enzymes, unlike other NSAIDs which bind reversibly.",
+		"rationale": "Aspirin forms an irreversible, covalent bond with COX enzymes, unlike other NSAIDs which bind reversibly.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5248,7 +5248,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["919364d7"],
-		"explanation": "Indomethacin is uniquely used for the treatment of patent ductus arteriosus.",
+		"rationale": "Indomethacin is uniquely used for the treatment of patent ductus arteriosus.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5278,7 +5278,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["83033b0c"],
-		"explanation": "Indomethacin is noted for causing headaches in 25-50% of users, making it the most likely NSAID to cause this side effect.",
+		"rationale": "Indomethacin is noted for causing headaches in 25-50% of users, making it the most likely NSAID to cause this side effect.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5308,7 +5308,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3de71e45"],
-		"explanation": "Flurbiprofen is available in an ophthalmic formulation and can reverse post-operative miosis.",
+		"rationale": "Flurbiprofen is available in an ophthalmic formulation and can reverse post-operative miosis.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5338,7 +5338,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["84a2eed6"],
-		"explanation": "Celecoxib is a COX-2 selective inhibitor, unlike the other NSAIDs listed.",
+		"rationale": "Celecoxib is a COX-2 selective inhibitor, unlike the other NSAIDs listed.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5368,7 +5368,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5e02202f"],
-		"explanation": "NSAIDs are weak organic acids, have efficient gastrointestinal absorption, and are efficiently excreted via enterohepatic and renal pathways. They do accumulate in inflamed tissues.",
+		"rationale": "NSAIDs are weak organic acids, have efficient gastrointestinal absorption, and are efficiently excreted via enterohepatic and renal pathways. They do accumulate in inflamed tissues.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5398,7 +5398,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["eeed45dc", "5b03748f"],
-		"explanation": "NSAIDs inhibit prostaglandin synthesis, which normally suppresses gastric acid secretion and maintains the gastric mucosal barrier. This inhibition leads to increased gastric acid secretion and reduced protection, causing gastrointestinal toxicity. Enhanced gastric mucosal barrier and decreased gastric acid secretion are incorrect as they are protective mechanisms.",
+		"rationale": "NSAIDs inhibit prostaglandin synthesis, which normally suppresses gastric acid secretion and maintains the gastric mucosal barrier. This inhibition leads to increased gastric acid secretion and reduced protection, causing gastrointestinal toxicity. Enhanced gastric mucosal barrier and decreased gastric acid secretion are incorrect as they are protective mechanisms.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5432,7 +5432,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fbd70097", "dab706af"],
-		"explanation": "Risk factors for NSAID-induced gastrointestinal toxicity include concurrent steroid use and a history of peptic ulcer disease. Younger age and lower NSAID doses are not risk factors; higher doses and older age increase risk. Antacids may reduce NSAID absorption but are not a risk factor for toxicity.",
+		"rationale": "Risk factors for NSAID-induced gastrointestinal toxicity include concurrent steroid use and a history of peptic ulcer disease. Younger age and lower NSAID doses are not risk factors; higher doses and older age increase risk. Antacids may reduce NSAID absorption but are not a risk factor for toxicity.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5466,7 +5466,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f3efe57"],
-		"explanation": "NSAIDs can displace warfarin from plasma protein binding sites, increasing the risk of bleeding. They do not decrease warfarin's effectiveness or increase thrombosis risk. NSAID efficacy is not reduced, and renal clearance is not enhanced by warfarin.",
+		"rationale": "NSAIDs can displace warfarin from plasma protein binding sites, increasing the risk of bleeding. They do not decrease warfarin's effectiveness or increase thrombosis risk. NSAID efficacy is not reduced, and renal clearance is not enhanced by warfarin.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5500,7 +5500,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["027c7a32", "aa9fa1bd"],
-		"explanation": "CNS toxicity, such as confusion, and gastrointestinal toxicity are more common in elderly patients. Hepatic toxicity, nephrotoxicity, and skin reactions are not specifically more common in the elderly.",
+		"rationale": "CNS toxicity, such as confusion, and gastrointestinal toxicity are more common in elderly patients. Hepatic toxicity, nephrotoxicity, and skin reactions are not specifically more common in the elderly.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5534,7 +5534,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0dfcf769", "68750e25"],
-		"explanation": "NSAID-induced nephrotoxicity is more likely in patients with congestive heart failure and can cause hyperkalemia. It is more likely, not less, in patients with chronic renal disease. NSAIDs decrease renal blood flow, and nephrotoxicity is seen with both selective and non-selective NSAIDs.",
+		"rationale": "NSAID-induced nephrotoxicity is more likely in patients with congestive heart failure and can cause hyperkalemia. It is more likely, not less, in patients with chronic renal disease. NSAIDs decrease renal blood flow, and nephrotoxicity is seen with both selective and non-selective NSAIDs.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5568,7 +5568,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["50afa474"],
-		"explanation": "Reye's Syndrome is associated with aspirin use in children, particularly after viral infections. Stevens-Johnson Syndrome, Kawasaki Disease, Guillain-Barré Syndrome, and Henoch-Schönlein Purpura are not directly linked to aspirin use in children.",
+		"rationale": "Reye's Syndrome is associated with aspirin use in children, particularly after viral infections. Stevens-Johnson Syndrome, Kawasaki Disease, Guillain-Barré Syndrome, and Henoch-Schönlein Purpura are not directly linked to aspirin use in children.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5602,7 +5602,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2df8e11f", "2f29dfe7"],
-		"explanation": "Methotrexate and phenytoin may have increased toxicity when co-administered with NSAIDs due to displacement from plasma protein binding sites. Digoxin and lithium are affected by NSAIDs through inhibition of clearance, not displacement. Aspirin may lower levels of other NSAIDs but does not increase toxicity through displacement.",
+		"rationale": "Methotrexate and phenytoin may have increased toxicity when co-administered with NSAIDs due to displacement from plasma protein binding sites. Digoxin and lithium are affected by NSAIDs through inhibition of clearance, not displacement. Aspirin may lower levels of other NSAIDs but does not increase toxicity through displacement.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5636,7 +5636,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3178d1a2", "c2f1174a", "6ab40ba0"],
-		"explanation": "NSAID use can lead to increased creatinine levels, renal papillary necrosis, and nephrotic syndrome. They can cause increased blood pressure, not decreased, and hyperkalemia, not hypernatremia.",
+		"rationale": "NSAID use can lead to increased creatinine levels, renal papillary necrosis, and nephrotic syndrome. They can cause increased blood pressure, not decreased, and hyperkalemia, not hypernatremia.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5670,7 +5670,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["02c541bf", "99f4f4cf", "540eaaba"],
-		"explanation": "Common symptoms of NSAID-induced CNS toxicity include tinnitus, confusion, and depression. Seizures and insomnia are not typically associated with NSAID-induced CNS toxicity.",
+		"rationale": "Common symptoms of NSAID-induced CNS toxicity include tinnitus, confusion, and depression. Seizures and insomnia are not typically associated with NSAID-induced CNS toxicity.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5704,7 +5704,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f6bdd73", "b163c47a"],
-		"explanation": "NSAID-induced hepatic toxicity may cause asymptomatic elevations of liver enzymes and is more common with diclofenac. Ibuprofen has a better liver safety profile, significant hepatic injury is rare, and Reye's Syndrome is associated with aspirin in children, not adults.",
+		"rationale": "NSAID-induced hepatic toxicity may cause asymptomatic elevations of liver enzymes and is more common with diclofenac. Ibuprofen has a better liver safety profile, significant hepatic injury is rare, and Reye's Syndrome is associated with aspirin in children, not adults.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5738,7 +5738,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3abe023f", "0183763a"],
-		"explanation": "Lucentis is approved for wet macular degeneration, not metastatic colon cancer (A is incorrect). Avastin is used off-label for wet AMD (B is correct). Both drugs bind VEGF (C is correct). Lucentis is a smaller molecule version of Avastin (D is incorrect). Avastin is cheaper than Lucentis (E is incorrect).",
+		"rationale": "Lucentis is approved for wet macular degeneration, not metastatic colon cancer (A is incorrect). Avastin is used off-label for wet AMD (B is correct). Both drugs bind VEGF (C is correct). Lucentis is a smaller molecule version of Avastin (D is incorrect). Avastin is cheaper than Lucentis (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5772,7 +5772,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["514c9182"],
-		"explanation": "Apremilast is a PDE4 inhibitor (A is correct). Tofacitinib is a JAK inhibitor (B is incorrect). Dupilumab inhibits IL-4 and IL-13 (C is incorrect). Anakinra is an IL-1 antagonist (D is incorrect). Etanercept is a TNF-a inhibitor (E is incorrect).",
+		"rationale": "Apremilast is a PDE4 inhibitor (A is correct). Tofacitinib is a JAK inhibitor (B is incorrect). Dupilumab inhibits IL-4 and IL-13 (C is incorrect). Anakinra is an IL-1 antagonist (D is incorrect). Etanercept is a TNF-a inhibitor (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5806,7 +5806,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["79d052f0", "cb9cf6cb"],
-		"explanation": "JAK inhibitors like tofacitinib have been associated with elevated risks for cardiovascular events (A is correct) and malignancy (C is correct). Ocular surface disease, severe dryness, and corneal infiltrates are associated with dupilumab (B, E are incorrect). Immunosuppression is a risk with TNF-a inhibitors (D is incorrect).",
+		"rationale": "JAK inhibitors like tofacitinib have been associated with elevated risks for cardiovascular events (A is correct) and malignancy (C is correct). Ocular surface disease, severe dryness, and corneal infiltrates are associated with dupilumab (B, E are incorrect). Immunosuppression is a risk with TNF-a inhibitors (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5840,7 +5840,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["11836021", "dc52ae47"],
-		"explanation": "Crisaborole (B) and Dupilumab (D) are used to treat atopic dermatitis. Apremilast is used for psoriasis (A is incorrect). Tofacitinib is used for rheumatoid arthritis and psoriasis (C is incorrect). Anakinra is used for rheumatoid arthritis (E is incorrect).",
+		"rationale": "Crisaborole (B) and Dupilumab (D) are used to treat atopic dermatitis. Apremilast is used for psoriasis (A is incorrect). Tofacitinib is used for rheumatoid arthritis and psoriasis (C is incorrect). Anakinra is used for rheumatoid arthritis (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5874,7 +5874,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4acf02bb"],
-		"explanation": "Anakinra is a recombinant version of an endogenous IL-1 receptor antagonist (B is correct). Etanercept is a TNF-a inhibitor (A is incorrect). Dupilumab inhibits IL-4 and IL-13 (C is incorrect). Ocrelizumab and Ofatumumab are anti-CD20 antibodies (D, E are incorrect).",
+		"rationale": "Anakinra is a recombinant version of an endogenous IL-1 receptor antagonist (B is correct). Etanercept is a TNF-a inhibitor (A is incorrect). Dupilumab inhibits IL-4 and IL-13 (C is incorrect). Ocrelizumab and Ofatumumab are anti-CD20 antibodies (D, E are incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5908,7 +5908,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["335474de"],
-		"explanation": "Etanercept is a TNF-a inhibitor (B is correct). Anakinra is an IL-1 antagonist (A is incorrect). Tofacitinib is a JAK inhibitor (C is incorrect). Apremilast is a PDE4 inhibitor (D is incorrect). Dupilumab inhibits IL-4 and IL-13 (E is incorrect).",
+		"rationale": "Etanercept is a TNF-a inhibitor (B is correct). Anakinra is an IL-1 antagonist (A is incorrect). Tofacitinib is a JAK inhibitor (C is incorrect). Apremilast is a PDE4 inhibitor (D is incorrect). Dupilumab inhibits IL-4 and IL-13 (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5942,7 +5942,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9d530ff5", "10388538"],
-		"explanation": "Dupilumab (D) and Anakinra (E) are administered via injection. Apremilast is an oral medication (A is incorrect). Crisaborole is a topical medication (B is incorrect). Tofacitinib is an oral medication (C is incorrect).",
+		"rationale": "Dupilumab (D) and Anakinra (E) are administered via injection. Apremilast is an oral medication (A is incorrect). Crisaborole is a topical medication (B is incorrect). Tofacitinib is an oral medication (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -5976,7 +5976,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5e03256b", "6cc83e70"],
-		"explanation": "Anakinra (A) and Tofacitinib (B) are used in the treatment of rheumatoid arthritis. Dupilumab is used for atopic dermatitis and asthma (C is incorrect). Apremilast is used for psoriasis (D is incorrect). Crisaborole is used for atopic dermatitis (E is incorrect).",
+		"rationale": "Anakinra (A) and Tofacitinib (B) are used in the treatment of rheumatoid arthritis. Dupilumab is used for atopic dermatitis and asthma (C is incorrect). Apremilast is used for psoriasis (D is incorrect). Crisaborole is used for atopic dermatitis (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6010,7 +6010,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fabb27bd"],
-		"explanation": "Dupilumab is known to cause ocular surface disease, including severe dryness and corneal infiltrates (A is correct). Etanercept, Anakinra, Tofacitinib, and Apremilast do not have this side effect profile (B, C, D, E are incorrect).",
+		"rationale": "Dupilumab is known to cause ocular surface disease, including severe dryness and corneal infiltrates (A is correct). Etanercept, Anakinra, Tofacitinib, and Apremilast do not have this side effect profile (B, C, D, E are incorrect).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6044,7 +6044,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["58367786", "3b5508dd"],
-		"explanation": "Methotrexate inhibits dihydrofolate reductase, which is crucial for DNA production, making it effective in treating autoimmune diseases and cancer. It is not primarily used for tissue transplantation, nor does it enhance DNA production.",
+		"rationale": "Methotrexate inhibits dihydrofolate reductase, which is crucial for DNA production, making it effective in treating autoimmune diseases and cancer. It is not primarily used for tissue transplantation, nor does it enhance DNA production.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6078,7 +6078,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a90e2346", "11b48656"],
-		"explanation": "Tacrolimus and sirolimus are macrolide compounds used to prevent tissue rejection. Tacrolimus inhibits calcineurin and is available as a topical agent, while sirolimus is not. Nephrotoxicity is not a shared characteristic.",
+		"rationale": "Tacrolimus and sirolimus are macrolide compounds used to prevent tissue rejection. Tacrolimus inhibits calcineurin and is available as a topical agent, while sirolimus is not. Nephrotoxicity is not a shared characteristic.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6112,7 +6112,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8ef5ca2a"],
-		"explanation": "Cyclosporine is known for its nephrotoxic effects with extended use. Methotrexate, tacrolimus, hydroxychloroquine, and azathioprine do not have nephrotoxicity as a primary concern.",
+		"rationale": "Cyclosporine is known for its nephrotoxic effects with extended use. Methotrexate, tacrolimus, hydroxychloroquine, and azathioprine do not have nephrotoxicity as a primary concern.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6146,7 +6146,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d1383982", "522d42f0", "59a2b662"],
-		"explanation": "Monoclonal antibodies targeting TNFa diminish IL-1 and IL-6 generation, treat autoimmune diseases, and have the suffix -umab. They are administered via injection, not orally, and they reduce, not enhance, pro-inflammatory cytokine activity.",
+		"rationale": "Monoclonal antibodies targeting TNFa diminish IL-1 and IL-6 generation, treat autoimmune diseases, and have the suffix -umab. They are administered via injection, not orally, and they reduce, not enhance, pro-inflammatory cytokine activity.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6180,7 +6180,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4736c822", "66f32591", "eaae0638"],
-		"explanation": "Patients on hydroxychloroquine should be monitored for retinal toxicity with OCT and visual field testing, especially after 5 years. Corneal verticillata is a known side effect. Nephrotoxicity and bone marrow suppression are not primary concerns for hydroxychloroquine.",
+		"rationale": "Patients on hydroxychloroquine should be monitored for retinal toxicity with OCT and visual field testing, especially after 5 years. Corneal verticillata is a known side effect. Nephrotoxicity and bone marrow suppression are not primary concerns for hydroxychloroquine.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6214,7 +6214,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6564a64a"],
-		"explanation": "Hydroxychloroquine is primarily used for its anti-inflammatory properties in autoimmune diseases. Methotrexate, azathioprine, and cyclosporine are also used in autoimmune conditions but have different primary mechanisms or uses.",
+		"rationale": "Hydroxychloroquine is primarily used for its anti-inflammatory properties in autoimmune diseases. Methotrexate, azathioprine, and cyclosporine are also used in autoimmune conditions but have different primary mechanisms or uses.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6248,7 +6248,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fe700bc0"],
-		"explanation": "Tacrolimus is available as a topical agent for atopic dermatitis. Methotrexate, sirolimus, cyclosporine, and azathioprine are not used topically for this condition.",
+		"rationale": "Tacrolimus is available as a topical agent for atopic dermatitis. Methotrexate, sirolimus, cyclosporine, and azathioprine are not used topically for this condition.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6282,7 +6282,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9a202fde", "4262020e", "98cf2b25"],
-		"explanation": "Azathioprine inhibits purine synthesis, is used in rheumatoid arthritis, and prevents rejection in kidney transplants. It does not cause nephrotoxicity or corneal verticillata.",
+		"rationale": "Azathioprine inhibits purine synthesis, is used in rheumatoid arthritis, and prevents rejection in kidney transplants. It does not cause nephrotoxicity or corneal verticillata.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6316,7 +6316,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2b59eced"],
-		"explanation": "Azathioprine is associated with bone marrow suppression as a serious side effect. Methotrexate, tacrolimus, cyclosporine, and hydroxychloroquine do not have this as a primary concern.",
+		"rationale": "Azathioprine is associated with bone marrow suppression as a serious side effect. Methotrexate, tacrolimus, cyclosporine, and hydroxychloroquine do not have this as a primary concern.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6350,7 +6350,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["21c8a9b4"],
-		"explanation": "Cyclosporine is used in ophthalmic formulations like Restasis and Cequa for dry eye treatment. Methotrexate, tacrolimus, hydroxychloroquine, and azathioprine are not used for this purpose.",
+		"rationale": "Cyclosporine is used in ophthalmic formulations like Restasis and Cequa for dry eye treatment. Methotrexate, tacrolimus, hydroxychloroquine, and azathioprine are not used for this purpose.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6384,7 +6384,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0d7a5439", "8c685b1c", "4de8ded3"],
-		"explanation": "Hydroxychloroquine is primarily used as an anti-inflammatory for autoimmune diseases, not as an anti-malarial today. It can cause retinal toxicity after prolonged use, requiring regular monitoring. It is not fully excreted at a typical dose, and it is associated with corneal verticillata.",
+		"rationale": "Hydroxychloroquine is primarily used as an anti-inflammatory for autoimmune diseases, not as an anti-malarial today. It can cause retinal toxicity after prolonged use, requiring regular monitoring. It is not fully excreted at a typical dose, and it is associated with corneal verticillata.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6418,7 +6418,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["30bb04bb", "6903daff", "2f6f6d21"],
-		"explanation": "Methotrexate is used for autoimmune diseases, cancer treatment, and less frequently for tissue transplantation. It is not used for malaria or atopic dermatitis.",
+		"rationale": "Methotrexate is used for autoimmune diseases, cancer treatment, and less frequently for tissue transplantation. It is not used for malaria or atopic dermatitis.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6452,7 +6452,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d3fede6c", "48c94959"],
-		"explanation": "Tacrolimus and cyclosporine both inhibit T cell activation by interfering with IL-2. Methotrexate inhibits dihydrofolate reductase, azathioprine inhibits purine synthesis, and hydroxychloroquine's mechanism is not fully understood but does not involve IL-2.",
+		"rationale": "Tacrolimus and cyclosporine both inhibit T cell activation by interfering with IL-2. Methotrexate inhibits dihydrofolate reductase, azathioprine inhibits purine synthesis, and hydroxychloroquine's mechanism is not fully understood but does not involve IL-2.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6486,7 +6486,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cf73e693", "6bb8e17e"],
-		"explanation": "Azathioprine's most common side effects are nausea and vomiting, with bone marrow suppression being the most serious. Nephrotoxicity, retinal toxicity, and corneal verticillata are not associated with azathioprine.",
+		"rationale": "Azathioprine's most common side effects are nausea and vomiting, with bone marrow suppression being the most serious. Nephrotoxicity, retinal toxicity, and corneal verticillata are not associated with azathioprine.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6520,7 +6520,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["21c67216", "18990b29"],
-		"explanation": "Tacrolimus is used topically for atopic dermatitis, and crisaborole is used for atopic dermatitis as well. Apremilast is used for psoriasis but not topically, cyclosporine is used ophthalmically, and hydroxychloroquine is not used topically.",
+		"rationale": "Tacrolimus is used topically for atopic dermatitis, and crisaborole is used for atopic dermatitis as well. Apremilast is used for psoriasis but not topically, cyclosporine is used ophthalmically, and hydroxychloroquine is not used topically.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6554,7 +6554,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f75024a6", "a06de309", "0631ede2"],
-		"explanation": "JAK inhibitors inhibit enzymes that phosphorylate activated cytokine receptors and are used for rheumatoid arthritis and psoriasis. Tofacitinib is an example. They have significant side effects, including elevated risks for cardiovascular events and malignancy, and are not primarily used for cancer treatment.",
+		"rationale": "JAK inhibitors inhibit enzymes that phosphorylate activated cytokine receptors and are used for rheumatoid arthritis and psoriasis. Tofacitinib is an example. They have significant side effects, including elevated risks for cardiovascular events and malignancy, and are not primarily used for cancer treatment.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6588,7 +6588,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4afafd3e"],
-		"explanation": "Cyclosporine is associated with nephrotoxicity with extended use. Tacrolimus, methotrexate, azathioprine, and hydroxychloroquine are not primarily associated with nephrotoxicity.",
+		"rationale": "Cyclosporine is associated with nephrotoxicity with extended use. Tacrolimus, methotrexate, azathioprine, and hydroxychloroquine are not primarily associated with nephrotoxicity.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6622,7 +6622,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6351b33a"],
-		"explanation": "Hydroxychloroquine requires monitoring for ocular side effects, particularly retinal toxicity. Methotrexate, cyclosporine, tacrolimus, and azathioprine do not require such monitoring for ocular side effects.",
+		"rationale": "Hydroxychloroquine requires monitoring for ocular side effects, particularly retinal toxicity. Methotrexate, cyclosporine, tacrolimus, and azathioprine do not require such monitoring for ocular side effects.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6656,7 +6656,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d6caec47", "933e35f5", "81ac3ee7"],
-		"explanation": "Apremilast, tofacitinib, and methotrexate are used in the treatment of psoriasis. Crisaborole is used for atopic dermatitis, and hydroxychloroquine is not typically used for psoriasis.",
+		"rationale": "Apremilast, tofacitinib, and methotrexate are used in the treatment of psoriasis. Crisaborole is used for atopic dermatitis, and hydroxychloroquine is not typically used for psoriasis.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6690,7 +6690,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["359062a0", "563fe2ee", "5ae8a1a4"],
-		"explanation": "PDE4 inhibitors block the degradative action of phosphodiesterase 4 on cAMP and are used for conditions like psoriasis and atopic dermatitis. Apremilast is an example. They are not used to prevent tissue rejection and are not associated with bone marrow suppression.",
+		"rationale": "PDE4 inhibitors block the degradative action of phosphodiesterase 4 on cAMP and are used for conditions like psoriasis and atopic dermatitis. Apremilast is an example. They are not used to prevent tissue rejection and are not associated with bone marrow suppression.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6724,7 +6724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a8979b7b", "47e5add3"],
-		"explanation": "Ocrelizumab and ofatumumab are anti-CD20+/B cell antibodies used in the treatment of MS. Benlysta targets CD20 but is used for other conditions. Lucentis and Avastin are used in eye care, not MS.",
+		"rationale": "Ocrelizumab and ofatumumab are anti-CD20+/B cell antibodies used in the treatment of MS. Benlysta targets CD20 but is used for other conditions. Lucentis and Avastin are used in eye care, not MS.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6758,7 +6758,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["55765cc3", "d4b8c0ad"],
-		"explanation": "Avastin is used off-label for wet AMD, and all anti-VEGF drugs, including Lucentis, Eylea, and Beovu, are administered via intra-vitreal injection. Lucentis is approved for wet AMD, not colon cancer. Eylea is not administered orally.",
+		"rationale": "Avastin is used off-label for wet AMD, and all anti-VEGF drugs, including Lucentis, Eylea, and Beovu, are administered via intra-vitreal injection. Lucentis is approved for wet AMD, not colon cancer. Eylea is not administered orally.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6792,7 +6792,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d9846676", "01bfa428", "7ec1a682"],
-		"explanation": "Humira, Infliximab, and Etanercept are TNF-a inhibitors. Anakinra is an IL-1 antagonist, and Dupilumab inhibits IL-4 and IL-13.",
+		"rationale": "Humira, Infliximab, and Etanercept are TNF-a inhibitors. Anakinra is an IL-1 antagonist, and Dupilumab inhibits IL-4 and IL-13.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6826,7 +6826,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["57b90505"],
-		"explanation": "The primary risk of TNF-a inhibitors, including Etanercept, is immunosuppression. Ocular surface disease is associated with Dupilumab, and vascular side effects are noted with Aduhelm.",
+		"rationale": "The primary risk of TNF-a inhibitors, including Etanercept, is immunosuppression. Ocular surface disease is associated with Dupilumab, and vascular side effects are noted with Aduhelm.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6860,7 +6860,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9581061c"],
-		"explanation": "Humira is approved for the treatment of non-infectious uveitis. Anakinra is used for rheumatoid arthritis, Aduhelm for Alzheimer's, Dupilumab for atopic dermatitis, and Etanercept for rheumatoid arthritis.",
+		"rationale": "Humira is approved for the treatment of non-infectious uveitis. Anakinra is used for rheumatoid arthritis, Aduhelm for Alzheimer's, Dupilumab for atopic dermatitis, and Etanercept for rheumatoid arthritis.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6894,7 +6894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cf9728e4"],
-		"explanation": "Aduhelm binds to amyloid plaques in the brain, which are associated with Alzheimer's disease. The other drugs target different proteins or conditions.",
+		"rationale": "Aduhelm binds to amyloid plaques in the brain, which are associated with Alzheimer's disease. The other drugs target different proteins or conditions.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6928,7 +6928,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["72c6e43a"],
-		"explanation": "Anakinra is a modified, synthetic IL-1 antagonist. Humira and Infliximab are TNF-a inhibitors, Dupilumab inhibits IL-4 and IL-13, and Etanercept is a TNF-a inhibitor.",
+		"rationale": "Anakinra is a modified, synthetic IL-1 antagonist. Humira and Infliximab are TNF-a inhibitors, Dupilumab inhibits IL-4 and IL-13, and Etanercept is a TNF-a inhibitor.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6962,7 +6962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a6e5dc5"],
-		"explanation": "Dupilumab is associated with ocular surface disease, including severe dryness and corneal infiltrates. The other drugs do not have this side effect profile.",
+		"rationale": "Dupilumab is associated with ocular surface disease, including severe dryness and corneal infiltrates. The other drugs do not have this side effect profile.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -6996,7 +6996,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["04160272"],
-		"explanation": "Both Lucentis and Avastin bind VEGF. Lucentis is a smaller molecule than Avastin, which is used off-label for wet AMD. Avastin is approved for metastatic colon cancer and is cheaper than Lucentis.",
+		"rationale": "Both Lucentis and Avastin bind VEGF. Lucentis is a smaller molecule than Avastin, which is used off-label for wet AMD. Avastin is approved for metastatic colon cancer and is cheaper than Lucentis.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7030,7 +7030,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dc52ae47"],
-		"explanation": "Dupilumab is used to treat atopic dermatitis. Anakinra is used for rheumatoid arthritis, Humira for arthritis and uveitis, Etanercept for rheumatoid arthritis, and Ocrelizumab for MS.",
+		"rationale": "Dupilumab is used to treat atopic dermatitis. Anakinra is used for rheumatoid arthritis, Humira for arthritis and uveitis, Etanercept for rheumatoid arthritis, and Ocrelizumab for MS.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7064,7 +7064,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["140aba85", "17077248"],
-		"explanation": "Oral steroids should be taken with food to minimize stomach upset (A). H2 blockers or PPIs are recommended for gastric protection when high doses or prolonged use is necessary (B). Taking steroids on an empty stomach (C) can increase gastrointestinal side effects, and dividing the dose (D) can help manage side effects and maintain therapeutic levels.",
+		"rationale": "Oral steroids should be taken with food to minimize stomach upset (A). H2 blockers or PPIs are recommended for gastric protection when high doses or prolonged use is necessary (B). Taking steroids on an empty stomach (C) can increase gastrointestinal side effects, and dividing the dose (D) can help manage side effects and maintain therapeutic levels.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7094,7 +7094,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6f1fcc77", "be30be7f", "fd050ff8"],
-		"explanation": "Long-term steroid use can lead to hyperglycemia (A), immunosuppression (B), and cataracts (C). Hypotension (D) is not a typical side effect; steroids can actually cause hypertension.",
+		"rationale": "Long-term steroid use can lead to hyperglycemia (A), immunosuppression (B), and cataracts (C). Hypotension (D) is not a typical side effect; steroids can actually cause hypertension.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7124,7 +7124,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["030f1dff"],
-		"explanation": "Tapering the dose gradually (B) is necessary to avoid rebound inflammation and adrenal suppression. Stopping immediately (A) or switching without tapering (C) can lead to withdrawal symptoms. Increasing the dose (D) is not appropriate when discontinuing.",
+		"rationale": "Tapering the dose gradually (B) is necessary to avoid rebound inflammation and adrenal suppression. Stopping immediately (A) or switching without tapering (C) can lead to withdrawal symptoms. Increasing the dose (D) is not appropriate when discontinuing.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7154,7 +7154,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["180baa1e", "e21b2fe6", "d9daa685"],
-		"explanation": "Symptoms of steroid withdrawal include joint and muscle pain (A), hypotension (C), and fever (D). Weight gain (B) is more commonly associated with steroid use, not withdrawal.",
+		"rationale": "Symptoms of steroid withdrawal include joint and muscle pain (A), hypotension (C), and fever (D). Weight gain (B) is more commonly associated with steroid use, not withdrawal.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7184,7 +7184,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["806d4b1c"],
-		"explanation": "Prednisone (B) is the most commonly used oral steroid formulation. Dexamethasone (A) is often used topically, while methylprednisolone (C) and prednisolone (D) are used in specific cases but are not as common as prednisone for oral use.",
+		"rationale": "Prednisone (B) is the most commonly used oral steroid formulation. Dexamethasone (A) is often used topically, while methylprednisolone (C) and prednisolone (D) are used in specific cases but are not as common as prednisone for oral use.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7214,7 +7214,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5a535126", "52fcc15e", "81e722e8"],
-		"explanation": "Glucocorticoids are used to treat Addison's disease (A), help diagnose Cushing's syndrome (B), and manage various inflammatory conditions (C). They are not used to treat hyperthyroidism (D).",
+		"rationale": "Glucocorticoids are used to treat Addison's disease (A), help diagnose Cushing's syndrome (B), and manage various inflammatory conditions (C). They are not used to treat hyperthyroidism (D).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7244,7 +7244,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e2356f79"],
-		"explanation": "Increased potency of glucocorticoids correlates with increased side effects (B). Potency is related to both the intrinsic biological activity and the duration of action, but it does not decrease side effects (A) or have no relation to them (C). Potency affects more than just the duration of action (D).",
+		"rationale": "Increased potency of glucocorticoids correlates with increased side effects (B). Potency is related to both the intrinsic biological activity and the duration of action, but it does not decrease side effects (A) or have no relation to them (C). Potency affects more than just the duration of action (D).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7274,7 +7274,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b161f80f", "c04cde01", "84a25a0a"],
-		"explanation": "Common endocrine side effects include hypokalemia (A), growth suppression (B), and truncal obesity (C). Hyperthyroidism (D) is not a typical side effect of steroid use.",
+		"rationale": "Common endocrine side effects include hypokalemia (A), growth suppression (B), and truncal obesity (C). Hyperthyroidism (D) is not a typical side effect of steroid use.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7304,7 +7304,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b8298bf5"],
-		"explanation": "The first dose of oral steroids is recommended to be taken in the morning (B) to align with the body's natural cortisol rhythm and minimize insomnia. Taking it at bedtime (A), noon (C), or in the evening (D) can disrupt sleep patterns.",
+		"rationale": "The first dose of oral steroids is recommended to be taken in the morning (B) to align with the body's natural cortisol rhythm and minimize insomnia. Taking it at bedtime (A), noon (C), or in the evening (D) can disrupt sleep patterns.",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7334,7 +7334,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8170baa7", "e66d503a"],
-		"explanation": "The duration of action is related to the potency of glucocorticoids (B), and increased potency can lead to increased side effects (D). The observed potency is not solely determined by the circulating half-life (A), and the relationship between half-life and potency is imprecise (C).",
+		"rationale": "The duration of action is related to the potency of glucocorticoids (B), and increased potency can lead to increased side effects (D). The observed potency is not solely determined by the circulating half-life (A), and the relationship between half-life and potency is imprecise (C).",
 		"metadata": {},
 		"moduleId": "js7565kf1zxbp0tw2j90pjas217m9nf7",
 		"options": [
@@ -7364,7 +7364,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ec1ef4ba", "8c74cf40", "f0681b4c"],
-		"explanation": "Alcohol is rapidly bactericidal and effective against vegetative forms of bacteria, but it is not effective against bacterial spores. Its antimicrobial activity decreases sharply when diluted below 50%. Alcohol is not recommended for sterilizing medical and surgical materials due to its lack of sporicidal action.",
+		"rationale": "Alcohol is rapidly bactericidal and effective against vegetative forms of bacteria, but it is not effective against bacterial spores. Its antimicrobial activity decreases sharply when diluted below 50%. Alcohol is not recommended for sterilizing medical and surgical materials due to its lack of sporicidal action.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7398,7 +7398,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2eaebf82"],
-		"explanation": "The most feasible explanation for the antimicrobial action of alcohol is the denaturation of proteins. Other options describe mechanisms of action for different disinfectants.",
+		"rationale": "The most feasible explanation for the antimicrobial action of alcohol is the denaturation of proteins. Other options describe mechanisms of action for different disinfectants.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7432,7 +7432,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a9fdca41", "e77633f0"],
-		"explanation": "Formaldehyde and hydrogen peroxide are effective against bacterial spores. Alcohols and sodium hypochlorite are not sporicidal.",
+		"rationale": "Formaldehyde and hydrogen peroxide are effective against bacterial spores. Alcohols and sodium hypochlorite are not sporicidal.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7466,7 +7466,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9a9e7248", "9429dd55"],
-		"explanation": "70% ethanol wipes are not recommended for tonometer tip disinfection due to their lack of activity against adenovirus and other non-enveloped viruses. They do not cause ocular irritation or leave toxic residues.",
+		"rationale": "70% ethanol wipes are not recommended for tonometer tip disinfection due to their lack of activity against adenovirus and other non-enveloped viruses. They do not cause ocular irritation or leave toxic residues.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7500,7 +7500,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["be42f8c8", "8843350e", "a3d9aa4d"],
-		"explanation": "Sodium hypochlorite is unaffected by water hardness, can cause ocular irritation and burns, and is effective in removing biofilms from surfaces. It does not leave toxic residues and is inexpensive and fast-acting.",
+		"rationale": "Sodium hypochlorite is unaffected by water hardness, can cause ocular irritation and burns, and is effective in removing biofilms from surfaces. It does not leave toxic residues and is inexpensive and fast-acting.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7534,7 +7534,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["04271e6e"],
-		"explanation": "Formaldehyde inactivates microorganisms by alkylating the amino and sulfhydral groups of proteins and ring nitrogen atoms of purine bases. Other options describe mechanisms of action for different disinfectants.",
+		"rationale": "Formaldehyde inactivates microorganisms by alkylating the amino and sulfhydral groups of proteins and ring nitrogen atoms of purine bases. Other options describe mechanisms of action for different disinfectants.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7568,7 +7568,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["13cfd6f2"],
-		"explanation": "Hydrogen peroxide works by producing destructive hydroxyl free radicals that can attack membrane lipids, DNA, and other essential cell components. Other options do not produce free radicals.",
+		"rationale": "Hydrogen peroxide works by producing destructive hydroxyl free radicals that can attack membrane lipids, DNA, and other essential cell components. Other options do not produce free radicals.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7602,7 +7602,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["656e3f91"],
-		"explanation": "Formaldehyde is a potential carcinogen. Other disinfectants listed are not classified as carcinogens.",
+		"rationale": "Formaldehyde is a potential carcinogen. Other disinfectants listed are not classified as carcinogens.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7636,7 +7636,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c0b61d5f"],
-		"explanation": "A 10% concentration of hydrogen peroxide is recommended for disinfecting tonometer tips. Lower concentrations are used for other purposes, such as disinfecting soft contact lenses.",
+		"rationale": "A 10% concentration of hydrogen peroxide is recommended for disinfecting tonometer tips. Lower concentrations are used for other purposes, such as disinfecting soft contact lenses.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7670,7 +7670,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c77969fe", "02e44e7b"],
-		"explanation": "Hydrogen peroxide is effective against a wide range of microorganisms, including spores, and is stable and effective when used on inanimate surfaces. It works by producing hydroxyl free radicals, not by denaturing proteins. It is not specifically recommended for sterilizing medical and surgical materials.",
+		"rationale": "Hydrogen peroxide is effective against a wide range of microorganisms, including spores, and is stable and effective when used on inanimate surfaces. It works by producing hydroxyl free radicals, not by denaturing proteins. It is not specifically recommended for sterilizing medical and surgical materials.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7704,7 +7704,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2f38d3e8", "68b78695"],
-		"explanation": "β-lactam antibiotics are broad-spectrum and effective against both Gram-positive and Gram-negative bacteria (A). They are not inherently resistant to β-lactamase enzymes (B), but their efficacy can be enhanced by combining them with β-lactamase inhibitors (D). They are effective against Pseudomonas when combined with specific inhibitors (C), and they are not used for viral infections (E).",
+		"rationale": "β-lactam antibiotics are broad-spectrum and effective against both Gram-positive and Gram-negative bacteria (A). They are not inherently resistant to β-lactamase enzymes (B), but their efficacy can be enhanced by combining them with β-lactamase inhibitors (D). They are effective against Pseudomonas when combined with specific inhibitors (C), and they are not used for viral infections (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7738,7 +7738,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a80f11c0"],
-		"explanation": "Nafcillin is the drug of choice for Staphylococcal endocarditis (C). Methicillin is primarily used for testing resistance (A), Oxacillin is more potent than methicillin but not specifically indicated for endocarditis (B), Dicloxacillin is used for penicillinase-resistant infections but not specifically for endocarditis (D), and Piperacillin is used for gram-negative infections (E).",
+		"rationale": "Nafcillin is the drug of choice for Staphylococcal endocarditis (C). Methicillin is primarily used for testing resistance (A), Oxacillin is more potent than methicillin but not specifically indicated for endocarditis (B), Dicloxacillin is used for penicillinase-resistant infections but not specifically for endocarditis (D), and Piperacillin is used for gram-negative infections (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7772,7 +7772,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ddc74843", "75fec3b5"],
-		"explanation": "Piperacillin (B) and Aztreonam (C) are specifically developed to treat infections caused by Pseudomonas aeruginosa. Vancomycin is used for resistant Gram-positive infections (A), Dicloxacillin is used for penicillinase-resistant infections (D), and Imipenem is a broad-spectrum antibiotic held in reserve for multi-drug resistant bacteria (E).",
+		"rationale": "Piperacillin (B) and Aztreonam (C) are specifically developed to treat infections caused by Pseudomonas aeruginosa. Vancomycin is used for resistant Gram-positive infections (A), Dicloxacillin is used for penicillinase-resistant infections (D), and Imipenem is a broad-spectrum antibiotic held in reserve for multi-drug resistant bacteria (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7806,7 +7806,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3942bc3f", "455391d7"],
-		"explanation": "Vancomycin is nephrotoxic (B) and used for MRSA infections (C). It is not effective against Gram-negative bacteria (A), is not administered orally for systemic infections (D), and is not a β-lactam antibiotic (E).",
+		"rationale": "Vancomycin is nephrotoxic (B) and used for MRSA infections (C). It is not effective against Gram-negative bacteria (A), is not administered orally for systemic infections (D), and is not a β-lactam antibiotic (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7840,7 +7840,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["98ed9eb6"],
-		"explanation": "Aztreonam is a monobactam (A). Imipenem is a carbapenem (B), Piperacillin is an anti-Pseudomonal penicillin (C), Nafcillin is a penicillinase-resistant penicillin (D), and Vancomycin is a glycopeptide antibiotic (E).",
+		"rationale": "Aztreonam is a monobactam (A). Imipenem is a carbapenem (B), Piperacillin is an anti-Pseudomonal penicillin (C), Nafcillin is a penicillinase-resistant penicillin (D), and Vancomycin is a glycopeptide antibiotic (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7874,7 +7874,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6cb82031", "d729dd4c"],
-		"explanation": "Carbapenems are typically held in reserve for multi-drug resistant bacteria (B) and are combined with cilastatin to decrease nephrotoxicity (D). They are broad-spectrum antibiotics (A), effective against Gram-positive bacteria (C), and are not used for viral infections (E).",
+		"rationale": "Carbapenems are typically held in reserve for multi-drug resistant bacteria (B) and are combined with cilastatin to decrease nephrotoxicity (D). They are broad-spectrum antibiotics (A), effective against Gram-positive bacteria (C), and are not used for viral infections (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7908,7 +7908,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e53613f0"],
-		"explanation": "Diarrhea is a common side effect of β-lactam antibiotics (A). Nephrotoxicity is more associated with Vancomycin (B), retinal hemorrhaging is associated with intravitreal Vancomycin (C), and hepatotoxicity (D) and ototoxicity (E) are not commonly associated with β-lactam antibiotics.",
+		"rationale": "Diarrhea is a common side effect of β-lactam antibiotics (A). Nephrotoxicity is more associated with Vancomycin (B), retinal hemorrhaging is associated with intravitreal Vancomycin (C), and hepatotoxicity (D) and ototoxicity (E) are not commonly associated with β-lactam antibiotics.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7942,7 +7942,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["84dcdfcd", "5dbb674e"],
-		"explanation": "Penicillinase-resistant penicillins are resistant to β-lactamase (C) and include drugs like methicillin and oxacillin (D). They have narrow-spectrum activity (A), are not effective against Gram-negative bacteria (B), and are not used for treating Pseudomonas infections (E).",
+		"rationale": "Penicillinase-resistant penicillins are resistant to β-lactamase (C) and include drugs like methicillin and oxacillin (D). They have narrow-spectrum activity (A), are not effective against Gram-negative bacteria (B), and are not used for treating Pseudomonas infections (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -7976,7 +7976,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8d1212c4", "d5061014"],
-		"explanation": "β-lactamase inhibitors enhance the efficacy of β-lactam antibiotics (B) and include drugs like tazobactam and clavulanic acid (E). They are not antibiotics themselves (A), are effective against bacteria when combined with β-lactam antibiotics (C), and are not used to treat viral infections (D).",
+		"rationale": "β-lactamase inhibitors enhance the efficacy of β-lactam antibiotics (B) and include drugs like tazobactam and clavulanic acid (E). They are not antibiotics themselves (A), are effective against bacteria when combined with β-lactam antibiotics (C), and are not used to treat viral infections (D).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8010,7 +8010,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["93524cda", "a3779ccf"],
-		"explanation": "More recent studies indicate that the true cross-reaction rate between penicillin and cephalosporins is under 10% (B) and may be as low as 1% (C). Older studies suggested a rate as high as 25% (A), but this is not supported by recent data. Cross-reactivity is a concern for some patients (D), and it is not limited to those with a history of anaphylaxis (E).",
+		"rationale": "More recent studies indicate that the true cross-reaction rate between penicillin and cephalosporins is under 10% (B) and may be as low as 1% (C). Older studies suggested a rate as high as 25% (A), but this is not supported by recent data. Cross-reactivity is a concern for some patients (D), and it is not limited to those with a history of anaphylaxis (E).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8044,7 +8044,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1d2ef3a3", "86de07a1"],
-		"explanation": "Aminoglycosides act on the 70s ribosome subunit and are contraindicated in pregnant women due to systemic toxicity. They are primarily used for gram-negative infections and have significant oto- and nephrotoxicity. Neomycin is not used systemically due to high toxicity.",
+		"rationale": "Aminoglycosides act on the 70s ribosome subunit and are contraindicated in pregnant women due to systemic toxicity. They are primarily used for gram-negative infections and have significant oto- and nephrotoxicity. Neomycin is not used systemically due to high toxicity.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8078,7 +8078,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0682a6e8", "7e3365a5"],
-		"explanation": "Tetracyclines are bacteriostatic, not bactericidal, and are contraindicated in children and pregnant women due to potential bone and teeth malformations. Their absorption is impaired by food and antacids, and they can cause photosensitivity. Many gram-positive bacteria are resistant to tetracyclines.",
+		"rationale": "Tetracyclines are bacteriostatic, not bactericidal, and are contraindicated in children and pregnant women due to potential bone and teeth malformations. Their absorption is impaired by food and antacids, and they can cause photosensitivity. Many gram-positive bacteria are resistant to tetracyclines.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8112,7 +8112,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0ffeee2c"],
-		"explanation": "Oritavancin is a semi-synthetic cousin of vancomycin used as a one-dose treatment for skin infections, including MRSA. Vancomycin is used for resistant gram-positive infections but requires multiple doses. Bacitracin is used topically, Aztreonam is used for gram-negative infections, and Gentamicin is used for gram-negative infections.",
+		"rationale": "Oritavancin is a semi-synthetic cousin of vancomycin used as a one-dose treatment for skin infections, including MRSA. Vancomycin is used for resistant gram-positive infections but requires multiple doses. Bacitracin is used topically, Aztreonam is used for gram-negative infections, and Gentamicin is used for gram-negative infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8146,7 +8146,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b0d00913", "1f5eee90"],
-		"explanation": "Neomycin and Bacitracin have high rates of hypersensitivity reactions. Vancomycin, Gentamicin, and Tobramycin do not have as high a rate of hypersensitivity.",
+		"rationale": "Neomycin and Bacitracin have high rates of hypersensitivity reactions. Vancomycin, Gentamicin, and Tobramycin do not have as high a rate of hypersensitivity.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8180,7 +8180,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3d5e844f", "7b667bd4"],
-		"explanation": "Vancomycin is nephrotoxic and used for resistant gram-positive infections, including MRSA. It is ineffective against gram-negative bacteria, is administered intravenously for systemic infections, and has good CNS penetration.",
+		"rationale": "Vancomycin is nephrotoxic and used for resistant gram-positive infections, including MRSA. It is ineffective against gram-negative bacteria, is administered intravenously for systemic infections, and has good CNS penetration.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8214,7 +8214,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0d6ad2d1", "f0efd744"],
-		"explanation": "Neomycin and Bacitracin are used topically due to high systemic toxicity. Amikacin is used systemically for specific infections, and All cephalosporins (cephalexin) and Penicillins (Amoxicillin) are only used systemically, not topically.",
+		"rationale": "Neomycin and Bacitracin are used topically due to high systemic toxicity. Amikacin is used systemically for specific infections, and All cephalosporins (cephalexin) and Penicillins (Amoxicillin) are only used systemically, not topically.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8248,7 +8248,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ed9ab52f"],
-		"explanation": "Tetracyclines can cause idiopathic intracranial hypertension as a rare side effect. Aminoglycosides, Vancomycin, Monobactams, and Bacitracin do not have this side effect.",
+		"rationale": "Tetracyclines can cause idiopathic intracranial hypertension as a rare side effect. Aminoglycosides, Vancomycin, Monobactams, and Bacitracin do not have this side effect.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8282,7 +8282,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["974c6bea"],
-		"explanation": "Aztreonam, a monobactam, has no cross-allergy with penicillin. Vancomycin, Gentamicin, Tobramycin, and Bacitracin do not have this characteristic.",
+		"rationale": "Aztreonam, a monobactam, has no cross-allergy with penicillin. Vancomycin, Gentamicin, Tobramycin, and Bacitracin do not have this characteristic.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8316,7 +8316,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["82253ace", "9f56ea15"],
-		"explanation": "Tetracycline is infrequently used due to its high dosing schedule. Doxycycline is excreted primarily in feces, not via the renal route, making it safer for patients with kidney issues. Minocycline is highly lipid soluble and used in dermatology. Tetracycline absorption is impaired by calcium, not enhanced. Doxycycline is effective against tick-borne diseases.",
+		"rationale": "Tetracycline is infrequently used due to its high dosing schedule. Doxycycline is excreted primarily in feces, not via the renal route, making it safer for patients with kidney issues. Minocycline is highly lipid soluble and used in dermatology. Tetracycline absorption is impaired by calcium, not enhanced. Doxycycline is effective against tick-borne diseases.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8350,7 +8350,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bd8dc8dd"],
-		"explanation": "Tigecycline is a broad-spectrum antibiotic developed to treat resistant organisms such as MRSA. Tetracycline, doxycycline, and minocycline are not specifically developed for resistant organisms like MRSA. Chloramphenicol is broad-spectrum but not specifically noted for treating MRSA.",
+		"rationale": "Tigecycline is a broad-spectrum antibiotic developed to treat resistant organisms such as MRSA. Tetracycline, doxycycline, and minocycline are not specifically developed for resistant organisms like MRSA. Chloramphenicol is broad-spectrum but not specifically noted for treating MRSA.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8384,7 +8384,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["315ed6ae"],
-		"explanation": "Tetracyclines can cause gastrointestinal distress, photosensitivity, a metallic taste, and, rarely, idiopathic intracranial hypertension.",
+		"rationale": "Tetracyclines can cause gastrointestinal distress, photosensitivity, a metallic taste, and, rarely, idiopathic intracranial hypertension.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8418,7 +8418,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["22999458", "f360b498"],
-		"explanation": "Doxycycline is not contraindicated in patients with compromised kidneys as it is excreted in feces. It is highly effective against chlamydia (although Azithromycin has better compliance) and is used in eye care for its anti-inflammatory effects. It has fair activity against MRSA and is not primarily excreted via the renal route.",
+		"rationale": "Doxycycline is not contraindicated in patients with compromised kidneys as it is excreted in feces. It is highly effective against chlamydia (although Azithromycin has better compliance) and is used in eye care for its anti-inflammatory effects. It has fair activity against MRSA and is not primarily excreted via the renal route.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8452,7 +8452,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7c2bc580", "cd79fc8d"],
-		"explanation": "Tetracycline absorption is impaired by dairy products and antacids. Doxycycline absorption is minimally affected by calcium, with a decrease of about 20% that is not clinically significant. Minocycline absorption is affected by food, similar to other tetracyclines.",
+		"rationale": "Tetracycline absorption is impaired by dairy products and antacids. Doxycycline absorption is minimally affected by calcium, with a decrease of about 20% that is not clinically significant. Minocycline absorption is affected by food, similar to other tetracyclines.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8486,7 +8486,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44021963"],
-		"explanation": "Doxycycline is known for its anti-inflammatory effects in eye care, particularly for conditions like meibomianitis. Tetracycline, minocycline, tigecycline, and chloramphenicol are not specifically noted for this use.",
+		"rationale": "Doxycycline is known for its anti-inflammatory effects in eye care, particularly for conditions like meibomianitis. Tetracycline, minocycline, tigecycline, and chloramphenicol are not specifically noted for this use.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8520,7 +8520,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["41159b57"],
-		"explanation": "Chloramphenicol is available in IV, oral, and topical forms, including ophthalmic formulations. Tetracycline, doxycycline, minocycline, and tigecycline do not have this range of formulations.",
+		"rationale": "Chloramphenicol is available in IV, oral, and topical forms, including ophthalmic formulations. Tetracycline, doxycycline, minocycline, and tigecycline do not have this range of formulations.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8554,7 +8554,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["29bb71be", "27807365", "41aa470a"],
-		"explanation": "Tetracycline, doxycycline, and minocycline are contraindicated in children and pregnant women due to potential effects on bone and teeth. Clindamycin is not specifically noted for these contraindications. Chloramphenicol is contraindicated in pregnant women but for 'grey baby syndrome' instead on bone and tooth deformities.",
+		"rationale": "Tetracycline, doxycycline, and minocycline are contraindicated in children and pregnant women due to potential effects on bone and teeth. Clindamycin is not specifically noted for these contraindications. Chloramphenicol is contraindicated in pregnant women but for 'grey baby syndrome' instead on bone and tooth deformities.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8588,7 +8588,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1c0ca5e5", "dbcc774f", "5ab9756a"],
-		"explanation": "Tetracycline, doxycycline, and minocycline work on the 30s bacterial subunit. Gentamicin and Chloramphenicol do not; Chloramphenicol works on the 50s subunit. Gentamicin works on the 70S subunit. ",
+		"rationale": "Tetracycline, doxycycline, and minocycline work on the 30s bacterial subunit. Gentamicin and Chloramphenicol do not; Chloramphenicol works on the 50s subunit. Gentamicin works on the 70S subunit. ",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8622,7 +8622,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["477c0069", "05766b3a"],
-		"explanation": "Chloramphenicol is not readily available in the U.S. due to historical concerns about aplastic anemia, although these concerns have been questioned. It is contraindicated in pregnancy due to the risk of grey baby syndrome. It is not a macrolide antibiotic and is not commonly used for meningitis.",
+		"rationale": "Chloramphenicol is not readily available in the U.S. due to historical concerns about aplastic anemia, although these concerns have been questioned. It is contraindicated in pregnancy due to the risk of grey baby syndrome. It is not a macrolide antibiotic and is not commonly used for meningitis.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8656,7 +8656,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["df1715f4", "cd05dc36", "95caa825"],
-		"explanation": "Macrolides work on the 50s ribosomal subunit, not the 30s. They can be bacteriostatic or bactericidal depending on various factors. They are not used for meningitis due to poor CNS penetration. Resistance to macrolides is relatively easy for many bacteria.",
+		"rationale": "Macrolides work on the 50s ribosomal subunit, not the 30s. They can be bacteriostatic or bactericidal depending on various factors. They are not used for meningitis due to poor CNS penetration. Resistance to macrolides is relatively easy for many bacteria.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8690,7 +8690,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["afa161d4", "f657a59e", "9a6ecffc"],
-		"explanation": "Clarithromycin is a macrolide antibiotic and can cause a metallic taste. It acts as an inhibitor, not an inducer, of CYP3A4. It is effective against both gram-positive and gram-negative bacteria. It shares a similar mechanism of action with telithromycin.",
+		"rationale": "Clarithromycin is a macrolide antibiotic and can cause a metallic taste. It acts as an inhibitor, not an inducer, of CYP3A4. It is effective against both gram-positive and gram-negative bacteria. It shares a similar mechanism of action with telithromycin.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8724,7 +8724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7246c48d", "4a982d0b", "c68daee8"],
-		"explanation": "Erythromycin is the oldest macrolide and is more effective against gram-positive bacteria. It causes more GI upset than other macrolides and is used as a prophylactic ophthalmic ointment for newborns. It has considerable bacterial resistance.",
+		"rationale": "Erythromycin is the oldest macrolide and is more effective against gram-positive bacteria. It causes more GI upset than other macrolides and is used as a prophylactic ophthalmic ointment for newborns. It has considerable bacterial resistance.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8758,7 +8758,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c8f8f59d", "2524d88a", "b7142f0c"],
-		"explanation": "Azithromycin has a long half-life of 68 hours, making it effective with fewer doses. It is a primary drug for Chlamydia and has anti-inflammatory properties. It is effective against both gram-positive and gram-negative bacteria and is available in oral and ophthalmic forms.",
+		"rationale": "Azithromycin has a long half-life of 68 hours, making it effective with fewer doses. It is a primary drug for Chlamydia and has anti-inflammatory properties. It is effective against both gram-positive and gram-negative bacteria and is available in oral and ophthalmic forms.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8792,7 +8792,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b0b3155", "45bf7077", "aedfb6f5"],
-		"explanation": "Clindamycin is a lincosamide, not a macrolide. It is effective against anaerobic bacteria and can lead to pseudomembranous colitis. It is used in the treatment of acne and has pediatric dosing.",
+		"rationale": "Clindamycin is a lincosamide, not a macrolide. It is effective against anaerobic bacteria and can lead to pseudomembranous colitis. It is used in the treatment of acne and has pediatric dosing.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8826,7 +8826,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b116c510", "c9b221b3"],
-		"explanation": "Linezolid is an Oxazolidinone and is bacteriostatic, not bactericidal. It is used for antibiotic-resistant Staph, Strep, and Enterococci. It has a strong interaction with MAOIs and is effective against gram-positive bacteria.",
+		"rationale": "Linezolid is an Oxazolidinone and is bacteriostatic, not bactericidal. It is used for antibiotic-resistant Staph, Strep, and Enterococci. It has a strong interaction with MAOIs and is effective against gram-positive bacteria.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8860,7 +8860,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["61c26b4a", "598bb243"],
-		"explanation": "Clarithromycin and erythromycin are known to inhibit CYP3A4. Chloramphenicol, azithromycin, and clindamycin do not have this effect.",
+		"rationale": "Clarithromycin and erythromycin are known to inhibit CYP3A4. Chloramphenicol, azithromycin, and clindamycin do not have this effect.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8894,7 +8894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["255c94b4"],
-		"explanation": "Telithromycin has a risk of hepatotoxicity. Chloramphenicol, erythromycin, azithromycin, and clindamycin do not have a significant risk of hepatotoxicity.",
+		"rationale": "Telithromycin has a risk of hepatotoxicity. Chloramphenicol, erythromycin, azithromycin, and clindamycin do not have a significant risk of hepatotoxicity.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8928,7 +8928,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f8b0507", "d231f245"],
-		"explanation": "Clindamycin and linezolid are effective against MRSA. Chloramphenicol, clarithromycin, and azithromycin are not typically used for MRSA.",
+		"rationale": "Clindamycin and linezolid are effective against MRSA. Chloramphenicol, clarithromycin, and azithromycin are not typically used for MRSA.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8962,7 +8962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a0128111", "3ef7ee6a"],
-		"explanation": "Fluoroquinolones have good activity against Pseudomonas and are contraindicated in children due to potential cartilage damage. They are ineffective against MRSA and are primarily excreted in urine, not feces. They are effective against Haemophilus.",
+		"rationale": "Fluoroquinolones have good activity against Pseudomonas and are contraindicated in children due to potential cartilage damage. They are ineffective against MRSA and are primarily excreted in urine, not feces. They are effective against Haemophilus.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -8996,7 +8996,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0c83d6c8", "b8092c43"],
-		"explanation": "Delafloxacin and moxifloxacin are part of the newer group of fluoroquinolones. Ciprofloxacin, norfloxacin, and ofloxacin are part of the older group.",
+		"rationale": "Delafloxacin and moxifloxacin are part of the newer group of fluoroquinolones. Ciprofloxacin, norfloxacin, and ofloxacin are part of the older group.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9030,7 +9030,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d0364511"],
-		"explanation": "The Black Box warning for systemic fluoroquinolones is due to the potential for permanent damage to muscles, tendons, joints, nerves, and the central nervous system. Hepatic toxicity and hypoglycemia/hyperglycemia are specific to certain fluoroquinolones that have been withdrawn. Retinal toxicity is associated with intravitreal moxifloxacin.",
+		"rationale": "The Black Box warning for systemic fluoroquinolones is due to the potential for permanent damage to muscles, tendons, joints, nerves, and the central nervous system. Hepatic toxicity and hypoglycemia/hyperglycemia are specific to certain fluoroquinolones that have been withdrawn. Retinal toxicity is associated with intravitreal moxifloxacin.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9064,7 +9064,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["327b3787"],
-		"explanation": "Besifloxacin is known for its increased gram-positive activity and additional anti-inflammatory properties, including inhibition of TNF-α, IL-1, IL-8, and MIP-1α.",
+		"rationale": "Besifloxacin is known for its increased gram-positive activity and additional anti-inflammatory properties, including inhibition of TNF-α, IL-1, IL-8, and MIP-1α.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9098,7 +9098,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3d44e6b0", "3480550d", "c1063814"],
-		"explanation": "Fluoroquinolones are contraindicated in conditions that predispose to arrhythmias, such as QT-interval prolongation, uncorrected hypokalemia, and bradycardia. Hyperkalemia and tachycardia are not listed as contraindications.",
+		"rationale": "Fluoroquinolones are contraindicated in conditions that predispose to arrhythmias, such as QT-interval prolongation, uncorrected hypokalemia, and bradycardia. Hyperkalemia and tachycardia are not listed as contraindications.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9132,7 +9132,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a884888"],
-		"explanation": "Trovafloxacin was withdrawn from the US market due to severe hepatic toxicity. Gatifloxacin was withdrawn due to hypoglycemia and hyperglycemia.",
+		"rationale": "Trovafloxacin was withdrawn from the US market due to severe hepatic toxicity. Gatifloxacin was withdrawn due to hypoglycemia and hyperglycemia.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9166,7 +9166,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b820f9c"],
-		"explanation": "Besifloxacin is used only in ophthalmic formulations and not systemically. Other fluoroquinolones like ciprofloxacin, levofloxacin, and moxifloxacin have systemic formulations.",
+		"rationale": "Besifloxacin is used only in ophthalmic formulations and not systemically. Other fluoroquinolones like ciprofloxacin, levofloxacin, and moxifloxacin have systemic formulations.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9200,7 +9200,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["eabd2347"],
-		"explanation": "Intravitreal moxifloxacin has been shown to have significant retinal toxicity. Other fluoroquinolones are not associated with this specific side effect.",
+		"rationale": "Intravitreal moxifloxacin has been shown to have significant retinal toxicity. Other fluoroquinolones are not associated with this specific side effect.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9234,7 +9234,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c44ddf7e", "b8d0413f", "6810796f"],
-		"explanation": "Older generation fluoroquinolones like ciprofloxacin, norfloxacin, and ofloxacin have been replaced by newer generation drugs like gatifloxacin and moxifloxacin for severe infections and corneal ulcers.",
+		"rationale": "Older generation fluoroquinolones like ciprofloxacin, norfloxacin, and ofloxacin have been replaced by newer generation drugs like gatifloxacin and moxifloxacin for severe infections and corneal ulcers.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9268,7 +9268,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3522ffc1", "ee1c1ce1", "7a60506a", "c546d51e"],
-		"explanation": "Metoclopramide, cisapride, erythromycin, and clarithromycin should be avoided in combination with fluoroquinolones due to the risk of QT interval prolongation. Theophylline has a significant drug interaction with ciprofloxacin but is not related to QT prolongation.",
+		"rationale": "Metoclopramide, cisapride, erythromycin, and clarithromycin should be avoided in combination with fluoroquinolones due to the risk of QT interval prolongation. Theophylline has a significant drug interaction with ciprofloxacin but is not related to QT prolongation.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9302,7 +9302,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6aca88db"],
-		"explanation": "Sulfonamides are bacteriostatic, not bactericidal, and they inhibit the conversion of PABA to dihydropteroate. Humans do not synthesize folate; they acquire it through diet, so sulfonamides do not affect human DNA synthesis. Sulfonamides are ineffective against group A streptococcal pharyngitis but are effective against MRSA.",
+		"rationale": "Sulfonamides are bacteriostatic, not bactericidal, and they inhibit the conversion of PABA to dihydropteroate. Humans do not synthesize folate; they acquire it through diet, so sulfonamides do not affect human DNA synthesis. Sulfonamides are ineffective against group A streptococcal pharyngitis but are effective against MRSA.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9336,7 +9336,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a61de705"],
-		"explanation": "Sulfamethoxazole is commonly combined with trimethoprim to form TMP/SMX, also known as Bactrim or Septra. The other options are not typically combined with trimethoprim.",
+		"rationale": "Sulfamethoxazole is commonly combined with trimethoprim to form TMP/SMX, also known as Bactrim or Septra. The other options are not typically combined with trimethoprim.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9370,7 +9370,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4ce13e90", "6e2209ff"],
-		"explanation": "Sulfonamides can cause sulfa allergies and have been associated with increased risk of thrombocytopenia with purpura when used with thiazide diuretics. Cartilage lesions in children, severe hepatic toxicity, and hypoglycemia/hyperglycemia are associated with fluoroquinolones, not sulfonamides.",
+		"rationale": "Sulfonamides can cause sulfa allergies and have been associated with increased risk of thrombocytopenia with purpura when used with thiazide diuretics. Cartilage lesions in children, severe hepatic toxicity, and hypoglycemia/hyperglycemia are associated with fluoroquinolones, not sulfonamides.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9404,7 +9404,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b158dfb"],
-		"explanation": "Resistance to one sulfonamide indicates resistance to all due to their similar mechanism of action. Sulfonamide resistance is widespread, and it does affect their efficacy against bacteria, including MRSA. Resistance is primarily due to bacterial adaptation, not human overuse.",
+		"rationale": "Resistance to one sulfonamide indicates resistance to all due to their similar mechanism of action. Sulfonamide resistance is widespread, and it does affect their efficacy against bacteria, including MRSA. Resistance is primarily due to bacterial adaptation, not human overuse.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9434,7 +9434,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["30c2f19c", "cce85cd2"],
-		"explanation": "Carbonic anhydrase inhibitors and topiramate are derivatives of sulfonamides and may be listed as contraindicated in patients with sulfa allergies. However, studies suggest minimal cross-reactivity. Trimethoprim is not a sulfonamide derivative, and fluoroquinolones and ACE inhibitors are unrelated to sulfonamides.",
+		"rationale": "Carbonic anhydrase inhibitors and topiramate are derivatives of sulfonamides and may be listed as contraindicated in patients with sulfa allergies. However, studies suggest minimal cross-reactivity. Trimethoprim is not a sulfonamide derivative, and fluoroquinolones and ACE inhibitors are unrelated to sulfonamides.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9468,7 +9468,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7dd30153"],
-		"explanation": "Silver sulfadiazine is used for topical application, particularly in burn creams. The other options are primarily used for oral administration.",
+		"rationale": "Silver sulfadiazine is used for topical application, particularly in burn creams. The other options are primarily used for oral administration.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9502,7 +9502,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c846a94d", "8bff842e", "29573a00"],
-		"explanation": "Sulfonamides are effective against Plasmodium, Toxoplasma, and MRSA. They are ineffective against group A streptococcal pharyngitis and Pseudomonas aeruginosa.",
+		"rationale": "Sulfonamides are effective against Plasmodium, Toxoplasma, and MRSA. They are ineffective against group A streptococcal pharyngitis and Pseudomonas aeruginosa.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9536,7 +9536,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["47cc338e"],
-		"explanation": "Sulfonamides inhibit bacterial folate synthesis by competitively inhibiting the conversion of PABA to dihydropteroate. They do not affect cell wall synthesis, protein synthesis, DNA replication, or RNA synthesis directly.",
+		"rationale": "Sulfonamides inhibit bacterial folate synthesis by competitively inhibiting the conversion of PABA to dihydropteroate. They do not affect cell wall synthesis, protein synthesis, DNA replication, or RNA synthesis directly.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9570,7 +9570,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5645d0a0"],
-		"explanation": "The combination of sulfamethoxazole and trimethoprim is known as cotrimoxazole. Trimethoprim is not a sulfonamide and works on a different enzyme in the PABA pathway. The combination is effective against gram-negative bacteria and is available under the brand names Bactrim and Septra, not Daraprim.",
+		"rationale": "The combination of sulfamethoxazole and trimethoprim is known as cotrimoxazole. Trimethoprim is not a sulfonamide and works on a different enzyme in the PABA pathway. The combination is effective against gram-negative bacteria and is available under the brand names Bactrim and Septra, not Daraprim.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9604,7 +9604,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4fa1ef38", "830d6623"],
-		"explanation": "Fluoroquinolones have a Black Box warning for potential permanent damage to muscles, tendons, joints, nerves, and the central nervous system. Many have been withdrawn from the market due to toxicity. They are not considered safe for use in children due to cartilage lesions and are not commonly used as front-line medications. They are effective against both gram-positive and gram-negative bacteria.",
+		"rationale": "Fluoroquinolones have a Black Box warning for potential permanent damage to muscles, tendons, joints, nerves, and the central nervous system. Many have been withdrawn from the market due to toxicity. They are not considered safe for use in children due to cartilage lesions and are not commonly used as front-line medications. They are effective against both gram-positive and gram-negative bacteria.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9638,7 +9638,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["83855349", "09211027"],
-		"explanation": "Tetracyclines are bacteriostatic and work on the 30s bacterial subunit, not the 50s. Their absorption is impaired by food and antacids, and they can cause photosensitivity and gastrointestinal distress. They are contraindicated in children and pregnant women due to risks of tooth discoloration and bone growth issues. Many gram-positive bacteria demonstrate resistance to tetracyclines.",
+		"rationale": "Tetracyclines are bacteriostatic and work on the 30s bacterial subunit, not the 50s. Their absorption is impaired by food and antacids, and they can cause photosensitivity and gastrointestinal distress. They are contraindicated in children and pregnant women due to risks of tooth discoloration and bone growth issues. Many gram-positive bacteria demonstrate resistance to tetracyclines.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9672,7 +9672,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ffbf417b", "5c92384c"],
-		"explanation": "Isoniazid can cause hepatitis, so liver function tests should be monitored. It also leaches vitamin B6, necessitating supplementation to prevent deficiency. Renal function, calcium, and blood glucose levels are not directly affected by isoniazid.",
+		"rationale": "Isoniazid can cause hepatitis, so liver function tests should be monitored. It also leaches vitamin B6, necessitating supplementation to prevent deficiency. Renal function, calcium, and blood glucose levels are not directly affected by isoniazid.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9706,7 +9706,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5be47af5"],
-		"explanation": "Amikacin is used to treat atypical mycobacteria. Gentamicin and tobramycin are primarily used for gram-negative infections, while streptomycin is used for Streptococcus endocarditis and tuberculosis. Neomycin is used topically due to systemic toxicity.",
+		"rationale": "Amikacin is used to treat atypical mycobacteria. Gentamicin and tobramycin are primarily used for gram-negative infections, while streptomycin is used for Streptococcus endocarditis and tuberculosis. Neomycin is used topically due to systemic toxicity.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9740,7 +9740,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b05d7d26", "06fa7ae1", "9124cbe4", "0e6c98db"],
-		"explanation": "Tetracyclines can cause ototoxicity at high doses, a metallic taste, photosensitivity, and tooth discoloration in children. Hepatitis is not a known side effect of tetracyclines but is associated with isoniazid.",
+		"rationale": "Tetracyclines can cause ototoxicity at high doses, a metallic taste, photosensitivity, and tooth discoloration in children. Hepatitis is not a known side effect of tetracyclines but is associated with isoniazid.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9774,7 +9774,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ad52f440", "29152bf2"],
-		"explanation": "Isoniazid is bacteriostatic and interferes with mycolic acid formation, not DNA synthesis. It has high CNS penetration and can cause optic neuropathies. Alcohol consumption increases the risk of hepatic side effects, and vitamin B6 supplementation is necessary.",
+		"rationale": "Isoniazid is bacteriostatic and interferes with mycolic acid formation, not DNA synthesis. It has high CNS penetration and can cause optic neuropathies. Alcohol consumption increases the risk of hepatic side effects, and vitamin B6 supplementation is necessary.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9808,7 +9808,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b0d00913"],
-		"explanation": "Neomycin has one of the highest rates of hypersensitivity among antibiotics. Amikacin, streptomycin, gentamicin, and tobramycin do not have as high a rate of hypersensitivity reactions.",
+		"rationale": "Neomycin has one of the highest rates of hypersensitivity among antibiotics. Amikacin, streptomycin, gentamicin, and tobramycin do not have as high a rate of hypersensitivity reactions.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9842,7 +9842,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["335c1561", "9971ddec"],
-		"explanation": "Antimicrobial agents target various cellular portions, including the cell wall, cytoplasmic membrane, and cytoplasm. Preservative dose is a factor in choosing an agent, and phenol is an example. They can be effective against mycobacteria, and hydrogen peroxide-related compounds are used as preservatives.",
+		"rationale": "Antimicrobial agents target various cellular portions, including the cell wall, cytoplasmic membrane, and cytoplasm. Preservative dose is a factor in choosing an agent, and phenol is an example. They can be effective against mycobacteria, and hydrogen peroxide-related compounds are used as preservatives.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9876,7 +9876,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7c737bc0"],
-		"explanation": "Neomycin is used topically in ophthalmic preparations due to high systemic toxicity. Amikacin, streptomycin, gentamicin, and tobramycin have different primary uses.",
+		"rationale": "Neomycin is used topically in ophthalmic preparations due to high systemic toxicity. Amikacin, streptomycin, gentamicin, and tobramycin have different primary uses.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9910,7 +9910,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bb391d1c"],
-		"explanation": "Tobramycin has increased activity against Pseudomonas compared to other aminoglycosides. Amikacin, streptomycin, gentamicin, and neomycin do not have this specific increased activity.",
+		"rationale": "Tobramycin has increased activity against Pseudomonas compared to other aminoglycosides. Amikacin, streptomycin, gentamicin, and neomycin do not have this specific increased activity.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9944,7 +9944,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d75a5637", "fdd7c182"],
-		"explanation": "Nitrofurantoin is a narrow-spectrum antibiotic used primarily for resistant urinary tract infections due to E. coli and is bacteriostatic, not bactericidal. It has neurological side effects, including nystagmus. It is not effective against systemic fungal infections.",
+		"rationale": "Nitrofurantoin is a narrow-spectrum antibiotic used primarily for resistant urinary tract infections due to E. coli and is bacteriostatic, not bactericidal. It has neurological side effects, including nystagmus. It is not effective against systemic fungal infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -9978,7 +9978,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d652b3c0", "29f8a9ed"],
-		"explanation": "Nystatin and Natamycin are polyene antifungal drugs that bind to ergosterol in fungal cell membranes, increasing permeability. Miconazole and Ketoconazole are imidazole drugs that inhibit the fungal cytochrome P-450 system. Amphotericin B is used for systemic infections.",
+		"rationale": "Nystatin and Natamycin are polyene antifungal drugs that bind to ergosterol in fungal cell membranes, increasing permeability. Miconazole and Ketoconazole are imidazole drugs that inhibit the fungal cytochrome P-450 system. Amphotericin B is used for systemic infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10012,7 +10012,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bdc86d63"],
-		"explanation": "Amphotericin B is known for its severe side effects, including nephrotoxicity, and is nicknamed \"Ampho the Terrible.\" Nystatin and Natamycin are used for superficial infections, while Ketoconazole and Fluconazole are azole antifungals with different side effect profiles.",
+		"rationale": "Amphotericin B is known for its severe side effects, including nephrotoxicity, and is nicknamed \"Ampho the Terrible.\" Nystatin and Natamycin are used for superficial infections, while Ketoconazole and Fluconazole are azole antifungals with different side effect profiles.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10046,7 +10046,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b3a41ff4", "4c33f760"],
-		"explanation": "Imidazole antifungal drugs inhibit the fungal cytochrome P-450 system, leading to increased cell membrane permeability. They have significant drug interactions and can cause hepatic and adrenal toxicity. They do not bind to ergosterol and are not primarily used for ophthalmic infections.",
+		"rationale": "Imidazole antifungal drugs inhibit the fungal cytochrome P-450 system, leading to increased cell membrane permeability. They have significant drug interactions and can cause hepatic and adrenal toxicity. They do not bind to ergosterol and are not primarily used for ophthalmic infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10080,7 +10080,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["75188da5"],
-		"explanation": "Natamycin is the only commercially available ophthalmic antifungal medication. Nystatin, Miconazole, Amphotericin B, and Ketoconazole are not primarily used for ophthalmic infections.",
+		"rationale": "Natamycin is the only commercially available ophthalmic antifungal medication. Nystatin, Miconazole, Amphotericin B, and Ketoconazole are not primarily used for ophthalmic infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10114,7 +10114,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8544a015", "58e3a968"],
-		"explanation": "Fluoroquinolones are contraindicated in children due to potential cartilage lesions. Besifloxacin is an ophthalmic-only fluoroquinolone. They are not effective against fungal infections and can have significant drug interactions.",
+		"rationale": "Fluoroquinolones are contraindicated in children due to potential cartilage lesions. Besifloxacin is an ophthalmic-only fluoroquinolone. They are not effective against fungal infections and can have significant drug interactions.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10148,7 +10148,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["98b6f9bb"],
-		"explanation": "Ketoconazole requires an acidic environment for absorption and should not be taken with stomach acid-reducing medications. Nystatin and Natamycin are used for superficial infections, while Amphotericin B and Fluconazole have different absorption requirements.",
+		"rationale": "Ketoconazole requires an acidic environment for absorption and should not be taken with stomach acid-reducing medications. Nystatin and Natamycin are used for superficial infections, while Amphotericin B and Fluconazole have different absorption requirements.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10182,7 +10182,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e1e1a0d2"],
-		"explanation": "Fluconazole is the most well-tolerated antifungal drug and is primarily excreted by the kidneys. Nystatin and Natamycin are used for superficial infections, while Ketoconazole and Amphotericin B have different side effect profiles and excretion pathways.",
+		"rationale": "Fluconazole is the most well-tolerated antifungal drug and is primarily excreted by the kidneys. Nystatin and Natamycin are used for superficial infections, while Ketoconazole and Amphotericin B have different side effect profiles and excretion pathways.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10216,7 +10216,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fd56614b", "b74c542e"],
-		"explanation": "Ketoconazole and Amphotericin B can be compounded for ocular infections. Nystatin and Natamycin are used for superficial infections, while Fluconazole is not typically compounded for ocular use.",
+		"rationale": "Ketoconazole and Amphotericin B can be compounded for ocular infections. Nystatin and Natamycin are used for superficial infections, while Fluconazole is not typically compounded for ocular use.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10250,7 +10250,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cfa92be3"],
-		"explanation": "Ciprofloxacin has a significant drug interaction with theophylline, which can lead to toxic increases in theophylline levels. Nitrofurantoin, Besifloxacin, Miconazole, and Ketoconazole do not have this specific interaction.",
+		"rationale": "Ciprofloxacin has a significant drug interaction with theophylline, which can lead to toxic increases in theophylline levels. Nitrofurantoin, Besifloxacin, Miconazole, and Ketoconazole do not have this specific interaction.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10284,7 +10284,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["98a7e2f4", "e10209e5"],
-		"explanation": "Acyclovir is effective against herpes simplex and herpes zoster infections and can cause neurotoxicity, especially in patients with renal insufficiency. It does not interact with human DNA polymerases, is not effective against CMV, and is not a protease inhibitor.",
+		"rationale": "Acyclovir is effective against herpes simplex and herpes zoster infections and can cause neurotoxicity, especially in patients with renal insufficiency. It does not interact with human DNA polymerases, is not effective against CMV, and is not a protease inhibitor.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10318,7 +10318,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["70bd833a"],
-		"explanation": "Nirmatrelvir is used in combination with ritonavir (Paxlovid) to treat coronavirus infections. Remdesivir is used for COVID-19 but not in combination with ritonavir. Acyclovir, amantadine, and metronidazole are not used for coronavirus infections.",
+		"rationale": "Nirmatrelvir is used in combination with ritonavir (Paxlovid) to treat coronavirus infections. Remdesivir is used for COVID-19 but not in combination with ritonavir. Acyclovir, amantadine, and metronidazole are not used for coronavirus infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10352,7 +10352,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3635e769"],
-		"explanation": "Mebendazole is used for helminth infections. Pentamidine is used for PCP, metronidazole for protozoan and anaerobic bacterial infections, acyclovir for herpes infections, and amantadine for influenza and Parkinson’s disease.",
+		"rationale": "Mebendazole is used for helminth infections. Pentamidine is used for PCP, metronidazole for protozoan and anaerobic bacterial infections, acyclovir for herpes infections, and amantadine for influenza and Parkinson’s disease.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10386,7 +10386,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9f22080c"],
-		"explanation": "Descovy, which contains emtricitabine and tenofovir, is approved for PrEP therapy for HIV. Acyclovir is an antiviral for herpes, remdesivir is used for COVID-19, metronidazole is for protozoan infections, and amantadine is for influenza and Parkinson’s disease.",
+		"rationale": "Descovy, which contains emtricitabine and tenofovir, is approved for PrEP therapy for HIV. Acyclovir is an antiviral for herpes, remdesivir is used for COVID-19, metronidazole is for protozoan infections, and amantadine is for influenza and Parkinson’s disease.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10420,7 +10420,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["72522403"],
-		"explanation": "Metronidazole can cause a metallic taste as a side effect. Acyclovir, pentamidine, mebendazole, and amantadine do not typically cause this side effect.",
+		"rationale": "Metronidazole can cause a metallic taste as a side effect. Acyclovir, pentamidine, mebendazole, and amantadine do not typically cause this side effect.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10454,7 +10454,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e4ff2074"],
-		"explanation": "Metronidazole is used to treat amoeboid dysentery. Acyclovir is for herpes infections, pentamidine for PCP, mebendazole for helminth infections, and amantadine for influenza and Parkinson’s disease.",
+		"rationale": "Metronidazole is used to treat amoeboid dysentery. Acyclovir is for herpes infections, pentamidine for PCP, mebendazole for helminth infections, and amantadine for influenza and Parkinson’s disease.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10488,7 +10488,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3455cd43"],
-		"explanation": "Amantadine is used to prevent dyskinesia in Parkinson’s disease. Acyclovir is for herpes infections, metronidazole for protozoan infections, pentamidine for PCP, and mebendazole for helminth infections.",
+		"rationale": "Amantadine is used to prevent dyskinesia in Parkinson’s disease. Acyclovir is for herpes infections, metronidazole for protozoan infections, pentamidine for PCP, and mebendazole for helminth infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10522,7 +10522,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["90df2045", "0582eb7a", "ed4b8cb3"],
-		"explanation": "Tenofovir, emtricitabine, and efavirenz are all examples of reverse transcriptase inhibitors (RTIs). Dolutegravir and raltegravir are integrase inhibitors, not RTIs.",
+		"rationale": "Tenofovir, emtricitabine, and efavirenz are all examples of reverse transcriptase inhibitors (RTIs). Dolutegravir and raltegravir are integrase inhibitors, not RTIs.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10556,7 +10556,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5086026b"],
-		"explanation": "Amantadine, originally developed as an anti-influenza drug, is now used in Parkinson's disease to help prevent dyskinesia. The other drugs listed are not used for Parkinson's disease.",
+		"rationale": "Amantadine, originally developed as an anti-influenza drug, is now used in Parkinson's disease to help prevent dyskinesia. The other drugs listed are not used for Parkinson's disease.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10590,7 +10590,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1ef72239", "e10209e5"],
-		"explanation": "Acyclovir interacts with herpesvirus thymidine kinase and can cause neurotoxicity, particularly in patients with renal insufficiency. It is not effective against cytomegalovirus, does not treat helminth infections, and is not a protease inhibitor.",
+		"rationale": "Acyclovir interacts with herpesvirus thymidine kinase and can cause neurotoxicity, particularly in patients with renal insufficiency. It is not effective against cytomegalovirus, does not treat helminth infections, and is not a protease inhibitor.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10624,7 +10624,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8adb0ef2", "4b539f1b", "bc2f7104"],
-		"explanation": "Elvitegravir, raltegravir, and dolutegravir are integrase inhibitors. Tenofovir and efavirenz are reverse transcriptase inhibitors.",
+		"rationale": "Elvitegravir, raltegravir, and dolutegravir are integrase inhibitors. Tenofovir and efavirenz are reverse transcriptase inhibitors.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10658,7 +10658,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d7abfc23"],
-		"explanation": "Nirmatrelvir is used in combination with ritonavir (Paxlovid) to treat COVID-19. It is contraindicated with drugs highly dependent on CYP3A due to ritonavir's effect on the cytochrome P450 pathway.",
+		"rationale": "Nirmatrelvir is used in combination with ritonavir (Paxlovid) to treat COVID-19. It is contraindicated with drugs highly dependent on CYP3A due to ritonavir's effect on the cytochrome P450 pathway.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10692,7 +10692,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["56ad61e5"],
-		"explanation": "Zanamivir is a neuraminidase inhibitor used to treat influenza. Amantadine is used for Parkinson's disease, baloxavir marboxil is a nuclease inhibitor, nirmatrelvir is a protease inhibitor, and mebendazole is used for helminth infections.",
+		"rationale": "Zanamivir is a neuraminidase inhibitor used to treat influenza. Amantadine is used for Parkinson's disease, baloxavir marboxil is a nuclease inhibitor, nirmatrelvir is a protease inhibitor, and mebendazole is used for helminth infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10726,7 +10726,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["01baf1f5"],
-		"explanation": "Baloxavir marboxil is a nuclease inhibitor used for influenza treatment. Oseltamivir is a neuraminidase inhibitor, remdesivir is a ribonucleotide analogue inhibitor, and efavirenz and dolutegravir are used for HIV/AIDS treatment.",
+		"rationale": "Baloxavir marboxil is a nuclease inhibitor used for influenza treatment. Oseltamivir is a neuraminidase inhibitor, remdesivir is a ribonucleotide analogue inhibitor, and efavirenz and dolutegravir are used for HIV/AIDS treatment.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10760,7 +10760,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c81df227"],
-		"explanation": "Remdesivir is a ribonucleotide analogue inhibitor of viral RNA polymerase. Tenofovir is a reverse transcriptase inhibitor, elvitegravir is an integrase inhibitor, nirmatrelvir is a protease inhibitor, and zanamivir is a neuraminidase inhibitor.",
+		"rationale": "Remdesivir is a ribonucleotide analogue inhibitor of viral RNA polymerase. Tenofovir is a reverse transcriptase inhibitor, elvitegravir is an integrase inhibitor, nirmatrelvir is a protease inhibitor, and zanamivir is a neuraminidase inhibitor.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10794,7 +10794,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d41486f1", "92262412"],
-		"explanation": "Clarithromycin and Metronidazole are known to cause a metallic taste. Tetracyclines are less commonly associated with this effect.",
+		"rationale": "Clarithromycin and Metronidazole are known to cause a metallic taste. Tetracyclines are less commonly associated with this effect.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10828,7 +10828,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["22a0d4eb", "f23c38c9"],
-		"explanation": "Foscarnet is used in cases of CMV retinitis and Acyclovir-resistant herpes simplex. It is not effective against influenza, HIV, or pseudomonal infections.",
+		"rationale": "Foscarnet is used in cases of CMV retinitis and Acyclovir-resistant herpes simplex. It is not effective against influenza, HIV, or pseudomonal infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10862,7 +10862,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a1d45b95", "cc6b33f7", "a1541000"],
-		"explanation": "Piperacillin, Ticarcillin, and Carbenicillin are antipseudomonal penicillins. Methicillin and Dicloxacillin lack strong activity against Pseudomonas.",
+		"rationale": "Piperacillin, Ticarcillin, and Carbenicillin are antipseudomonal penicillins. Methicillin and Dicloxacillin lack strong activity against Pseudomonas.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10896,7 +10896,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["92a486d5", "ef93da39"],
-		"explanation": "Ceftazidime and Cefepime are the most effective cephalosporins against Pseudomonas. Cephalexin, Ceftriaxone, and Ceftaroline have limited to no activity against Pseudomonas.",
+		"rationale": "Ceftazidime and Cefepime are the most effective cephalosporins against Pseudomonas. Cephalexin, Ceftriaxone, and Ceftaroline have limited to no activity against Pseudomonas.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10930,7 +10930,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bb64c4e6"],
-		"explanation": "Rifampin causes reddish-orange discoloration of bodily fluids. Pneumonia and sudden vision loss are not common side effects.",
+		"rationale": "Rifampin causes reddish-orange discoloration of bodily fluids. Pneumonia and sudden vision loss are not common side effects.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10964,7 +10964,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d201c17f"],
-		"explanation": "Ribavirin is teratogenic and can cause hemolytic anemia. The other drugs do not have these effects.",
+		"rationale": "Ribavirin is teratogenic and can cause hemolytic anemia. The other drugs do not have these effects.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -10998,7 +10998,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c0eb0700"],
-		"explanation": "Oritavancin is a lipoglycopeptide antibiotic similar to Vancomycin but with an improved safety profile. The other drugs have different mechanisms of action.",
+		"rationale": "Oritavancin is a lipoglycopeptide antibiotic similar to Vancomycin but with an improved safety profile. The other drugs have different mechanisms of action.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11032,7 +11032,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c727a99a", "550387ce", "7f1b3bb4"],
-		"explanation": "Ethambutol toxicity primarily affects the optic nerve, leading to optic neuropathy. Monitoring should include color vision testing (red-green), visual acuity, and visual field assessment.",
+		"rationale": "Ethambutol toxicity primarily affects the optic nerve, leading to optic neuropathy. Monitoring should include color vision testing (red-green), visual acuity, and visual field assessment.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11074,7 +11074,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a0b5f793"],
-		"explanation": "Pentamidine is a second-line treatment for Pneumocystis pneumonia in patients who cannot tolerate Bactrim. Amantadine is an antiviral, Nystatin is used for fungal infections, Amphotericin B is for systemic fungal infections, and Ketoconazole has limited use in Pneumocystis.",
+		"rationale": "Pentamidine is a second-line treatment for Pneumocystis pneumonia in patients who cannot tolerate Bactrim. Amantadine is an antiviral, Nystatin is used for fungal infections, Amphotericin B is for systemic fungal infections, and Ketoconazole has limited use in Pneumocystis.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11108,7 +11108,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3c0b5968", "9cfee175"],
-		"explanation": "Bactrim is a combination of Sulfamethoxazole and Trimethoprim. The other options are not components of Bactrim.",
+		"rationale": "Bactrim is a combination of Sulfamethoxazole and Trimethoprim. The other options are not components of Bactrim.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11142,7 +11142,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d7c33c5b", "97758a8b", "37e7461d"],
-		"explanation": "Type I hypersensitivity reactions (anaphylaxis) are commonly associated with Penicillins, Cephalosporins, and Sulfonamides. Macrolides and Aminoglycosides are less likely to cause this reaction.",
+		"rationale": "Type I hypersensitivity reactions (anaphylaxis) are commonly associated with Penicillins, Cephalosporins, and Sulfonamides. Macrolides and Aminoglycosides are less likely to cause this reaction.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11176,7 +11176,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5e309cf2", "3dbbc603", "a433f0b1"],
-		"explanation": "Type IV hypersensitivity reactions (delayed-type hypersensitivity) are commonly seen with Bacitracin, Sulfonamides, and Neomycin.",
+		"rationale": "Type IV hypersensitivity reactions (delayed-type hypersensitivity) are commonly seen with Bacitracin, Sulfonamides, and Neomycin.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11210,7 +11210,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["19ebfbf4", "0eac176d", "d1bbd355"],
-		"explanation": "Bacitracin, Mupirocin, and Neomycin are only available in topical formulations. Penicillins and Cephalosporins are available in systemic forms.",
+		"rationale": "Bacitracin, Mupirocin, and Neomycin are only available in topical formulations. Penicillins and Cephalosporins are available in systemic forms.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11248,7 +11248,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["997d84b5"],
-		"explanation": "Valacyclovir 500 mg TID has the least lactose content and is generally well tolerated in lactose-intolerant patients. Acyclovir and Famciclovir formulations may contain more lactose.",
+		"rationale": "Valacyclovir 500 mg TID has the least lactose content and is generally well tolerated in lactose-intolerant patients. Acyclovir and Famciclovir formulations may contain more lactose.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11282,7 +11282,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5341051c", "b7190d04"],
-		"explanation": "'-Azole' antifungals inhibit the cytochrome P450 enzyme system, leading to significant drug interactions. They do not directly bind Ergosterol but inhibit its synthesis.",
+		"rationale": "'-Azole' antifungals inhibit the cytochrome P450 enzyme system, leading to significant drug interactions. They do not directly bind Ergosterol but inhibit its synthesis.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11316,7 +11316,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["79ecd5bd"],
-		"explanation": "Cephalexin (Keflex) is a first-generation cephalosporin commonly used for prophylaxis in facial fractures due to its good coverage of skin flora.",
+		"rationale": "Cephalexin (Keflex) is a first-generation cephalosporin commonly used for prophylaxis in facial fractures due to its good coverage of skin flora.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11350,7 +11350,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c91f81a6"],
-		"explanation": "Cefaclor (Ceclor) is a second-generation cephalosporin with good activity against Haemophilus influenzae B, making it an appropriate choice for pediatric patients.",
+		"rationale": "Cefaclor (Ceclor) is a second-generation cephalosporin with good activity against Haemophilus influenzae B, making it an appropriate choice for pediatric patients.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11384,7 +11384,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["853bde0a"],
-		"explanation": "Ceftriaxone is the first-line treatment for Neisseria gonorrhoeae due to its effectiveness and current CDC guidelines.",
+		"rationale": "Ceftriaxone is the first-line treatment for Neisseria gonorrhoeae due to its effectiveness and current CDC guidelines.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11418,7 +11418,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["21e20d20"],
-		"explanation": "Streptomycin is commonly used for Streptococcus-induced endocarditis, especially in cases of penicillin resistance or beta-lactam allergy.",
+		"rationale": "Streptomycin is commonly used for Streptococcus-induced endocarditis, especially in cases of penicillin resistance or beta-lactam allergy.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11452,7 +11452,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["452ecfbb", "d1f89467"],
-		"explanation": "Vancomycin and Moxifloxacin have been associated with retinal toxicity when administered intravitreally.",
+		"rationale": "Vancomycin and Moxifloxacin have been associated with retinal toxicity when administered intravitreally.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11486,7 +11486,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["91955833", "e291d925", "eb1a4f8f"],
-		"explanation": "Besifloxacin is unique among fluoroquinolones as it is chlorinated, has a gel-forming property, and possesses anti-inflammatory effects.",
+		"rationale": "Besifloxacin is unique among fluoroquinolones as it is chlorinated, has a gel-forming property, and possesses anti-inflammatory effects.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11520,7 +11520,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["adbb616b"],
-		"explanation": "Natamycin is the only FDA-approved ophthalmic antifungal medication, primarily used for fungal keratitis.",
+		"rationale": "Natamycin is the only FDA-approved ophthalmic antifungal medication, primarily used for fungal keratitis.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11554,7 +11554,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fd21df08"],
-		"explanation": "Fluconazole is considered the most well-tolerated antifungal medication due to its low toxicity and good oral bioavailability.",
+		"rationale": "Fluconazole is considered the most well-tolerated antifungal medication due to its low toxicity and good oral bioavailability.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11588,7 +11588,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6907004e"],
-		"explanation": "Linezolid is primarily used for treating antibiotic-resistant Gram-positive infections, including MRSA and VRE.",
+		"rationale": "Linezolid is primarily used for treating antibiotic-resistant Gram-positive infections, including MRSA and VRE.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11618,7 +11618,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3130a950"],
-		"explanation": "Cidofovir is an antiviral used to treat CMV retinitis, which is common in immunocompromised patients such as those with AIDS.",
+		"rationale": "Cidofovir is an antiviral used to treat CMV retinitis, which is common in immunocompromised patients such as those with AIDS.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11652,7 +11652,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c58f7bc5", "972c0751"],
-		"explanation": "Ganciclovir and Foscarnet are both first-line treatments for CMV retinitis. Acyclovir is ineffective against CMV, and Amphotericin B is an antifungal, not an antiviral.",
+		"rationale": "Ganciclovir and Foscarnet are both first-line treatments for CMV retinitis. Acyclovir is ineffective against CMV, and Amphotericin B is an antifungal, not an antiviral.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11686,7 +11686,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["81a967aa", "702ad1d9", "e66d56a9", "27c50e4f"],
-		"explanation": "Metronidazole is used for anaerobic infections and protozoal infections such as Entamoeba histolytica, Giardia lamblia, Trichomonas vaginalis, and Amoeboid dysentery. It is not used for viral infections (RSV) or Rickettsial infections.",
+		"rationale": "Metronidazole is used for anaerobic infections and protozoal infections such as Entamoeba histolytica, Giardia lamblia, Trichomonas vaginalis, and Amoeboid dysentery. It is not used for viral infections (RSV) or Rickettsial infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11724,7 +11724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["75ccc322", "72000d2b", "ac2aeb59"],
-		"explanation": "Pyrazinamide, used for tuberculosis, is known to cause hepatotoxicity, gout flares due to hyperuricemia, and joint pain.",
+		"rationale": "Pyrazinamide, used for tuberculosis, is known to cause hepatotoxicity, gout flares due to hyperuricemia, and joint pain.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11758,7 +11758,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3c8c4fd2"],
-		"explanation": "Trifluridine, a thymidine analog used for herpes simplex keratitis, can cause corneal toxicity with prolonged use.",
+		"rationale": "Trifluridine, a thymidine analog used for herpes simplex keratitis, can cause corneal toxicity with prolonged use.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11792,7 +11792,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["57e1e91d", "645f9667"],
-		"explanation": "Foscarnet is nephrotoxic and can cause WBC suppression, leading to increased risk of infections.",
+		"rationale": "Foscarnet is nephrotoxic and can cause WBC suppression, leading to increased risk of infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11826,7 +11826,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c30bcdb8"],
-		"explanation": "Nafcillin is a penicillinase-resistant penicillin and is the drug of choice for MSSA-related Staph endocarditis.",
+		"rationale": "Nafcillin is a penicillinase-resistant penicillin and is the drug of choice for MSSA-related Staph endocarditis.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11860,7 +11860,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1e6d8e96", "3752a6ff", "b110cafa"],
-		"explanation": "Flucytosine can cause bone marrow suppression, hepatotoxicity, and gastrointestinal (GI) upset. Pseudomembranous colitis is more commonly associated with Clostridioides difficile infections.",
+		"rationale": "Flucytosine can cause bone marrow suppression, hepatotoxicity, and gastrointestinal (GI) upset. Pseudomembranous colitis is more commonly associated with Clostridioides difficile infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11894,7 +11894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["91ba43e1", "02a51a0b", "8dd2bfbb"],
-		"explanation": "Ganciclovir can cause thrombocytopenia, granulocytopenia, and psychosis. Retinal toxicity and hepatotoxicity are not common.",
+		"rationale": "Ganciclovir can cause thrombocytopenia, granulocytopenia, and psychosis. Retinal toxicity and hepatotoxicity are not common.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11928,7 +11928,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a51acdb1"],
-		"explanation": "Mebendazole is an anti-helminthic drug used to treat worm infections. The other drugs are used for viral or fungal infections.",
+		"rationale": "Mebendazole is an anti-helminthic drug used to treat worm infections. The other drugs are used for viral or fungal infections.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11958,7 +11958,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4743f486", "0567c2fc"],
-		"explanation": "Cefepime is effective against meningitis because it crosses the blood-brain barrier and has a broad-spectrum antibacterial activity.",
+		"rationale": "Cefepime is effective against meningitis because it crosses the blood-brain barrier and has a broad-spectrum antibacterial activity.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -11988,7 +11988,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7e327260"],
-		"explanation": "Benzathine Penicillin is the first-line treatment for syphilis. Ceftriaxone can be used for neurosyphilis, but Azithromycin, Doxycycline, and Augmentin are not preferred.",
+		"rationale": "Benzathine Penicillin is the first-line treatment for syphilis. Ceftriaxone can be used for neurosyphilis, but Azithromycin, Doxycycline, and Augmentin are not preferred.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12022,7 +12022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2dcc2ffc", "1c060a10"],
-		"explanation": "Ethambutol is known for causing optic neuritis and color vision changes (achromatopsia). Regular vision monitoring is essential.",
+		"rationale": "Ethambutol is known for causing optic neuritis and color vision changes (achromatopsia). Regular vision monitoring is essential.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12056,7 +12056,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["490d314f"],
-		"explanation": "Topical fluoroquinolones are generally safe for use in infants, while systemic fluoroquinolones, sulfonamides, and tetracyclines (like doxycycline) pose risks such as cartilage damage and kernicterus.",
+		"rationale": "Topical fluoroquinolones are generally safe for use in infants, while systemic fluoroquinolones, sulfonamides, and tetracyclines (like doxycycline) pose risks such as cartilage damage and kernicterus.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12090,7 +12090,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f0ed21b", "4cc1683d"],
-		"explanation": "Pegylated Interferon alfa-2a toxicity can cause retinal complications such as hemorrhaging and cotton wool spots.",
+		"rationale": "Pegylated Interferon alfa-2a toxicity can cause retinal complications such as hemorrhaging and cotton wool spots.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12124,7 +12124,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8a81481c"],
-		"explanation": "Besifloxacin is a fluoroquinolone specifically formulated for ophthalmic infections, making it the best choice for bacterial corneal ulcers.",
+		"rationale": "Besifloxacin is a fluoroquinolone specifically formulated for ophthalmic infections, making it the best choice for bacterial corneal ulcers.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12158,7 +12158,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["861a1e90"],
-		"explanation": "Doxycycline is commonly used for meibomianitis due to its anti-lipase activity, reducing inflammation in the meibomian glands.",
+		"rationale": "Doxycycline is commonly used for meibomianitis due to its anti-lipase activity, reducing inflammation in the meibomian glands.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12192,7 +12192,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5bd813b8"],
-		"explanation": "Doxycycline is primarily excreted via the fecal route, making it a safer tetracycline option for patients with renal impairment.",
+		"rationale": "Doxycycline is primarily excreted via the fecal route, making it a safer tetracycline option for patients with renal impairment.",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12226,7 +12226,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fdb68398"],
-		"explanation": "Tenofovir is a key component in most modern HIV regimens, serving as a foundational nucleoside reverse transcriptase inhibitor (NRTI).",
+		"rationale": "Tenofovir is a key component in most modern HIV regimens, serving as a foundational nucleoside reverse transcriptase inhibitor (NRTI).",
 		"metadata": {},
 		"moduleId": "js70s9hxt8dp75pm516q1v8q3x7m8a20",
 		"options": [
@@ -12260,7 +12260,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f4e62b92", "041c5315", "a86e73fa"],
-		"explanation": "Thiazide diuretics inhibit the Na/Cl symporter in the distal convoluted tubule, not the proximal tubule (A is incorrect). They enhance calcium reabsorption in the distal convoluted tubule (B is correct). They are contraindicated in patients with severe sulfonamide reactions (C is correct). They increase the excretion of potassium and bicarbonate (D is correct).",
+		"rationale": "Thiazide diuretics inhibit the Na/Cl symporter in the distal convoluted tubule, not the proximal tubule (A is incorrect). They enhance calcium reabsorption in the distal convoluted tubule (B is correct). They are contraindicated in patients with severe sulfonamide reactions (C is correct). They increase the excretion of potassium and bicarbonate (D is correct).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12290,7 +12290,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f50621c0", "10760e68", "2a776a6b"],
-		"explanation": "Thiazide diuretics reduce urinary calcium excretion (A is correct), which can help increase bone mineral density (B is correct) and decrease the risk of fractures (C is correct). They do not enhance magnesium reabsorption (D is incorrect).",
+		"rationale": "Thiazide diuretics reduce urinary calcium excretion (A is correct), which can help increase bone mineral density (B is correct) and decrease the risk of fractures (C is correct). They do not enhance magnesium reabsorption (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12320,7 +12320,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ba03e0b6", "66d0ee7f", "8f87421e"],
-		"explanation": "Common side effects of thiazide diuretics include dry eye and mouth (A is correct), constipation (B is correct), and hyponatremia (D is correct). Thiazides typically cause hypokalemia, not hyperkalemia (C is incorrect).",
+		"rationale": "Common side effects of thiazide diuretics include dry eye and mouth (A is correct), constipation (B is correct), and hyponatremia (D is correct). Thiazides typically cause hypokalemia, not hyperkalemia (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12350,7 +12350,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8f4952cd"],
-		"explanation": "Thiazide diuretics may be more effective in lowering blood pressure in African American populations (B is correct). There is no specific mention of increased effectiveness in Caucasian, Asian, or Hispanic populations (A, C, D are incorrect).",
+		"rationale": "Thiazide diuretics may be more effective in lowering blood pressure in African American populations (B is correct). There is no specific mention of increased effectiveness in Caucasian, Asian, or Hispanic populations (A, C, D are incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12380,7 +12380,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6895af8e"],
-		"explanation": "Metolazone is a thiazide-like diuretic that is long-acting and useful in chronic renal failure (C is correct). Hydrochlorothiazide and chlorthalidone are not specifically noted for use in chronic renal failure (A, B are incorrect). Furosemide is a loop diuretic, not a thiazide or thiazide-like diuretic (D is incorrect).",
+		"rationale": "Metolazone is a thiazide-like diuretic that is long-acting and useful in chronic renal failure (C is correct). Hydrochlorothiazide and chlorthalidone are not specifically noted for use in chronic renal failure (A, B are incorrect). Furosemide is a loop diuretic, not a thiazide or thiazide-like diuretic (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12410,7 +12410,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["49b35bbb"],
-		"explanation": "The proposed mechanism for the antihypertensive effects of thiazide diuretics is a reduction in plasma Na levels, which reduces intracellular Ca levels in vascular smooth muscle (B is correct). Direct vasodilation is not the primary proposed mechanism (A is incorrect). Thiazides do not inhibit the Na/K/2Cl co-transporter; this is the mechanism of loop diuretics (C is incorrect). Thiazides reduce intracellular Ca levels, not increase them (D is incorrect).",
+		"rationale": "The proposed mechanism for the antihypertensive effects of thiazide diuretics is a reduction in plasma Na levels, which reduces intracellular Ca levels in vascular smooth muscle (B is correct). Direct vasodilation is not the primary proposed mechanism (A is incorrect). Thiazides do not inhibit the Na/K/2Cl co-transporter; this is the mechanism of loop diuretics (C is incorrect). Thiazides reduce intracellular Ca levels, not increase them (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12440,7 +12440,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d1f9121b", "8280b4a8", "5999a74e"],
-		"explanation": "Thiazide diuretics are indicated to treat edema (A is correct), hypertension (B is correct), and congestive heart failure (D is correct). They are not indicated for treating hypercalcemia; they reduce urinary calcium excretion (C is incorrect).",
+		"rationale": "Thiazide diuretics are indicated to treat edema (A is correct), hypertension (B is correct), and congestive heart failure (D is correct). They are not indicated for treating hypercalcemia; they reduce urinary calcium excretion (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12470,7 +12470,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["15e6aa41", "526df26c"],
-		"explanation": "Hydrochlorothiazide use is declining in favor of ACE inhibitors (B is correct), and it is often combined with other agent classes (C is correct). It is a thiazide diuretic, not a loop diuretic (A is incorrect). Chlorthalidone has a longer duration of action than hydrochlorothiazide (D is incorrect).",
+		"rationale": "Hydrochlorothiazide use is declining in favor of ACE inhibitors (B is correct), and it is often combined with other agent classes (C is correct). It is a thiazide diuretic, not a loop diuretic (A is incorrect). Chlorthalidone has a longer duration of action than hydrochlorothiazide (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12500,7 +12500,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7ec5a964", "b84880ee", "4c980c32"],
-		"explanation": "Thiazide diuretics are contraindicated in patients with poor kidney function (A is correct), severe liver dysfunction (B is correct), and concurrent NSAID use (C is correct). They are contraindicated in severe sulfonamide reactions, not mild ones (D is incorrect).",
+		"rationale": "Thiazide diuretics are contraindicated in patients with poor kidney function (A is correct), severe liver dysfunction (B is correct), and concurrent NSAID use (C is correct). They are contraindicated in severe sulfonamide reactions, not mild ones (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12530,7 +12530,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["887634a3"],
-		"explanation": "Ototoxicity is a side effect associated with loop diuretics, especially at high doses (A is correct). Both loop and thiazide diuretics can cause hypokalemia (B is incorrect) and hyponatremia (C is incorrect). Metabolic alkalosis can occur with both types of diuretics (D is incorrect).",
+		"rationale": "Ototoxicity is a side effect associated with loop diuretics, especially at high doses (A is correct). Both loop and thiazide diuretics can cause hypokalemia (B is incorrect) and hyponatremia (C is incorrect). Metabolic alkalosis can occur with both types of diuretics (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12560,7 +12560,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["361a0c7a", "438d86d0"],
-		"explanation": "Loop diuretics inhibit the Na+/K+/2Cl co-transporter in the thick ascending loop of Henle, not the distal convoluted tubule (A is incorrect). They reduce the reabsorption of calcium and magnesium (B is incorrect). They can cause hypokalemia and hyponatremia due to increased excretion of these ions (C is correct). They are not typically used as monotherapy for hypertension (D is incorrect). High doses can lead to ototoxicity (E is correct).",
+		"rationale": "Loop diuretics inhibit the Na+/K+/2Cl co-transporter in the thick ascending loop of Henle, not the distal convoluted tubule (A is incorrect). They reduce the reabsorption of calcium and magnesium (B is incorrect). They can cause hypokalemia and hyponatremia due to increased excretion of these ions (C is correct). They are not typically used as monotherapy for hypertension (D is incorrect). High doses can lead to ototoxicity (E is correct).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12594,7 +12594,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d64bc36c", "68452d32", "884cd9a3"],
-		"explanation": "Loop diuretics can cause metabolic alkalosis due to increased bicarbonate reabsorption (B is correct). They can lead to hypovolemia due to excessive fluid loss (C is correct). They can increase uric acid levels, potentially leading to gout (E is correct). They cause hypokalemia, not hyperkalemia (A is incorrect), and hyponatremia, not hypernatremia (D is incorrect).",
+		"rationale": "Loop diuretics can cause metabolic alkalosis due to increased bicarbonate reabsorption (B is correct). They can lead to hypovolemia due to excessive fluid loss (C is correct). They can increase uric acid levels, potentially leading to gout (E is correct). They cause hypokalemia, not hyperkalemia (A is incorrect), and hyponatremia, not hypernatremia (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12628,7 +12628,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8f1f9f07"],
-		"explanation": "Ethacrynic acid is a loop diuretic with less toxicity than furosemide (B is correct). Bumetanide is more potent but not less toxic (A is incorrect). Spironolactone and amiloride are potassium-sparing diuretics (C and D are incorrect). Hydrochlorothiazide is a thiazide diuretic (E is incorrect).",
+		"rationale": "Ethacrynic acid is a loop diuretic with less toxicity than furosemide (B is correct). Bumetanide is more potent but not less toxic (A is incorrect). Spironolactone and amiloride are potassium-sparing diuretics (C and D are incorrect). Hydrochlorothiazide is a thiazide diuretic (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12662,7 +12662,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["542c879a", "dcab5528"],
-		"explanation": "Potassium-sparing diuretics prevent excessive excretion of potassium in urine (B is correct) and can be used in combination with other antihypertensives (D is correct). They are not effective as monotherapy for hypertension (A is incorrect). They do not inhibit the Na+/K+/2Cl co-transporter (C is incorrect). They do not cause significant blood pressure changes (E is incorrect).",
+		"rationale": "Potassium-sparing diuretics prevent excessive excretion of potassium in urine (B is correct) and can be used in combination with other antihypertensives (D is correct). They are not effective as monotherapy for hypertension (A is incorrect). They do not inhibit the Na+/K+/2Cl co-transporter (C is incorrect). They do not cause significant blood pressure changes (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12696,7 +12696,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dfb7755b", "5ccd3762", "f4552fc0"],
-		"explanation": "Furosemide is indicated for edema associated with congestive heart failure (A is correct), cirrhosis of the liver (D is correct), and nephrotic syndrome (E is correct). It is not used as the primary treatment for hypertension (B is incorrect) and is not indicated for hyperkalemia (C is incorrect).",
+		"rationale": "Furosemide is indicated for edema associated with congestive heart failure (A is correct), cirrhosis of the liver (D is correct), and nephrotic syndrome (E is correct). It is not used as the primary treatment for hypertension (B is incorrect) and is not indicated for hyperkalemia (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12730,7 +12730,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0c312266", "3f2fd112", "be0f4f89"],
-		"explanation": "Thiazide diuretics are commonly used at low doses for hypertension (B is correct) and can be used in the management of heart failure (D is correct). They increase calcium reabsorption (E is correct). They are fast acting but have a longer duration than loop diuretics (A is incorrect) and do not cause dramatic water loss (C is incorrect).",
+		"rationale": "Thiazide diuretics are commonly used at low doses for hypertension (B is correct) and can be used in the management of heart failure (D is correct). They increase calcium reabsorption (E is correct). They are fast acting but have a longer duration than loop diuretics (A is incorrect) and do not cause dramatic water loss (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12764,7 +12764,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a8974eee", "8b81f4c1"],
-		"explanation": "Furosemide is used for the treatment of edema in pediatric patients (B is correct) and is indicated for severe hypertension in combination with other medications (E is correct). It is available in oral, intravenous, and intramuscular formulations (A is incorrect). It is a loop diuretic, not a potassium-sparing diuretic (C is incorrect). It has a short duration of action (D is incorrect).",
+		"rationale": "Furosemide is used for the treatment of edema in pediatric patients (B is correct) and is indicated for severe hypertension in combination with other medications (E is correct). It is available in oral, intravenous, and intramuscular formulations (A is incorrect). It is a loop diuretic, not a potassium-sparing diuretic (C is incorrect). It has a short duration of action (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12798,7 +12798,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8d5c0d8a", "04028a76"],
-		"explanation": "Both loop diuretics and thiazide diuretics increase urine flow (C is correct) and increase potassium excretion (E is correct). Loop diuretics inhibit the Na+/K+/2Cl co-transporter (A is incorrect), while thiazide diuretics inhibit the Na+/Cl co-transporter (B is incorrect). Loop diuretics reduce calcium reabsorption, while thiazide diuretics increase it (D is incorrect).",
+		"rationale": "Both loop diuretics and thiazide diuretics increase urine flow (C is correct) and increase potassium excretion (E is correct). Loop diuretics inhibit the Na+/K+/2Cl co-transporter (A is incorrect), while thiazide diuretics inhibit the Na+/Cl co-transporter (B is incorrect). Loop diuretics reduce calcium reabsorption, while thiazide diuretics increase it (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12832,7 +12832,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5f6adff3", "1c3c87e1", "50c54b8c"],
-		"explanation": "Loop diuretics have a fast onset of action (B is correct) and are used for rapid diuresis (C is correct). They are used to treat acute pulmonary edema (E is correct). They can be administered intravenously in emergency situations (A is incorrect). They are not contraindicated in pediatric patients (D is incorrect).",
+		"rationale": "Loop diuretics have a fast onset of action (B is correct) and are used for rapid diuresis (C is correct). They are used to treat acute pulmonary edema (E is correct). They can be administered intravenously in emergency situations (A is incorrect). They are not contraindicated in pediatric patients (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12866,7 +12866,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["26e8a334", "4266fde1"],
-		"explanation": "High doses of loop diuretics can lead to ototoxicity (B is correct) and hypotension (C is correct). They cause hypocalcemia, not hypercalcemia (A is incorrect), and hypomagnesemia, not hypermagnesemia (D is incorrect). They can cause metabolic alkalosis, not acidosis (E is incorrect).",
+		"rationale": "High doses of loop diuretics can lead to ototoxicity (B is correct) and hypotension (C is correct). They cause hypocalcemia, not hypercalcemia (A is incorrect), and hypomagnesemia, not hypermagnesemia (D is incorrect). They can cause metabolic alkalosis, not acidosis (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12900,7 +12900,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4ff5a73f", "aedfc0c9"],
-		"explanation": "Carbonic anhydrase inhibitors decrease aqueous humor production, not increase it (A is incorrect). They are not primarily used for hypertension (B is incorrect). Methazolamide has a longer half-life than acetazolamide (D is incorrect). They are used to treat altitude sickness (C is correct) and cystoid macular edema secondary to retinitis pigmentosa (E is correct).",
+		"rationale": "Carbonic anhydrase inhibitors decrease aqueous humor production, not increase it (A is incorrect). They are not primarily used for hypertension (B is incorrect). Methazolamide has a longer half-life than acetazolamide (D is incorrect). They are used to treat altitude sickness (C is correct) and cystoid macular edema secondary to retinitis pigmentosa (E is correct).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12934,7 +12934,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ad975736", "a00b83d8", "4c4aef31"],
-		"explanation": "Loop diuretics can cause hypokalemia, not hyperkalemia (A is incorrect). They can cause hyponatremia (B is correct), ototoxicity (C is correct), and metabolic alkalosis (E is correct). They reduce calcium reabsorption, leading to hypocalcemia, not hypercalcemia (D is incorrect).",
+		"rationale": "Loop diuretics can cause hypokalemia, not hyperkalemia (A is incorrect). They can cause hyponatremia (B is correct), ototoxicity (C is correct), and metabolic alkalosis (E is correct). They reduce calcium reabsorption, leading to hypocalcemia, not hypercalcemia (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -12968,7 +12968,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["eb60b6b8", "426cc2a8"],
-		"explanation": "Thiazide diuretics inhibit the Na/Cl symporter in the distal convoluted tubule (A is correct) and enhance calcium reabsorption in the distal convoluted tubule (D is correct). They do not inhibit carbonic anhydrase (B is incorrect) or the Na+/K+/2Cl- co-transporter (C is incorrect). The vasodilatory effect is hypothesized but not a direct mechanism (E is incorrect).",
+		"rationale": "Thiazide diuretics inhibit the Na/Cl symporter in the distal convoluted tubule (A is correct) and enhance calcium reabsorption in the distal convoluted tubule (D is correct). They do not inhibit carbonic anhydrase (B is incorrect) or the Na+/K+/2Cl- co-transporter (C is incorrect). The vasodilatory effect is hypothesized but not a direct mechanism (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13002,7 +13002,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2679637c", "8c02adcf"],
-		"explanation": "Acetazolamide is used to treat glaucoma (A is correct) and epilepsy (C is correct). It is not primarily used for hypertension (B is incorrect), gout (D is incorrect), or osteoporosis (E is incorrect).",
+		"rationale": "Acetazolamide is used to treat glaucoma (A is correct) and epilepsy (C is correct). It is not primarily used for hypertension (B is incorrect), gout (D is incorrect), or osteoporosis (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13036,7 +13036,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["041c5315", "c09f3f01"],
-		"explanation": "Thiazide diuretics reduce urinary calcium excretion (A is incorrect). They are contraindicated in patients with severe sulfonamide reactions (B is correct). They are not primarily used for intracranial hypertension (C is incorrect). They can cause dry eye and mouth (D is correct). They are not used for acute intraocular pressure spikes (E is incorrect).",
+		"rationale": "Thiazide diuretics reduce urinary calcium excretion (A is incorrect). They are contraindicated in patients with severe sulfonamide reactions (B is correct). They are not primarily used for intracranial hypertension (C is incorrect). They can cause dry eye and mouth (D is correct). They are not used for acute intraocular pressure spikes (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13070,7 +13070,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2a40551d", "5063c51c"],
-		"explanation": "Carbonic anhydrase inhibitors can cause metabolic acidosis (A is correct) and dry mouth (D is correct). They do not typically cause hyperkalemia (B is incorrect) or hypocalcemia (C is incorrect). Constipation is not a common side effect (E is incorrect).",
+		"rationale": "Carbonic anhydrase inhibitors can cause metabolic acidosis (A is correct) and dry mouth (D is correct). They do not typically cause hyperkalemia (B is incorrect) or hypocalcemia (C is incorrect). Constipation is not a common side effect (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13104,7 +13104,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["39ccbbd4"],
-		"explanation": "Thiazides reduce urinary calcium excretion and are used to treat kidney stones (C is correct). Acetazolamide and methazolamide are not typically used for kidney stones (A and B are incorrect). Loop diuretics increase calcium excretion (D is incorrect). Uricosuric agents are used for gout, not kidney stones (E is incorrect).",
+		"rationale": "Thiazides reduce urinary calcium excretion and are used to treat kidney stones (C is correct). Acetazolamide and methazolamide are not typically used for kidney stones (A and B are incorrect). Loop diuretics increase calcium excretion (D is incorrect). Uricosuric agents are used for gout, not kidney stones (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13138,7 +13138,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5869d0c5"],
-		"explanation": "Loop diuretics are used to treat acute pulmonary edema (A is correct). They are not used for chronic glaucoma (B is incorrect), intracranial pressure (C is incorrect), altitude sickness (D is incorrect), or osteoporosis (E is incorrect).",
+		"rationale": "Loop diuretics are used to treat acute pulmonary edema (A is correct). They are not used for chronic glaucoma (B is incorrect), intracranial pressure (C is incorrect), altitude sickness (D is incorrect), or osteoporosis (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13172,7 +13172,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5b085dd4", "6319ea0f"],
-		"explanation": "Uricosuric agents are used to treat gout (B is correct) and increase the excretion of uric acid (C is correct). They are not used for hypertension (A is incorrect), altitude sickness (D is incorrect), and are not specifically contraindicated in sulfonamide allergies (E is incorrect).",
+		"rationale": "Uricosuric agents are used to treat gout (B is correct) and increase the excretion of uric acid (C is correct). They are not used for hypertension (A is incorrect), altitude sickness (D is incorrect), and are not specifically contraindicated in sulfonamide allergies (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13206,7 +13206,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ac44a9f9", "2cbc5ed0"],
-		"explanation": "Thiazides (C) and loop diuretics (D) can cause hypokalemia. Acetazolamide (A) and methazolamide (B) are carbonic anhydrase inhibitors and do not typically cause hypokalemia. Uricosuric agents (E) are not primarily associated with hypokalemia.",
+		"rationale": "Thiazides (C) and loop diuretics (D) can cause hypokalemia. Acetazolamide (A) and methazolamide (B) are carbonic anhydrase inhibitors and do not typically cause hypokalemia. Uricosuric agents (E) are not primarily associated with hypokalemia.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13240,7 +13240,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ace05b1c", "c7d2fe77", "b0b51e96"],
-		"explanation": "Glycerin is used to reduce intracranial pressure and ocular pressure by creating an osmotic gradient. It can be converted to glucose, which may raise blood glucose levels. Glycerin can be administered orally or intravenously. It is not used for long-term management of hypertension, and it is effective in reducing ocular pressure.",
+		"rationale": "Glycerin is used to reduce intracranial pressure and ocular pressure by creating an osmotic gradient. It can be converted to glucose, which may raise blood glucose levels. Glycerin can be administered orally or intravenously. It is not used for long-term management of hypertension, and it is effective in reducing ocular pressure.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13274,7 +13274,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f3faf8b3", "0113fa97", "d64bc36c"],
-		"explanation": "Loop diuretics can cause hypokalemia (low potassium levels), ototoxicity (hearing damage), and metabolic alkalosis (a disturbance in the body's acid-base balance). They do not cause hyperkalemia (high potassium levels) or hypernatremia (high sodium levels).",
+		"rationale": "Loop diuretics can cause hypokalemia (low potassium levels), ototoxicity (hearing damage), and metabolic alkalosis (a disturbance in the body's acid-base balance). They do not cause hyperkalemia (high potassium levels) or hypernatremia (high sodium levels).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13308,7 +13308,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e04b51bc", "ea35ae93"],
-		"explanation": "Potassium-sparing diuretics prevent excessive excretion of potassium and can be used in combination with other antihypertensives. They are not effective as primary therapy for hypertension, do not work by inhibiting the Na+/K+/2Cl co-transporter, and do not cause hypokalemia.",
+		"rationale": "Potassium-sparing diuretics prevent excessive excretion of potassium and can be used in combination with other antihypertensives. They are not effective as primary therapy for hypertension, do not work by inhibiting the Na+/K+/2Cl co-transporter, and do not cause hypokalemia.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13342,7 +13342,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5af411f9", "07ac0208"],
-		"explanation": "Osmotic diuretics and carbonic anhydrase inhibitors are used for the treatment of glaucoma. Loop diuretics, potassium-sparing diuretics, and uricosuric agents are not primarily used for this purpose.",
+		"rationale": "Osmotic diuretics and carbonic anhydrase inhibitors are used for the treatment of glaucoma. Loop diuretics, potassium-sparing diuretics, and uricosuric agents are not primarily used for this purpose.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13376,7 +13376,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5c0ec4c4", "6b1f1d3b", "ad80a62b"],
-		"explanation": "Carbonic anhydrase inhibitors are used for altitude sickness and acute intraocular pressure spikes, with acetazolamide being preferred for the latter. Dorzolamide and brinzolamide are topical ophthalmic agents. Methazolamide has a longer half-life than acetazolamide, and these drugs are not primarily used for hypertension management.",
+		"rationale": "Carbonic anhydrase inhibitors are used for altitude sickness and acute intraocular pressure spikes, with acetazolamide being preferred for the latter. Dorzolamide and brinzolamide are topical ophthalmic agents. Methazolamide has a longer half-life than acetazolamide, and these drugs are not primarily used for hypertension management.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13410,7 +13410,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3b8019e1", "353d4aed", "738a9e8c", "34a802c1"],
-		"explanation": "Beta blockers are contraindicated in asthma due to the risk of bronchospasm, cardiogenic shock, metabolic acidosis, and severe peripheral arterial disease. They are not contraindicated in hypertension; in fact, they are often used to treat it.",
+		"rationale": "Beta blockers are contraindicated in asthma due to the risk of bronchospasm, cardiogenic shock, metabolic acidosis, and severe peripheral arterial disease. They are not contraindicated in hypertension; in fact, they are often used to treat it.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13444,7 +13444,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fbaeb344", "2a7623a7"],
-		"explanation": "Atenolol and metoprolol are cardioselective beta blockers, meaning they primarily block ß1-receptors. Timolol, propranolol, and nadolol are non-selective beta blockers.",
+		"rationale": "Atenolol and metoprolol are cardioselective beta blockers, meaning they primarily block ß1-receptors. Timolol, propranolol, and nadolol are non-selective beta blockers.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13478,7 +13478,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["18b325d8"],
-		"explanation": "Beta blockers benefit CHF by blocking the effects of norepinephrine and epinephrine, thereby normalizing sympathetic activity and reducing heart rate and cardiac contraction force. They do not increase cardiac output or stimulate the renin-angiotensin system.",
+		"rationale": "Beta blockers benefit CHF by blocking the effects of norepinephrine and epinephrine, thereby normalizing sympathetic activity and reducing heart rate and cardiac contraction force. They do not increase cardiac output or stimulate the renin-angiotensin system.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13512,7 +13512,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["38aa07a2"],
-		"explanation": "Non-selective beta blockers are more likely to cause hyperglycemia due to ß2-receptor blockade. They are not safe for asthmatic patients and do not primarily block ß1-receptors. Atenolol and metoprolol are selective beta blockers.",
+		"rationale": "Non-selective beta blockers are more likely to cause hyperglycemia due to ß2-receptor blockade. They are not safe for asthmatic patients and do not primarily block ß1-receptors. Atenolol and metoprolol are selective beta blockers.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13546,7 +13546,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["da1bfc5a", "657abf3a"],
-		"explanation": "Propranolol and metoprolol are highly lipophilic, meaning they are well absorbed from the gut but undergo extensive first-pass metabolism. Atenolol and nadolol are hydrophilic.",
+		"rationale": "Propranolol and metoprolol are highly lipophilic, meaning they are well absorbed from the gut but undergo extensive first-pass metabolism. Atenolol and nadolol are hydrophilic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13580,7 +13580,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ae8002d7", "5d462fcc"],
-		"explanation": "Beta blockers should be used with caution in diabetes due to the risk of hypoglycemia and in COPD due to the risk of bronchospasm. They are commonly used in hypertension, hyperthyroidism, and migraine prophylaxis.",
+		"rationale": "Beta blockers should be used with caution in diabetes due to the risk of hypoglycemia and in COPD due to the risk of bronchospasm. They are commonly used in hypertension, hyperthyroidism, and migraine prophylaxis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13614,7 +13614,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7fc6fb31", "5a1694e2", "00d8ba9d"],
-		"explanation": "Beta blockers can cause bradycardia, hypotension, and bronchospasm. They do not cause hyperglycemia; instead, they can mask hypoglycemia. They decrease cardiac output rather than increase it.",
+		"rationale": "Beta blockers can cause bradycardia, hypotension, and bronchospasm. They do not cause hyperglycemia; instead, they can mask hypoglycemia. They decrease cardiac output rather than increase it.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13648,7 +13648,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["171309b1", "a23d4646"],
-		"explanation": "Atenolol and nadolol are hydrophilic beta blockers that undergo negligible first-pass metabolism. Propranolol and metoprolol are lipophilic and undergo extensive first-pass metabolism.",
+		"rationale": "Atenolol and nadolol are hydrophilic beta blockers that undergo negligible first-pass metabolism. Propranolol and metoprolol are lipophilic and undergo extensive first-pass metabolism.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13682,7 +13682,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["76d434f7"],
-		"explanation": "Cardioselective beta blockers can be used in asthmatic patients under specialist care, with attention to the risk of bronchospasm. They are not the first-line treatment for asthma, and non-selective beta blockers are not preferred.",
+		"rationale": "Cardioselective beta blockers can be used in asthmatic patients under specialist care, with attention to the risk of bronchospasm. They are not the first-line treatment for asthma, and non-selective beta blockers are not preferred.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13716,7 +13716,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["94d1f28c", "30c9a8a0", "dc567a7c"],
-		"explanation": "Bisoprolol, carvedilol, and metoprolol are used in the management of CHF. Timolol and propranolol are not typically used for this indication.",
+		"rationale": "Bisoprolol, carvedilol, and metoprolol are used in the management of CHF. Timolol and propranolol are not typically used for this indication.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13750,7 +13750,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9caeb37a"],
-		"explanation": "Beta blockers decrease sympathetic activity in CHF, which is beneficial as excessive sympathetic activity can damage the heart. They do not stimulate the renin-angiotensin system or enhance norepinephrine release.",
+		"rationale": "Beta blockers decrease sympathetic activity in CHF, which is beneficial as excessive sympathetic activity can damage the heart. They do not stimulate the renin-angiotensin system or enhance norepinephrine release.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13784,7 +13784,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["87cac292", "4b5f3703", "67950ebd"],
-		"explanation": "Timolol, nadolol, and propranolol are non-selective beta blockers. Atenolol and metoprolol are selective beta blockers.",
+		"rationale": "Timolol, nadolol, and propranolol are non-selective beta blockers. Atenolol and metoprolol are selective beta blockers.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13818,7 +13818,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["50a74b98", "e241b805"],
-		"explanation": "Beta blockers can exacerbate heart failure if not used carefully and can worsen asthma due to bronchospasm. They are used to treat hypertension, hyperthyroidism, and migraines.",
+		"rationale": "Beta blockers can exacerbate heart failure if not used carefully and can worsen asthma due to bronchospasm. They are used to treat hypertension, hyperthyroidism, and migraines.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13852,7 +13852,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6ad3bdc7", "e8c9a6a8"],
-		"explanation": "Atenolol and nadolol are hydrophilic beta blockers with longer half-lives. Propranolol and metoprolol are lipophilic and have shorter half-lives.",
+		"rationale": "Atenolol and nadolol are hydrophilic beta blockers with longer half-lives. Propranolol and metoprolol are lipophilic and have shorter half-lives.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13886,7 +13886,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5c7b7cc8"],
-		"explanation": "The combination of beta blockers and verapamil can precipitate heart failure, especially in patients with ischemic heart disease. They should be used together with caution.",
+		"rationale": "The combination of beta blockers and verapamil can precipitate heart failure, especially in patients with ischemic heart disease. They should be used together with caution.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13920,7 +13920,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cb936cc7", "7623e6b8", "2d83a51e"],
-		"explanation": "Non-selective beta blockers like timolol, propranolol, and nadolol are used with caution in diabetic patients due to the risk of hypoglycemia. Selective beta blockers like atenolol and metoprolol are generally safer.",
+		"rationale": "Non-selective beta blockers like timolol, propranolol, and nadolol are used with caution in diabetic patients due to the risk of hypoglycemia. Selective beta blockers like atenolol and metoprolol are generally safer.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13954,7 +13954,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44921f47", "bbc7c852"],
-		"explanation": "Propranolol and metoprolol are lipophilic beta blockers with short half-lives. Atenolol and nadolol are hydrophilic and have longer half-lives.",
+		"rationale": "Propranolol and metoprolol are lipophilic beta blockers with short half-lives. Atenolol and nadolol are hydrophilic and have longer half-lives.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -13988,7 +13988,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6506ba46", "8a052a23", "4709fb10", "604537b8"],
-		"explanation": "Beta blockers are used to manage CHF, hypertension, hyperthyroidism, and migraines. They are not used to manage asthma due to the risk of bronchospasm.",
+		"rationale": "Beta blockers are used to manage CHF, hypertension, hyperthyroidism, and migraines. They are not used to manage asthma due to the risk of bronchospasm.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14022,7 +14022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c62b09c1", "c2ddb701"],
-		"explanation": "Propranolol and metoprolol are lipophilic beta blockers that undergo extensive first-pass metabolism. Atenolol and nadolol are hydrophilic and undergo negligible first-pass metabolism.",
+		"rationale": "Propranolol and metoprolol are lipophilic beta blockers that undergo extensive first-pass metabolism. Atenolol and nadolol are hydrophilic and undergo negligible first-pass metabolism.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14056,7 +14056,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a63a8549"],
-		"explanation": "Cardioselective beta blockers are less likely to cause bronchospasm compared to non-selective beta blockers. Non-selective beta blockers are not safe in asthma, and bronchospasm is a concern with their use. Beta blockers are not used to treat bronchospasm.",
+		"rationale": "Cardioselective beta blockers are less likely to cause bronchospasm compared to non-selective beta blockers. Non-selective beta blockers are not safe in asthma, and bronchospasm is a concern with their use. Beta blockers are not used to treat bronchospasm.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14090,7 +14090,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["56379a4b", "b9b78ffa"],
-		"explanation": "ACE inhibitors prevent the conversion of angiotensin I to angiotensin II, reducing vasoconstriction and aldosterone secretion, which lowers blood pressure. They do not directly cause vasodilation or increase bradykinin breakdown, nor do they antagonize angiotensin II receptors directly.",
+		"rationale": "ACE inhibitors prevent the conversion of angiotensin I to angiotensin II, reducing vasoconstriction and aldosterone secretion, which lowers blood pressure. They do not directly cause vasodilation or increase bradykinin breakdown, nor do they antagonize angiotensin II receptors directly.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14124,7 +14124,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5050e404", "96d27bb0", "bd89a045"],
-		"explanation": "ACE inhibitors reduce afterload and fluid volume, decreasing the heart's workload and improving function. They also slow kidney disease progression. They do not increase heart rate or directly strengthen heart contractions.",
+		"rationale": "ACE inhibitors reduce afterload and fluid volume, decreasing the heart's workload and improving function. They also slow kidney disease progression. They do not increase heart rate or directly strengthen heart contractions.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14158,7 +14158,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9d8962b4", "bcb099f0", "24d9488e"],
-		"explanation": "ACE inhibitors can cause a dry cough, angioedema, and hyperkalemia. Bradycardia and retinal hemorrhage are not common side effects of ACE inhibitors.",
+		"rationale": "ACE inhibitors can cause a dry cough, angioedema, and hyperkalemia. Bradycardia and retinal hemorrhage are not common side effects of ACE inhibitors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14192,7 +14192,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fc306dd8", "1b28b524", "986ebd7b"],
-		"explanation": "African Americans, smokers, and those with a history of drug rash have a higher risk of angioedema with ACE inhibitors. Diabetes and young age are not specifically associated with increased risk.",
+		"rationale": "African Americans, smokers, and those with a history of drug rash have a higher risk of angioedema with ACE inhibitors. Diabetes and young age are not specifically associated with increased risk.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14226,7 +14226,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["da7bd947"],
-		"explanation": "ACE inhibitors are administered as prodrugs and metabolized in the liver to active compounds. They do not have a rapid onset, are not excreted unchanged, and their half-life varies.",
+		"rationale": "ACE inhibitors are administered as prodrugs and metabolized in the liver to active compounds. They do not have a rapid onset, are not excreted unchanged, and their half-life varies.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14260,7 +14260,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e1eff462", "aa3ee89d", "d1ea34ed"],
-		"explanation": "Fosinopril, benazepril, and captopril are commonly used for CHF. Lisinopril and enalapril are also used but were not mentioned in the provided material.",
+		"rationale": "Fosinopril, benazepril, and captopril are commonly used for CHF. Lisinopril and enalapril are also used but were not mentioned in the provided material.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14294,7 +14294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bdd8181d"],
-		"explanation": "ACE inhibitors increase bradykinin levels by decreasing its breakdown, contributing to vasodilation.",
+		"rationale": "ACE inhibitors increase bradykinin levels by decreasing its breakdown, contributing to vasodilation.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14328,7 +14328,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["952f387c", "93208c93", "43080cb8"],
-		"explanation": "ACE inhibitors are first-line for those under 55 and less effective in African Americans. They are contraindicated in renal artery stenosis. They are not always combined with diuretics and may not be effective in all populations.",
+		"rationale": "ACE inhibitors are first-line for those under 55 and less effective in African Americans. They are contraindicated in renal artery stenosis. They are not always combined with diuretics and may not be effective in all populations.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14362,7 +14362,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["40586f04", "71352de2", "ba3b2904"],
-		"explanation": "Angiotensin II causes vasoconstriction, promotes aldosterone secretion, and causes vascular hypertrophy. It increases blood pressure and does not affect bradykinin breakdown.",
+		"rationale": "Angiotensin II causes vasoconstriction, promotes aldosterone secretion, and causes vascular hypertrophy. It increases blood pressure and does not affect bradykinin breakdown.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14396,7 +14396,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5544de20", "778c1072", "153dd646"],
-		"explanation": "ACE inhibitors prevent conversion of angiotensin I to II, reduce aldosterone secretion, and increase renin activity. They do not inhibit renin release or block angiotensin II receptors.",
+		"rationale": "ACE inhibitors prevent conversion of angiotensin I to II, reduce aldosterone secretion, and increase renin activity. They do not inhibit renin release or block angiotensin II receptors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14430,7 +14430,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6d7843ed"],
-		"explanation": "Retinal hemorrhage may occur with anemia (ACE inhibitors inhibit release of erthyropoietin from the kidneys), which can be associated with ACE inhibitors. Other listed ocular side effects are not commonly associated with ACE inhibitors.",
+		"rationale": "Retinal hemorrhage may occur with anemia (ACE inhibitors inhibit release of erthyropoietin from the kidneys), which can be associated with ACE inhibitors. Other listed ocular side effects are not commonly associated with ACE inhibitors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14464,7 +14464,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["be15f743"],
-		"explanation": "African American patients often have reduced renin levels, making ACE inhibitors less effective. Genetic differences, higher angiotensin II levels, increased bradykinin breakdown, and enhanced aldosterone secretion are not the primary reasons.",
+		"rationale": "African American patients often have reduced renin levels, making ACE inhibitors less effective. Genetic differences, higher angiotensin II levels, increased bradykinin breakdown, and enhanced aldosterone secretion are not the primary reasons.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14498,7 +14498,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fd1f55ba", "38431103"],
-		"explanation": "ACE inhibitors are often administered as prodrugs and require liver metabolism to become active. They are not always taken with food, are not typically given intravenously, and do not have a rapid onset.",
+		"rationale": "ACE inhibitors are often administered as prodrugs and require liver metabolism to become active. They are not always taken with food, are not typically given intravenously, and do not have a rapid onset.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14532,7 +14532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5de22352"],
-		"explanation": "The dry cough is primarily due to increased bradykinin levels, not aldosterone, angiotensin I accumulation, direct irritation, or increased renin activity.",
+		"rationale": "The dry cough is primarily due to increased bradykinin levels, not aldosterone, angiotensin I accumulation, direct irritation, or increased renin activity.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14566,7 +14566,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7b004edd", "bc38f1ca"],
-		"explanation": "ACE inhibitors help protect kidney function and manage hypertension in diabetic patients. They are not contraindicated, do not increase hypoglycemia risk, and are beneficial in diabetic nephropathy.",
+		"rationale": "ACE inhibitors help protect kidney function and manage hypertension in diabetic patients. They are not contraindicated, do not increase hypoglycemia risk, and are beneficial in diabetic nephropathy.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14600,7 +14600,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["affce123", "58d0e89f"],
-		"explanation": "Prodrugs have the suffix '-pril', and their active forms have the suffix '-prilat'. The suffixes indicate different forms, not the same.",
+		"rationale": "Prodrugs have the suffix '-pril', and their active forms have the suffix '-prilat'. The suffixes indicate different forms, not the same.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14634,7 +14634,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["438f3d0a", "eaeed3ce"],
-		"explanation": "The benefit of ACE inhibitors in heart failure increases with age, and they are used regardless of age. They are not only effective in older patients, nor are they contraindicated.",
+		"rationale": "The benefit of ACE inhibitors in heart failure increases with age, and they are used regardless of age. They are not only effective in older patients, nor are they contraindicated.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14668,7 +14668,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f524eb1d", "4c4f6812", "f89df32e"],
-		"explanation": "Angioedema is more common in patients with seasonal allergies, on immunosuppressive therapy, and can occur after years of therapy. It is more frequent in women and smokers, not less.",
+		"rationale": "Angioedema is more common in patients with seasonal allergies, on immunosuppressive therapy, and can occur after years of therapy. It is more frequent in women and smokers, not less.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14702,7 +14702,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["418905c3"],
-		"explanation": "ACE inhibitors decrease bradykinin breakdown, leading to increased levels. They do not affect synthesis or increase breakdown.",
+		"rationale": "ACE inhibitors decrease bradykinin breakdown, leading to increased levels. They do not affect synthesis or increase breakdown.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14736,7 +14736,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8d3da55d", "c3e36ed0", "a4e123be"],
-		"explanation": "ARBs are often used in patients who cannot tolerate ACE inhibitors due to side effects like cough and angioedema (B, C). ARBs have a lower incidence of cough and angioedema compared to ACE inhibitors (C). They are associated with a higher rate of hypotensive symptoms such as dizziness (D). ARBs do not inhibit the conversion of angiotensin I to angiotensin II; instead, they block the receptors for angiotensin II (E).",
+		"rationale": "ARBs are often used in patients who cannot tolerate ACE inhibitors due to side effects like cough and angioedema (B, C). ARBs have a lower incidence of cough and angioedema compared to ACE inhibitors (C). They are associated with a higher rate of hypotensive symptoms such as dizziness (D). ARBs do not inhibit the conversion of angiotensin I to angiotensin II; instead, they block the receptors for angiotensin II (E).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14770,7 +14770,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["215f6104", "28b09499"],
-		"explanation": "Losartan and valsartan are ARBs, which have a lower incidence of angioedema compared to ACE inhibitors (B, D). Lisinopril, enalapril, and captopril are ACE inhibitors and are associated with a higher risk of angioedema (A, C, E).",
+		"rationale": "Losartan and valsartan are ARBs, which have a lower incidence of angioedema compared to ACE inhibitors (B, D). Lisinopril, enalapril, and captopril are ACE inhibitors and are associated with a higher risk of angioedema (A, C, E).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14804,7 +14804,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0fafb2f1", "27c0b888"],
-		"explanation": "Both ACE inhibitors and ARBs reduce aldosterone secretion and prevent angiotensin II-mediated vasoconstriction (B, D). ACE inhibitors inhibit the angiotensin converting enzyme and increase bradykinin levels, while ARBs do not (A, C). ARBs directly block angiotensin II receptors, which is not a mechanism shared with ACE inhibitors (E).",
+		"rationale": "Both ACE inhibitors and ARBs reduce aldosterone secretion and prevent angiotensin II-mediated vasoconstriction (B, D). ACE inhibitors inhibit the angiotensin converting enzyme and increase bradykinin levels, while ARBs do not (A, C). ARBs directly block angiotensin II receptors, which is not a mechanism shared with ACE inhibitors (E).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14838,7 +14838,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a7f348b1", "0e92dd9f"],
-		"explanation": "ARBs are preferred in patients with a history of chronic cough or angioedema because they have a lower incidence of these side effects compared to ACE inhibitors (A, C). Both ARBs and ACE inhibitors can cause issues in patients with renovascular hypertension or effective volume depletion (B, D). Ocular surface changes are not specifically related to the choice between ARBs and ACE inhibitors (E).",
+		"rationale": "ARBs are preferred in patients with a history of chronic cough or angioedema because they have a lower incidence of these side effects compared to ACE inhibitors (A, C). Both ARBs and ACE inhibitors can cause issues in patients with renovascular hypertension or effective volume depletion (B, D). Ocular surface changes are not specifically related to the choice between ARBs and ACE inhibitors (E).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14872,7 +14872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ec9aa8ae"],
-		"explanation": "Angiotensin II is a potent vasoconstrictor, not a vasodilator (A). ACE inhibitors decrease the breakdown of bradykinin, leading to increased levels (B). Angiotensin II causes hypertrophy of vascular tissues, which can increase the workload on the heart (C). Aldosterone secretion increases vascular fluid volume, not decreases it (D). Renin is released by the kidney, not the liver (E).",
+		"rationale": "Angiotensin II is a potent vasoconstrictor, not a vasodilator (A). ACE inhibitors decrease the breakdown of bradykinin, leading to increased levels (B). Angiotensin II causes hypertrophy of vascular tissues, which can increase the workload on the heart (C). Aldosterone secretion increases vascular fluid volume, not decreases it (D). Renin is released by the kidney, not the liver (E).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14906,7 +14906,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["32d22f6f", "55533aa3"],
-		"explanation": "Calcium channel blockers are effective in controlling hypertension in African Americans, especially when combined with thiazide diuretics. They work by blocking calcium influx into myocytes and vascular smooth muscle cells, leading to vasodilation. They are not primarily used for glaucoma, and they are not contraindicated in patients with angina; in fact, they can be beneficial for angina patients. While potent, they are not necessarily the most potent vasodilators among all cardiovascular drugs.",
+		"rationale": "Calcium channel blockers are effective in controlling hypertension in African Americans, especially when combined with thiazide diuretics. They work by blocking calcium influx into myocytes and vascular smooth muscle cells, leading to vasodilation. They are not primarily used for glaucoma, and they are not contraindicated in patients with angina; in fact, they can be beneficial for angina patients. While potent, they are not necessarily the most potent vasodilators among all cardiovascular drugs.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14940,7 +14940,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3be3614c"],
-		"explanation": "Nifedipine, a dihydropyridine calcium channel blocker, is most associated with peripheral edema due to its potent vasodilatory effects. Verapamil and diltiazem are less potent vasodilators and are less likely to cause this side effect. Amlodipine can also cause peripheral edema but is less likely than nifedipine. Lisinopril is an ACE inhibitor, not a calcium channel blocker.",
+		"rationale": "Nifedipine, a dihydropyridine calcium channel blocker, is most associated with peripheral edema due to its potent vasodilatory effects. Verapamil and diltiazem are less potent vasodilators and are less likely to cause this side effect. Amlodipine can also cause peripheral edema but is less likely than nifedipine. Lisinopril is an ACE inhibitor, not a calcium channel blocker.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -14974,7 +14974,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["26b110c9"],
-		"explanation": "Verapamil is preferred for patients with angina due to its effects on heart rate and contractility but can exacerbate heart failure due to its negative inotropic effects. Nifedipine and amlodipine are more potent vasodilators but are not preferred for angina. Diltiazem is also used for angina but does not have the same risk of exacerbating heart failure as verapamil. Propranolol is a beta-blocker, not a calcium channel blocker.",
+		"rationale": "Verapamil is preferred for patients with angina due to its effects on heart rate and contractility but can exacerbate heart failure due to its negative inotropic effects. Nifedipine and amlodipine are more potent vasodilators but are not preferred for angina. Diltiazem is also used for angina but does not have the same risk of exacerbating heart failure as verapamil. Propranolol is a beta-blocker, not a calcium channel blocker.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15008,7 +15008,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f5051af0", "74e0036a"],
-		"explanation": "Calcium channel blockers are not widely accepted for glaucoma treatment, and they are not the first-line treatment. Some studies show an increased risk of glaucoma with their use, although they may have potential benefits due to effects on NMDA receptors in retinal ganglion cells. They can affect aqueous production, but this is not their primary use.",
+		"rationale": "Calcium channel blockers are not widely accepted for glaucoma treatment, and they are not the first-line treatment. Some studies show an increased risk of glaucoma with their use, although they may have potential benefits due to effects on NMDA receptors in retinal ganglion cells. They can affect aqueous production, but this is not their primary use.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15042,7 +15042,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fb5e4146", "35a02f5f"],
-		"explanation": "Reflex tachycardia and constipation are common side effects of calcium channel blockers. Ocular side effects are minimal, hyperkalemia is not typically associated with calcium channel blockers, and bradycardia is more associated with non-dihydropyridine calcium channel blockers like verapamil and diltiazem.",
+		"rationale": "Reflex tachycardia and constipation are common side effects of calcium channel blockers. Ocular side effects are minimal, hyperkalemia is not typically associated with calcium channel blockers, and bradycardia is more associated with non-dihydropyridine calcium channel blockers like verapamil and diltiazem.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15076,7 +15076,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["06da39ce"],
-		"explanation": "Verapamil is known for having the least potent vasodilatory effect compared to dihydropyridine calcium channel blockers like nifedipine, amlodipine, and felodipine. Diltiazem falls between verapamil and the dihydropyridines in terms of vasodilatory potency.",
+		"rationale": "Verapamil is known for having the least potent vasodilatory effect compared to dihydropyridine calcium channel blockers like nifedipine, amlodipine, and felodipine. Diltiazem falls between verapamil and the dihydropyridines in terms of vasodilatory potency.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15110,7 +15110,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["427cd0d2", "b30fa368", "9596a755"],
-		"explanation": "Calcium channel blockers are used to treat stable angina pectoris, hypertrophic cardiomyopathy, and supraventricular arrhythmias. They are not used to treat hyperlipidemia or asthma.",
+		"rationale": "Calcium channel blockers are used to treat stable angina pectoris, hypertrophic cardiomyopathy, and supraventricular arrhythmias. They are not used to treat hyperlipidemia or asthma.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15144,7 +15144,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["95a8a381"],
-		"explanation": "Nifedipine is a short-acting calcium channel blocker and is contraindicated in patients at risk for myocardial infarction due to its potential to cause reflex tachycardia. It is more likely to cause peripheral edema than amlodipine. It is not effective in treating supraventricular arrhythmias, and it is a dihydropyridine, not a benzothiazepine derivative.",
+		"rationale": "Nifedipine is a short-acting calcium channel blocker and is contraindicated in patients at risk for myocardial infarction due to its potential to cause reflex tachycardia. It is more likely to cause peripheral edema than amlodipine. It is not effective in treating supraventricular arrhythmias, and it is a dihydropyridine, not a benzothiazepine derivative.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15178,7 +15178,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9f934b35"],
-		"explanation": "Diltiazem is a benzothiazepine derivative. Nifedipine, amlodipine, and felodipine are dihydropyridines, while verapamil is a phenylalkylamine.",
+		"rationale": "Diltiazem is a benzothiazepine derivative. Nifedipine, amlodipine, and felodipine are dihydropyridines, while verapamil is a phenylalkylamine.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15212,7 +15212,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a83b36c9"],
-		"explanation": "Calcium channel blockers decrease cardiac work by decreasing blood pressure, which reduces the workload on the heart. They do not increase heart rate or peripheral resistance, and they work by blocking calcium influx into myocytes, not increasing it. They do not enhance actin-myosin interaction; instead, they prevent it by reducing calcium availability.",
+		"rationale": "Calcium channel blockers decrease cardiac work by decreasing blood pressure, which reduces the workload on the heart. They do not increase heart rate or peripheral resistance, and they work by blocking calcium influx into myocytes, not increasing it. They do not enhance actin-myosin interaction; instead, they prevent it by reducing calcium availability.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15246,7 +15246,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a1df0d58", "8ddf04e1"],
-		"explanation": "Alpha blockers are not first-line treatments for hypertension (A) but are effective for urinary symptoms related to prostate enlargement (B). Phentolamine, an alpha blocker, is used in the diagnosis of pheochromocytoma (D). They are not commonly used for Raynaud's syndrome (C), and they are not contraindicated in BPH (E).",
+		"rationale": "Alpha blockers are not first-line treatments for hypertension (A) but are effective for urinary symptoms related to prostate enlargement (B). Phentolamine, an alpha blocker, is used in the diagnosis of pheochromocytoma (D). They are not commonly used for Raynaud's syndrome (C), and they are not contraindicated in BPH (E).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15280,7 +15280,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d0c89eae", "3b04f646"],
-		"explanation": "Clonidine (B) and guanfacine (E) are alpha-2 receptor agonists. Terazosin (A) and tamsulosin (D) are alpha blockers, while minoxidil (C) is a vasodilator.",
+		"rationale": "Clonidine (B) and guanfacine (E) are alpha-2 receptor agonists. Terazosin (A) and tamsulosin (D) are alpha blockers, while minoxidil (C) is a vasodilator.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15314,7 +15314,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4133fd99", "0f3aa624"],
-		"explanation": "Vasodilators can cause dizziness (B) and tissue edema (D) as side effects. They are used to treat hypertension, not cause it (A). Bradycardia (C) and hyperactivity (E) are not common side effects of vasodilators.",
+		"rationale": "Vasodilators can cause dizziness (B) and tissue edema (D) as side effects. They are used to treat hypertension, not cause it (A). Bradycardia (C) and hyperactivity (E) are not common side effects of vasodilators.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15348,7 +15348,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c6d6e675"],
-		"explanation": "Minoxidil (B) is used for hypertension and topically for hair loss. Hydralazine (A) is used for hypertension and eclampsia, but not hair loss. Tamsulosin (C) and phenoxybenzamine (D) are alpha blockers, and isosorbide mononitrate (E) is an anti-anginal agent.",
+		"rationale": "Minoxidil (B) is used for hypertension and topically for hair loss. Hydralazine (A) is used for hypertension and eclampsia, but not hair loss. Tamsulosin (C) and phenoxybenzamine (D) are alpha blockers, and isosorbide mononitrate (E) is an anti-anginal agent.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15382,7 +15382,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0a5b545e", "1a54f908"],
-		"explanation": "Clonidine (A) and tizanidine (C) can be used for pediatric sedation. Terazosin (B) and doxazosin (D) are alpha blockers, and apraclonidine (E) is used topically for eye conditions.",
+		"rationale": "Clonidine (A) and tizanidine (C) can be used for pediatric sedation. Terazosin (B) and doxazosin (D) are alpha blockers, and apraclonidine (E) is used topically for eye conditions.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15416,7 +15416,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["80fc929a"],
-		"explanation": "Hydralazine (A) is used to treat eclampsia. Minoxidil (B) is used for hypertension and hair loss, tamsulosin (C) and phenoxybenzamine (D) are alpha blockers, and isosorbide mononitrate (E) is an anti-anginal agent.",
+		"rationale": "Hydralazine (A) is used to treat eclampsia. Minoxidil (B) is used for hypertension and hair loss, tamsulosin (C) and phenoxybenzamine (D) are alpha blockers, and isosorbide mononitrate (E) is an anti-anginal agent.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15450,7 +15450,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["637b893a"],
-		"explanation": "Phentolamine (A) is used for the treatment of Raynaud's syndrome. Terazosin (B) and tamsulosin (E) are alpha blockers used for BPH, clonidine (C) is an alpha-2 agonist, and minoxidil (D) is a vasodilator.",
+		"rationale": "Phentolamine (A) is used for the treatment of Raynaud's syndrome. Terazosin (B) and tamsulosin (E) are alpha blockers used for BPH, clonidine (C) is an alpha-2 agonist, and minoxidil (D) is a vasodilator.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15484,7 +15484,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f9308cf1"],
-		"explanation": "Isosorbide mononitrate (C) is used to reduce cardiac preload. Hydralazine (A) and minoxidil (B) are vasodilators, tamsulosin (D) and phenoxybenzamine (E) are alpha blockers.",
+		"rationale": "Isosorbide mononitrate (C) is used to reduce cardiac preload. Hydralazine (A) and minoxidil (B) are vasodilators, tamsulosin (D) and phenoxybenzamine (E) are alpha blockers.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15518,7 +15518,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["60013aa3"],
-		"explanation": "Phentolamine (D) is used for the diagnosis of adrenal gland tumors (pheochromocytoma). Phenoxybenzamine (A) is used for pheochromocytoma treatment, terazosin (B) is used for BPH, clonidine (C) is an alpha-2 agonist, and minoxidil (E) is a vasodilator.",
+		"rationale": "Phentolamine (D) is used for the diagnosis of adrenal gland tumors (pheochromocytoma). Phenoxybenzamine (A) is used for pheochromocytoma treatment, terazosin (B) is used for BPH, clonidine (C) is an alpha-2 agonist, and minoxidil (E) is a vasodilator.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15552,7 +15552,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2d0ed2ea", "6f8d5850"],
-		"explanation": "Clonidine (A) and guanfacine (C) are used for ADHD. Terazosin (B) and tamsulosin (D) are alpha blockers used for BPH, and phenoxybenzamine (E) is used for pheochromocytoma.",
+		"rationale": "Clonidine (A) and guanfacine (C) are used for ADHD. Terazosin (B) and tamsulosin (D) are alpha blockers used for BPH, and phenoxybenzamine (E) is used for pheochromocytoma.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15586,7 +15586,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e58fa22f", "4fc9c697"],
-		"explanation": "Minoxidil is indeed used topically for hair loss, and hydralazine is used for eclampsia. Nitroprusside is reserved for severe hypertension, not mild cases. Isosorbide mononitrate predominantly relaxes venous smooth muscle, reducing cardiac preload. Vasodilators are not first-line treatments for hypertension; they are reserved for severe and resistant cases.",
+		"rationale": "Minoxidil is indeed used topically for hair loss, and hydralazine is used for eclampsia. Nitroprusside is reserved for severe hypertension, not mild cases. Isosorbide mononitrate predominantly relaxes venous smooth muscle, reducing cardiac preload. Vasodilators are not first-line treatments for hypertension; they are reserved for severe and resistant cases.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15620,7 +15620,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5f338b7f", "afc5af8a", "1b6b1975"],
-		"explanation": "Common side effects of vasodilators include dizziness, tissue edema, and reflex tachycardia. Constipation is not a typical side effect of vasodilators, and ocular side effects are minimal.",
+		"rationale": "Common side effects of vasodilators include dizziness, tissue edema, and reflex tachycardia. Constipation is not a typical side effect of vasodilators, and ocular side effects are minimal.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15654,7 +15654,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["555dba93"],
-		"explanation": "Verapamil is preferred for angina patients but can exacerbate heart failure. Nifedipine and amlodipine are dihydropyridines, which are potent vasodilators but not specifically preferred for angina. Diltiazem falls between the two classes in terms of effectivity and side effects. Isosorbide mononitrate is not a calcium channel blocker.",
+		"rationale": "Verapamil is preferred for angina patients but can exacerbate heart failure. Nifedipine and amlodipine are dihydropyridines, which are potent vasodilators but not specifically preferred for angina. Diltiazem falls between the two classes in terms of effectivity and side effects. Isosorbide mononitrate is not a calcium channel blocker.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15688,7 +15688,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a67fabc4", "100a2fc9", "e8801c4a"],
-		"explanation": "Alpha blockers are used to treat urinary symptoms related to prostate enlargement and are not first-line treatments for hypertension. Phenoxybenzamine is used for excessive sweating, and phentolamine is used for pheochromocytoma diagnosis. Tamsulosin is used for benign prostate hyperplasia, not erectile dysfunction.",
+		"rationale": "Alpha blockers are used to treat urinary symptoms related to prostate enlargement and are not first-line treatments for hypertension. Phenoxybenzamine is used for excessive sweating, and phentolamine is used for pheochromocytoma diagnosis. Tamsulosin is used for benign prostate hyperplasia, not erectile dysfunction.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15722,7 +15722,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["81ab7828"],
-		"explanation": "Nifedipine, a dihydropyridine calcium channel blocker, is associated with peripheral edema and reflex tachycardia. Amlodipine is also a dihydropyridine but has fewer side effects. Verapamil and diltiazem are less potent vasodilators and are not typically associated with reflex tachycardia. Minoxidil is not a calcium channel blocker.",
+		"rationale": "Nifedipine, a dihydropyridine calcium channel blocker, is associated with peripheral edema and reflex tachycardia. Amlodipine is also a dihydropyridine but has fewer side effects. Verapamil and diltiazem are less potent vasodilators and are not typically associated with reflex tachycardia. Minoxidil is not a calcium channel blocker.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15756,7 +15756,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9b64864e", "0fb1f169"],
-		"explanation": "Left-sided heart failure is indeed more common and leads to pulmonary congestion, not right-sided heart failure. Decreased systemic blood flow stimulates renin and aldosterone release, increasing workload. Increased peripheral resistance increases, not decreases, the workload on the heart. CHF can result from various cardiovascular issues, not just lung disease.",
+		"rationale": "Left-sided heart failure is indeed more common and leads to pulmonary congestion, not right-sided heart failure. Decreased systemic blood flow stimulates renin and aldosterone release, increasing workload. Increased peripheral resistance increases, not decreases, the workload on the heart. CHF can result from various cardiovascular issues, not just lung disease.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15790,7 +15790,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bc663a63"],
-		"explanation": "Beta blockers decrease sympathetic nervous system activity, which is beneficial in CHF. ACE inhibitors, cardiac glycosides, potassium-sparing diuretics, and vasodilators have different mechanisms of action.",
+		"rationale": "Beta blockers decrease sympathetic nervous system activity, which is beneficial in CHF. ACE inhibitors, cardiac glycosides, potassium-sparing diuretics, and vasodilators have different mechanisms of action.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15824,7 +15824,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["af536191"],
-		"explanation": "ACE inhibitors prevent vasoconstriction by inhibiting the formation of angiotensin II. They do not increase cardiac contraction force, block beta-adrenergic receptors, increase aldosterone secretion, or decrease bradykinin levels.",
+		"rationale": "ACE inhibitors prevent vasoconstriction by inhibiting the formation of angiotensin II. They do not increase cardiac contraction force, block beta-adrenergic receptors, increase aldosterone secretion, or decrease bradykinin levels.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15858,7 +15858,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8e5cf9a0", "eca55c0d", "82a99da9"],
-		"explanation": "Angiotensin II causes vasoconstriction, vascular tissue hypertrophy, and increased workload on the heart. It increases, not decreases, aldosterone secretion and blood volume.",
+		"rationale": "Angiotensin II causes vasoconstriction, vascular tissue hypertrophy, and increased workload on the heart. It increases, not decreases, aldosterone secretion and blood volume.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15892,7 +15892,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["76ad3489", "7657545f"],
-		"explanation": "Eplerenone and spironolactone are potassium-sparing diuretics. Furosemide and hydrochlorothiazide are not potassium-sparing, and isosorbide is a vasodilator.",
+		"rationale": "Eplerenone and spironolactone are potassium-sparing diuretics. Furosemide and hydrochlorothiazide are not potassium-sparing, and isosorbide is a vasodilator.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15926,7 +15926,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7f829b8d", "fdec8485"],
-		"explanation": "Beta blockers reduce cardiac contraction force and block the effects of norepinephrine and epinephrine. They decrease heart rate and angina, and are effective in CHF treatment.",
+		"rationale": "Beta blockers reduce cardiac contraction force and block the effects of norepinephrine and epinephrine. They decrease heart rate and angina, and are effective in CHF treatment.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15960,7 +15960,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["24c329c7", "8e6dea45"],
-		"explanation": "Bradykinin causes vasodilation and decreased vascular resistance. It does not increase blood pressure, cardiac workload, or directly affect aldosterone secretion.",
+		"rationale": "Bradykinin causes vasodilation and decreased vascular resistance. It does not increase blood pressure, cardiac workload, or directly affect aldosterone secretion.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -15994,7 +15994,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["daac288b", "00c55a30", "4b65766f"],
-		"explanation": "Fosinopril, benazepril, and captopril are ACE inhibitors. Metoprolol is a beta blocker, and digoxin is a cardiac glycoside.",
+		"rationale": "Fosinopril, benazepril, and captopril are ACE inhibitors. Metoprolol is a beta blocker, and digoxin is a cardiac glycoside.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16028,7 +16028,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["be4d4cd3", "c2f98a8e", "a1edc4ef"],
-		"explanation": "CHF compensatory mechanisms include increased sympathetic nervous system activity, increased aldosterone secretion, and increased heart rate. Renin release increases, and peripheral resistance typically increases, not decreases.",
+		"rationale": "CHF compensatory mechanisms include increased sympathetic nervous system activity, increased aldosterone secretion, and increased heart rate. Renin release increases, and peripheral resistance typically increases, not decreases.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16062,7 +16062,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8bcbf842", "67251e55"],
-		"explanation": "Vasodilators decrease preload cardiac volume and include hydralazine and isosorbide. They decrease, not increase, peripheral resistance, and are not primarily used to treat angina or increase cardiac contraction force.",
+		"rationale": "Vasodilators decrease preload cardiac volume and include hydralazine and isosorbide. They decrease, not increase, peripheral resistance, and are not primarily used to treat angina or increase cardiac contraction force.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16096,7 +16096,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["84428ca6", "085f0775"],
-		"explanation": "Cardiac glycosides increase the force of heart muscle contraction (positive inotropic effect) and decrease the velocity of action potential conduction through the AV node. They are not first-line agents in heart failure and are derived from natural sources like foxgloves. They have a narrow therapeutic window.",
+		"rationale": "Cardiac glycosides increase the force of heart muscle contraction (positive inotropic effect) and decrease the velocity of action potential conduction through the AV node. They are not first-line agents in heart failure and are derived from natural sources like foxgloves. They have a narrow therapeutic window.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16130,7 +16130,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["028c25db", "dabf2844", "4d5d7dd2"],
-		"explanation": "Digoxin, dobutamine, and isoprenaline are positive inotropic agents. Spironolactone is a potassium-sparing diuretic, and hydralazine is a vasodilator.",
+		"rationale": "Digoxin, dobutamine, and isoprenaline are positive inotropic agents. Spironolactone is a potassium-sparing diuretic, and hydralazine is a vasodilator.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16164,7 +16164,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f6cc2d5", "663fd112"],
-		"explanation": "Cardiac glycosides inhibit the Na+/K+-ATPase pump, leading to increased intracellular calcium, which enhances cardiac contractility. They do not block beta-adrenergic receptors, decrease preload, or enhance sodium reabsorption in the kidneys.",
+		"rationale": "Cardiac glycosides inhibit the Na+/K+-ATPase pump, leading to increased intracellular calcium, which enhances cardiac contractility. They do not block beta-adrenergic receptors, decrease preload, or enhance sodium reabsorption in the kidneys.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16198,7 +16198,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["61f2d125", "e5fae20a", "85fc85ef"],
-		"explanation": "Digoxin can cause bradycardia, has a narrow therapeutic index, and can lead to visual disturbances. It is more likely to cause hypokalemia rather than hyperkalemia and does not typically cause hypertension.",
+		"rationale": "Digoxin can cause bradycardia, has a narrow therapeutic index, and can lead to visual disturbances. It is more likely to cause hypokalemia rather than hyperkalemia and does not typically cause hypertension.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16232,7 +16232,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b5b2c6b3", "fdbb0b9a", "40a84532"],
-		"explanation": "Positive inotropic drugs are indicated in cardiogenic shock following myocardial infarction, acute decompensated heart failure, and septic shock. They are not typically used for chronic stable angina or hypertrophic cardiomyopathy.",
+		"rationale": "Positive inotropic drugs are indicated in cardiogenic shock following myocardial infarction, acute decompensated heart failure, and septic shock. They are not typically used for chronic stable angina or hypertrophic cardiomyopathy.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16266,7 +16266,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2ece9228", "f55ae2dc", "2398398a"],
-		"explanation": "Amiodarone, verapamil, and erythromycin can interact with digoxin, affecting its pharmacokinetics and pharmacodynamics. Lisinopril and metformin do not have significant interactions with digoxin.",
+		"rationale": "Amiodarone, verapamil, and erythromycin can interact with digoxin, affecting its pharmacokinetics and pharmacodynamics. Lisinopril and metformin do not have significant interactions with digoxin.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16300,7 +16300,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a4a70468", "1d4d48d8", "13b3db14"],
-		"explanation": "When using digoxin, it is important to monitor renal function, adjust the dose based on plasma concentration, and combine with potassium-sparing diuretics cautiously. It is not a first-line agent and can be used in patients with atrial fibrillation.",
+		"rationale": "When using digoxin, it is important to monitor renal function, adjust the dose based on plasma concentration, and combine with potassium-sparing diuretics cautiously. It is not a first-line agent and can be used in patients with atrial fibrillation.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16334,7 +16334,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c2ee6ecf", "8c88163b"],
-		"explanation": "Digoxin has a long half-life and a narrow therapeutic window. It is primarily excreted by the kidneys, not the liver, is not highly protein-bound, and is absorbed at a moderate rate in the gastrointestinal tract.",
+		"rationale": "Digoxin has a long half-life and a narrow therapeutic window. It is primarily excreted by the kidneys, not the liver, is not highly protein-bound, and is absorbed at a moderate rate in the gastrointestinal tract.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16368,7 +16368,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d698b041", "c0c43b3b", "da1b4558"],
-		"explanation": "Digoxin is contraindicated in ventricular fibrillation, hypokalemia, and severe renal impairment due to the risk of toxicity. It can be used in atrial flutter and hyperthyroidism with caution.",
+		"rationale": "Digoxin is contraindicated in ventricular fibrillation, hypokalemia, and severe renal impairment due to the risk of toxicity. It can be used in atrial flutter and hyperthyroidism with caution.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16402,7 +16402,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b314ef66", "323e9afe", "bfaf3a4b"],
-		"explanation": "Positive inotropic drugs are indicated for acute conditions with low cardiac output, such as cardiogenic shock following myocardial infarction, acute decompensated heart failure, and low cardiac output states after cardiac surgery. They are not typically used for chronic stable angina or hypertensive crisis.",
+		"rationale": "Positive inotropic drugs are indicated for acute conditions with low cardiac output, such as cardiogenic shock following myocardial infarction, acute decompensated heart failure, and low cardiac output states after cardiac surgery. They are not typically used for chronic stable angina or hypertensive crisis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16436,7 +16436,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["015c23e1", "89df53f7", "d58f3adc"],
-		"explanation": "Dobutamine, isoprenaline, and noradrenaline are catecholamines used as positive inotropic agents. Digoxin is a cardiac glycoside, and spironolactone is a potassium-sparing diuretic.",
+		"rationale": "Dobutamine, isoprenaline, and noradrenaline are catecholamines used as positive inotropic agents. Digoxin is a cardiac glycoside, and spironolactone is a potassium-sparing diuretic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16470,7 +16470,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["df1d947c", "3db04fd3"],
-		"explanation": "Digoxin can slow conduction through the AV node and is derived from the Digitalis plant. It is not a first-line treatment for heart failure and is not a synthetic catecholamine.",
+		"rationale": "Digoxin can slow conduction through the AV node and is derived from the Digitalis plant. It is not a first-line treatment for heart failure and is not a synthetic catecholamine.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16500,7 +16500,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1b4e7fad", "62418665"],
-		"explanation": "Hydralazine and isosorbide are vasodilators that decrease preload in the treatment of CHF. Eplerenone is a potassium-sparing diuretic, dobutamine is a positive inotrope, and digitoxin is a cardiac glycoside.",
+		"rationale": "Hydralazine and isosorbide are vasodilators that decrease preload in the treatment of CHF. Eplerenone is a potassium-sparing diuretic, dobutamine is a positive inotrope, and digitoxin is a cardiac glycoside.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16534,7 +16534,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6a85d403", "718a33b3", "7fde61d0"],
-		"explanation": "Catecholamines like isoprenaline can cause tachycardia, hypotension, and arrhythmias. They are not typically associated with bradycardia or hypertension.",
+		"rationale": "Catecholamines like isoprenaline can cause tachycardia, hypotension, and arrhythmias. They are not typically associated with bradycardia or hypertension.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16568,7 +16568,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fef94528", "d55b3d8d"],
-		"explanation": "Digoxin may be considered when ACE inhibitors and beta-blockers are insufficient and in patients with heart failure and atrial fibrillation. It is not a first-line agent for all heart failure patients and is not typically used in hypertrophic cardiomyopathy.",
+		"rationale": "Digoxin may be considered when ACE inhibitors and beta-blockers are insufficient and in patients with heart failure and atrial fibrillation. It is not a first-line agent for all heart failure patients and is not typically used in hypertrophic cardiomyopathy.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16598,7 +16598,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["61578952", "df3b6bf5"],
-		"explanation": "Cardiac glycosides decrease AV node conduction velocity and increase the force of cardiac contraction. They do not increase heart rate, cause vasoconstriction, or increase preload.",
+		"rationale": "Cardiac glycosides decrease AV node conduction velocity and increase the force of cardiac contraction. They do not increase heart rate, cause vasoconstriction, or increase preload.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16632,7 +16632,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["435a3adc", "3c451bc5"],
-		"explanation": "PDE5 inhibitors enhance the effects of nitric oxide by inhibiting cGMP hydrolysis, not by directly increasing nitric oxide production. They are structurally similar to cGMP, allowing them to competitively inhibit PDE5. They are not used for respiratory disorders, and they increase, not decrease, blood flow to the penis.",
+		"rationale": "PDE5 inhibitors enhance the effects of nitric oxide by inhibiting cGMP hydrolysis, not by directly increasing nitric oxide production. They are structurally similar to cGMP, allowing them to competitively inhibit PDE5. They are not used for respiratory disorders, and they increase, not decrease, blood flow to the penis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16666,7 +16666,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["68180428", "d46ac720"],
-		"explanation": "Milrinone is a PDE3 inhibitor associated with ventricular arrhythmias. Theophylline, although primarily used for respiratory disorders, also inhibits PDE3. Sildenafil and tadalafil are PDE5 inhibitors, and dipyridamole is not a PDE3 inhibitor.",
+		"rationale": "Milrinone is a PDE3 inhibitor associated with ventricular arrhythmias. Theophylline, although primarily used for respiratory disorders, also inhibits PDE3. Sildenafil and tadalafil are PDE5 inhibitors, and dipyridamole is not a PDE3 inhibitor.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16700,7 +16700,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["196014fc"],
-		"explanation": "Heparin binds to antithrombin III, leading to the inactivation of thrombin and factor Xa. It does not dissolve clots, increase platelet aggregation, act as a thrombolytic agent, or enhance the synthesis of vitamin K-dependent clotting factors.",
+		"rationale": "Heparin binds to antithrombin III, leading to the inactivation of thrombin and factor Xa. It does not dissolve clots, increase platelet aggregation, act as a thrombolytic agent, or enhance the synthesis of vitamin K-dependent clotting factors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16734,7 +16734,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cc8608e6", "058600a2", "a02b90b1"],
-		"explanation": "Common side effects of PDE3 inhibitors include ventricular arrhythmias, headaches, and hypotension. They cause vasodilation, not hypertension, and increased myocardial contractility is a mechanism of action, not a side effect.",
+		"rationale": "Common side effects of PDE3 inhibitors include ventricular arrhythmias, headaches, and hypotension. They cause vasodilation, not hypertension, and increased myocardial contractility is a mechanism of action, not a side effect.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16768,7 +16768,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["36139819", "e69ccba8"],
-		"explanation": "Terazosin and tamsulosin are alpha blockers used to treat BPH. Sildenafil is a PDE5 inhibitor, phentolamine is used for other conditions like pheochromocytoma, and dipyridamole is not an alpha blocker.",
+		"rationale": "Terazosin and tamsulosin are alpha blockers used to treat BPH. Sildenafil is a PDE5 inhibitor, phentolamine is used for other conditions like pheochromocytoma, and dipyridamole is not an alpha blocker.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16802,7 +16802,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a321d939"],
-		"explanation": "Dipyridamole is being investigated for use in diabetic retinopathy due to its PDE-inhibition properties. The other drugs listed are not being investigated for this purpose.",
+		"rationale": "Dipyridamole is being investigated for use in diabetic retinopathy due to its PDE-inhibition properties. The other drugs listed are not being investigated for this purpose.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16836,7 +16836,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a1fa33d5", "832384ed"],
-		"explanation": "Alpha blockers can be used to treat Raynaud's syndrome and are used to treat urinary symptoms related to prostate enlargement. They are not first-line medications for hypertension, do not treat respiratory disorders, and do not antagonize beta receptors.",
+		"rationale": "Alpha blockers can be used to treat Raynaud's syndrome and are used to treat urinary symptoms related to prostate enlargement. They are not first-line medications for hypertension, do not treat respiratory disorders, and do not antagonize beta receptors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16870,7 +16870,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bdef1281", "74f2f80a"],
-		"explanation": "Common side effects of dipyridamole include GI upset and dizziness. It does not cause hypertension, increased platelet aggregation, or ventricular arrhythmias.",
+		"rationale": "Common side effects of dipyridamole include GI upset and dizziness. It does not cause hypertension, increased platelet aggregation, or ventricular arrhythmias.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16904,7 +16904,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6b1b96fa"],
-		"explanation": "Phentolamine is used in the diagnosis of pheochromocytoma. The other drugs listed are not used for this purpose.",
+		"rationale": "Phentolamine is used in the diagnosis of pheochromocytoma. The other drugs listed are not used for this purpose.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16938,7 +16938,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8df4461b", "4d8388be"],
-		"explanation": "Theophylline is a non-selective phosphodiesterase inhibitor and is commonly used for respiratory disorders. It is not a selective PDE5 inhibitor, is not primarily used for erectile dysfunction, and does not cause vasoconstriction.",
+		"rationale": "Theophylline is a non-selective phosphodiesterase inhibitor and is commonly used for respiratory disorders. It is not a selective PDE5 inhibitor, is not primarily used for erectile dysfunction, and does not cause vasoconstriction.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -16972,7 +16972,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f9cb4261"],
-		"explanation": "Class II antiarrhythmics are conventional beta blockers, not calcium channel blockers, and they do not primarily affect potassium efflux. They are used to manage arrhythmias, not specifically for treating angina.",
+		"rationale": "Class II antiarrhythmics are conventional beta blockers, not calcium channel blockers, and they do not primarily affect potassium efflux. They are used to manage arrhythmias, not specifically for treating angina.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17002,7 +17002,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4e52bac9"],
-		"explanation": "Dronedarone is a Class III antiarrhythmic. Verapamil is a Class IV antiarrhythmic, lidocaine is a Class Ib antiarrhythmic, and flecainide is a Class Ic antiarrhythmic.",
+		"rationale": "Dronedarone is a Class III antiarrhythmic. Verapamil is a Class IV antiarrhythmic, lidocaine is a Class Ib antiarrhythmic, and flecainide is a Class Ic antiarrhythmic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17032,7 +17032,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2189a009"],
-		"explanation": "Amiodarone commonly causes corneal verticillata or \"whorl-like opacities.\" It does not typically cause retinal detachment, glaucoma, or macular degeneration.",
+		"rationale": "Amiodarone commonly causes corneal verticillata or \"whorl-like opacities.\" It does not typically cause retinal detachment, glaucoma, or macular degeneration.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17062,7 +17062,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["412f2c10"],
-		"explanation": "Amiodarone should not be given alongside sofosbuvir due to a risk of severe bradycardia and heart block. Digoxin, verapamil, and diltiazem do not have this specific interaction with amiodarone.",
+		"rationale": "Amiodarone should not be given alongside sofosbuvir due to a risk of severe bradycardia and heart block. Digoxin, verapamil, and diltiazem do not have this specific interaction with amiodarone.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17092,7 +17092,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2f0763e3"],
-		"explanation": "Disopyramide is a Class Ia antiarrhythmic with significant anticholinergic properties, leading to dry eye, dry mouth, decreased urination, and increased constipation. Lidocaine is Class Ib, propafenone is Class Ic, and dronedarone is Class III.",
+		"rationale": "Disopyramide is a Class Ia antiarrhythmic with significant anticholinergic properties, leading to dry eye, dry mouth, decreased urination, and increased constipation. Lidocaine is Class Ib, propafenone is Class Ic, and dronedarone is Class III.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17122,7 +17122,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f0889c6c"],
-		"explanation": "Magnesium sulfate is used to treat torsades de pointes. Adenosine is used for terminating supraventricular tachycardias, digoxin is used for congestive heart failure and atrial fibrillation, and flecainide is used for various arrhythmias.",
+		"rationale": "Magnesium sulfate is used to treat torsades de pointes. Adenosine is used for terminating supraventricular tachycardias, digoxin is used for congestive heart failure and atrial fibrillation, and flecainide is used for various arrhythmias.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17152,7 +17152,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["24dd93ec"],
-		"explanation": "Nitrates cause vasodilation by activating soluble guanylyl cyclase. They treat the symptoms, not the underlying cause, of angina and are not used to treat arrhythmias. They cause vasodilation, not vasoconstriction.",
+		"rationale": "Nitrates cause vasodilation by activating soluble guanylyl cyclase. They treat the symptoms, not the underlying cause, of angina and are not used to treat arrhythmias. They cause vasodilation, not vasoconstriction.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17182,7 +17182,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7448a135"],
-		"explanation": "Diltiazem is a Class IV antiarrhythmic. Lidocaine is Class Ib, amiodarone is Class III, and propafenone is Class Ic.",
+		"rationale": "Diltiazem is a Class IV antiarrhythmic. Lidocaine is Class Ib, amiodarone is Class III, and propafenone is Class Ic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17212,7 +17212,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d39848b2"],
-		"explanation": "Lidocaine can be used to treat ventricular arrhythmias and as an alternative for cardiopulmonary resuscitation if amiodarone is not available. Flecainide, verapamil, and disopyramide are not used for this purpose.",
+		"rationale": "Lidocaine can be used to treat ventricular arrhythmias and as an alternative for cardiopulmonary resuscitation if amiodarone is not available. Flecainide, verapamil, and disopyramide are not used for this purpose.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17242,7 +17242,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["45e54fe9"],
-		"explanation": "Propafenone is mainly used under specialist supervision in hospitals to treat supraventricular arrhythmias. Flecainide is used for various arrhythmias, dronedarone is a Class III antiarrhythmic, and digoxin is used for congestive heart failure and atrial fibrillation.",
+		"rationale": "Propafenone is mainly used under specialist supervision in hospitals to treat supraventricular arrhythmias. Flecainide is used for various arrhythmias, dronedarone is a Class III antiarrhythmic, and digoxin is used for congestive heart failure and atrial fibrillation.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17272,7 +17272,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d64dda67"],
-		"explanation": "Lidocaine is both a local anesthetic and a Class Ib antiarrhythmic. Disopyramide is Class Ia, flecainide is Class Ic, and verapamil is Class IV.",
+		"rationale": "Lidocaine is both a local anesthetic and a Class Ib antiarrhythmic. Disopyramide is Class Ia, flecainide is Class Ic, and verapamil is Class IV.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17302,7 +17302,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c05fe1cb", "caa87a29"],
-		"explanation": "Disopyramide and dronedarone are used to maintain sinus rhythm after cardioversion. Propafenone is used for supraventricular arrhythmias, and adenosine is used for terminating supraventricular tachycardias.",
+		"rationale": "Disopyramide and dronedarone are used to maintain sinus rhythm after cardioversion. Propafenone is used for supraventricular arrhythmias, and adenosine is used for terminating supraventricular tachycardias.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17332,7 +17332,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["08c0e00c"],
-		"explanation": "Verapamil is a Class IV antiarrhythmic that decreases AV node conduction and shortens the action potential plateau. Amiodarone is Class III, lidocaine is Class Ib, and flecainide is Class Ic.",
+		"rationale": "Verapamil is a Class IV antiarrhythmic that decreases AV node conduction and shortens the action potential plateau. Amiodarone is Class III, lidocaine is Class Ib, and flecainide is Class Ic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17362,7 +17362,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1298dee6"],
-		"explanation": "Digoxin is used to treat congestive heart failure and atrial fibrillation. Adenosine is used for terminating supraventricular tachycardias, magnesium sulfate is used for torsades de pointes, and dronedarone is a Class III antiarrhythmic.",
+		"rationale": "Digoxin is used to treat congestive heart failure and atrial fibrillation. Adenosine is used for terminating supraventricular tachycardias, magnesium sulfate is used for torsades de pointes, and dronedarone is a Class III antiarrhythmic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17392,7 +17392,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c89e7f52"],
-		"explanation": "Flecainide is a Class Ic antiarrhythmic. Lidocaine is Class Ib, dronedarone is Class III, and verapamil is Class IV.",
+		"rationale": "Flecainide is a Class Ic antiarrhythmic. Lidocaine is Class Ib, dronedarone is Class III, and verapamil is Class IV.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17422,7 +17422,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["07ce996f"],
-		"explanation": "Adenosine is used intravenously for terminating supraventricular tachycardias. Digoxin is used for congestive heart failure and atrial fibrillation, magnesium sulfate is used for torsades de pointes, and disopyramide is a Class Ia antiarrhythmic.",
+		"rationale": "Adenosine is used intravenously for terminating supraventricular tachycardias. Digoxin is used for congestive heart failure and atrial fibrillation, magnesium sulfate is used for torsades de pointes, and disopyramide is a Class Ia antiarrhythmic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17452,7 +17452,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["19ea6459"],
-		"explanation": "Glyceryl trinitrate (GTN) is a nitrate used to treat angina symptoms. Verapamil is a Class IV antiarrhythmic, lidocaine is a Class Ib antiarrhythmic, and flecainide is a Class Ic antiarrhythmic.",
+		"rationale": "Glyceryl trinitrate (GTN) is a nitrate used to treat angina symptoms. Verapamil is a Class IV antiarrhythmic, lidocaine is a Class Ib antiarrhythmic, and flecainide is a Class Ic antiarrhythmic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17482,7 +17482,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8d44f135"],
-		"explanation": "Disopyramide has significant anticholinergic properties. Dronedarone, propafenone, and adenosine do not have significant anticholinergic properties.",
+		"rationale": "Disopyramide has significant anticholinergic properties. Dronedarone, propafenone, and adenosine do not have significant anticholinergic properties.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17512,7 +17512,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bd257731"],
-		"explanation": "Dronedarone is used to treat life-threatening atrial flutter and fibrillation. Lidocaine is used for ventricular arrhythmias, verapamil is a Class IV antiarrhythmic, and lisinopril is used for hypertension.",
+		"rationale": "Dronedarone is used to treat life-threatening atrial flutter and fibrillation. Lidocaine is used for ventricular arrhythmias, verapamil is a Class IV antiarrhythmic, and lisinopril is used for hypertension.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17542,7 +17542,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a466a91f"],
-		"explanation": "Amiodarone is a Class III antiarrhythmic that primarily affects potassium efflux. Verapamil is a Class IV antiarrhythmic, lidocaine is a Class Ib antiarrhythmic, and flecainide is a Class Ic antiarrhythmic.",
+		"rationale": "Amiodarone is a Class III antiarrhythmic that primarily affects potassium efflux. Verapamil is a Class IV antiarrhythmic, lidocaine is a Class Ib antiarrhythmic, and flecainide is a Class Ic antiarrhythmic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17572,7 +17572,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2040b843", "8591533a"],
-		"explanation": "Class IV antiarrhythmics are slow calcium channel blockers that decrease AV node conduction. Verapamil and diltiazem are examples. They shorten, not prolong, the action potential plateau.",
+		"rationale": "Class IV antiarrhythmics are slow calcium channel blockers that decrease AV node conduction. Verapamil and diltiazem are examples. They shorten, not prolong, the action potential plateau.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17602,7 +17602,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ee04f315"],
-		"explanation": "Magnesium sulfate is used to treat torsades de pointes. Verapamil and adenosine are used for other types of arrhythmias, and digoxin is used for atrial fibrillation and heart failure.",
+		"rationale": "Magnesium sulfate is used to treat torsades de pointes. Verapamil and adenosine are used for other types of arrhythmias, and digoxin is used for atrial fibrillation and heart failure.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17632,7 +17632,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cd37a916", "8ba44eb6"],
-		"explanation": "Nitrates cause vasodilation by activating soluble guanylyl cyclase and are used for both prophylaxis and treatment of angina. They treat symptoms, not the underlying cause, and isosorbide dinitrate is slower to act than GTN.",
+		"rationale": "Nitrates cause vasodilation by activating soluble guanylyl cyclase and are used for both prophylaxis and treatment of angina. They treat symptoms, not the underlying cause, and isosorbide dinitrate is slower to act than GTN.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17662,7 +17662,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["29f3fab5"],
-		"explanation": "Ivabradine reduces heart rate without affecting myocardial contractility and is used for angina patients in normal sinus rhythm. It is administered orally, not intravenously.",
+		"rationale": "Ivabradine reduces heart rate without affecting myocardial contractility and is used for angina patients in normal sinus rhythm. It is administered orally, not intravenously.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17692,7 +17692,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["353cbafd"],
-		"explanation": "Verapamil can exacerbate heart failure due to its negative inotropic effects. Diltiazem is less likely to do so, and nicorandil and isosorbide mononitrate are primarily vasodilators.",
+		"rationale": "Verapamil can exacerbate heart failure due to its negative inotropic effects. Diltiazem is less likely to do so, and nicorandil and isosorbide mononitrate are primarily vasodilators.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17722,7 +17722,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6b3dbb9d", "f92e2305", "9be63a79"],
-		"explanation": "Vasodilators act on cyclic AMP and ATP-sensitive potassium channels. Minoxidil is also used for hair loss, and hydralazine is used for eclampsia. They are reserved for severe and resistant hypertension, not first-line treatment.",
+		"rationale": "Vasodilators act on cyclic AMP and ATP-sensitive potassium channels. Minoxidil is also used for hair loss, and hydralazine is used for eclampsia. They are reserved for severe and resistant hypertension, not first-line treatment.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17752,7 +17752,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e9a91d27"],
-		"explanation": "Adenosine is used intravenously for terminating supraventricular tachycardias. Digoxin is used for atrial fibrillation and heart failure, magnesium sulfate for torsades de pointes, and verapamil for other arrhythmias.",
+		"rationale": "Adenosine is used intravenously for terminating supraventricular tachycardias. Digoxin is used for atrial fibrillation and heart failure, magnesium sulfate for torsades de pointes, and verapamil for other arrhythmias.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17782,7 +17782,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bc3150b1", "94562860"],
-		"explanation": "Isosorbide mononitrate is used for the prophylaxis of angina and reduces cardiac preload by predominantly relaxing venous smooth muscle. It is not administered as a sublingual aerosol spray.",
+		"rationale": "Isosorbide mononitrate is used for the prophylaxis of angina and reduces cardiac preload by predominantly relaxing venous smooth muscle. It is not administered as a sublingual aerosol spray.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17812,7 +17812,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4461d30f", "bdd7554b"],
-		"explanation": "Class V antiarrhythmics include digoxin and adenosine. Verapamil and diltiazem are Class IV antiarrhythmics.",
+		"rationale": "Class V antiarrhythmics include digoxin and adenosine. Verapamil and diltiazem are Class IV antiarrhythmics.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17842,7 +17842,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6b1c3115"],
-		"explanation": "Nicorandil is a potassium channel activator with vasodilating properties. Isosorbide dinitrate is a nitrate, verapamil is a calcium channel blocker, and hydralazine is a vasodilator but not a potassium channel activator.",
+		"rationale": "Nicorandil is a potassium channel activator with vasodilating properties. Isosorbide dinitrate is a nitrate, verapamil is a calcium channel blocker, and hydralazine is a vasodilator but not a potassium channel activator.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17872,7 +17872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a7385f6d", "a3221151"],
-		"explanation": "Dipyridamole stimulates the release of prostacyclin and inhibits phosphodiesterase-3 and -5, leading to increased cAMP levels and reduced platelet aggregation. It does not inhibit thromboxane A2 synthesis, bind to P2Y12 receptors, or activate antithrombin III.",
+		"rationale": "Dipyridamole stimulates the release of prostacyclin and inhibits phosphodiesterase-3 and -5, leading to increased cAMP levels and reduced platelet aggregation. It does not inhibit thromboxane A2 synthesis, bind to P2Y12 receptors, or activate antithrombin III.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17906,7 +17906,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["345e614d", "18b2359d", "508ec81a"],
-		"explanation": "Clopidogrel is a prodrug that requires activation and works by irreversibly binding to P2Y12 receptors, preventing ADP-mediated platelet aggregation. In general, blood thinning agents should NOT be combined. It does not bind to COX-1 and is not contraindicated in patients with a history of stroke.",
+		"rationale": "Clopidogrel is a prodrug that requires activation and works by irreversibly binding to P2Y12 receptors, preventing ADP-mediated platelet aggregation. In general, blood thinning agents should NOT be combined. It does not bind to COX-1 and is not contraindicated in patients with a history of stroke.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17940,7 +17940,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fbdaa420", "056790b2", "9245dbbe"],
-		"explanation": "Dipyridamole can cause bleeding, GI upset, and dizziness. It does not typically cause hypertension or bradycardia.",
+		"rationale": "Dipyridamole can cause bleeding, GI upset, and dizziness. It does not typically cause hypertension or bradycardia.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -17974,7 +17974,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0e782eed", "13fa3039"],
-		"explanation": "Heparin enhances the activity of antithrombin III, preventing the progression of existing clots. It is not a thrombolytic agent and does not dissolve clots. It does not require continuous infusion due to a short half-life; this is a characteristic of epoprostenol.",
+		"rationale": "Heparin enhances the activity of antithrombin III, preventing the progression of existing clots. It is not a thrombolytic agent and does not dissolve clots. It does not require continuous infusion due to a short half-life; this is a characteristic of epoprostenol.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18008,7 +18008,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1c1788d0"],
-		"explanation": "Fondaparinux is indicated for the prevention of venous thrombus formation. It is not used for treating pulmonary hypertension, myocardial infarction, diabetic retinopathy, or stroke prevention in atrial fibrillation.",
+		"rationale": "Fondaparinux is indicated for the prevention of venous thrombus formation. It is not used for treating pulmonary hypertension, myocardial infarction, diabetic retinopathy, or stroke prevention in atrial fibrillation.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18042,7 +18042,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0c8edf50"],
-		"explanation": "Epoprostenol can be used to prevent platelet aggregation during renal dialysis when heparins are unsuitable. Aspirin, clopidogrel, dipyridamole, and fondaparinux are not specifically indicated for this purpose.",
+		"rationale": "Epoprostenol can be used to prevent platelet aggregation during renal dialysis when heparins are unsuitable. Aspirin, clopidogrel, dipyridamole, and fondaparinux are not specifically indicated for this purpose.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18076,7 +18076,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b8119993", "d83bbe1a", "e9487228"],
-		"explanation": "Aspirin irreversibly inhibits COX-1, increases the risk of bleeding, and reduces thromboxane A2 activity. It is not a prodrug and is not used to treat ocular hypertension.",
+		"rationale": "Aspirin irreversibly inhibits COX-1, increases the risk of bleeding, and reduces thromboxane A2 activity. It is not a prodrug and is not used to treat ocular hypertension.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18110,7 +18110,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["94f9f6ad"],
-		"explanation": "Dipyridamole inhibits phosphodiesterase activity, increasing cAMP levels and inhibiting platelet function. Clopidogrel, epoprostenol, fondaparinux, and aspirin do not inhibit phosphodiesterase.",
+		"rationale": "Dipyridamole inhibits phosphodiesterase activity, increasing cAMP levels and inhibiting platelet function. Clopidogrel, epoprostenol, fondaparinux, and aspirin do not inhibit phosphodiesterase.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18144,7 +18144,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["816cef70"],
-		"explanation": "Epoprostenol is used in the management of primary pulmonary hypertension. Aspirin, clopidogrel, dipyridamole, and fondaparinux are not indicated for this condition.",
+		"rationale": "Epoprostenol is used in the management of primary pulmonary hypertension. Aspirin, clopidogrel, dipyridamole, and fondaparinux are not indicated for this condition.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18178,7 +18178,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["269163db", "957a54e9"],
-		"explanation": "Factor Xa inhibitors do not require routine laboratory monitoring and have fewer drug and food interactions compared to warfarin. They do not affect platelet aggregation and are not used for thrombolytic effects. They are used to reduce the risk of stroke in people with nonvalvular atrial fibrillation.",
+		"rationale": "Factor Xa inhibitors do not require routine laboratory monitoring and have fewer drug and food interactions compared to warfarin. They do not affect platelet aggregation and are not used for thrombolytic effects. They are used to reduce the risk of stroke in people with nonvalvular atrial fibrillation.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18212,7 +18212,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1b526c32", "c07ad5a9"],
-		"explanation": "Dabigatran and argatroban are direct thrombin inhibitors. Rivaroxaban and apixaban are Factor Xa inhibitors, while warfarin is a vitamin K antagonist.",
+		"rationale": "Dabigatran and argatroban are direct thrombin inhibitors. Rivaroxaban and apixaban are Factor Xa inhibitors, while warfarin is a vitamin K antagonist.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18246,7 +18246,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["06c8e8f0"],
-		"explanation": "Bivalirudin is primarily used as an anticoagulant during percutaneous coronary intervention. It is not used for the other listed purposes.",
+		"rationale": "Bivalirudin is primarily used as an anticoagulant during percutaneous coronary intervention. It is not used for the other listed purposes.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18280,7 +18280,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e00b8d20", "805a3970"],
-		"explanation": "Warfarin requires dietary restrictions related to vitamin K and is commonly used due to its low cost. It does not directly inhibit Factor Xa or thrombin and is not used for thrombolysis.",
+		"rationale": "Warfarin requires dietary restrictions related to vitamin K and is commonly used due to its low cost. It does not directly inhibit Factor Xa or thrombin and is not used for thrombolysis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18314,7 +18314,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b9edaa0"],
-		"explanation": "Bivalirudin is indicated for use in patients with unstable angina undergoing urgent intervention. The other drugs are not indicated for this specific use.",
+		"rationale": "Bivalirudin is indicated for use in patients with unstable angina undergoing urgent intervention. The other drugs are not indicated for this specific use.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18348,7 +18348,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["921a48fa", "f424ee61"],
-		"explanation": "Dabigatran is a prodrug that is converted to its active form in the liver. It does not require routine INR monitoring, is not a Factor Xa inhibitor, and is not used to treat heparin-induced thrombocytopenia.",
+		"rationale": "Dabigatran is a prodrug that is converted to its active form in the liver. It does not require routine INR monitoring, is not a Factor Xa inhibitor, and is not used to treat heparin-induced thrombocytopenia.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18382,7 +18382,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["25f7a90b", "5f2f088d"],
-		"explanation": "Foods high in vitamin K, such as broccoli and spinach, should be moderated while on warfarin therapy. Grapefruit, cheese, and bananas do not have significant vitamin K content.",
+		"rationale": "Foods high in vitamin K, such as broccoli and spinach, should be moderated while on warfarin therapy. Grapefruit, cheese, and bananas do not have significant vitamin K content.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18416,7 +18416,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dc76f5b0", "87b93c81"],
-		"explanation": "Acetylsalicylic acid and clopidogrel interfere with primary hemostasis. Amiodarone affects CYP 2C9, acetaminophen interferes with the vitamin K cycle, and St. John’s wort has multiple effects but does not primarily interfere with hemostasis.",
+		"rationale": "Acetylsalicylic acid and clopidogrel interfere with primary hemostasis. Amiodarone affects CYP 2C9, acetaminophen interferes with the vitamin K cycle, and St. John’s wort has multiple effects but does not primarily interfere with hemostasis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18450,7 +18450,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4a97a4b3", "cf4baefe"],
-		"explanation": "Argatroban is an oral anticoagulant used for prophylaxis in patients with heparin-induced thrombocytopenia. It is not a Factor Xa inhibitor, does not require dietary restrictions, and is not specifically used to treat deep vein thrombosis.",
+		"rationale": "Argatroban is an oral anticoagulant used for prophylaxis in patients with heparin-induced thrombocytopenia. It is not a Factor Xa inhibitor, does not require dietary restrictions, and is not specifically used to treat deep vein thrombosis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18484,7 +18484,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e3583de6"],
-		"explanation": "Dabigatran is a prodrug that is converted to its active form in vivo. Rivaroxaban, apixaban, argatroban, and warfarin are not prodrugs.",
+		"rationale": "Dabigatran is a prodrug that is converted to its active form in vivo. Rivaroxaban, apixaban, argatroban, and warfarin are not prodrugs.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18518,7 +18518,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2bc3ab9a", "0f11d76e", "3e7294c6"],
-		"explanation": "Warfarin is a vitamin K antagonist that inhibits vitamin K epoxide reductase, making options A and D correct. It can cross the placental barrier, leading to potential fetal complications, making option B correct. Warfarin does not affect blood viscosity directly, and it is not safe during pregnancy due to its potential adverse effects on the fetus, making options C and E incorrect.",
+		"rationale": "Warfarin is a vitamin K antagonist that inhibits vitamin K epoxide reductase, making options A and D correct. It can cross the placental barrier, leading to potential fetal complications, making option B correct. Warfarin does not affect blood viscosity directly, and it is not safe during pregnancy due to its potential adverse effects on the fetus, making options C and E incorrect.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18552,7 +18552,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["14ab6f3e", "73f8c606", "c891f462"],
-		"explanation": "Antibiotics like co-trimoxazole and metronidazole, antifungals like fluconazole, and serotonergic antidepressants increase the risk of hemorrhage when used with warfarin due to their effects on vitamin K synthesis and CYP 2C9 inhibition, making options A, C, and D correct. Rifampin decreases the risk of hemorrhage by inducing CYP 2C9, and St. John’s wort decreases warfarin's effectiveness, making options B and E incorrect.",
+		"rationale": "Antibiotics like co-trimoxazole and metronidazole, antifungals like fluconazole, and serotonergic antidepressants increase the risk of hemorrhage when used with warfarin due to their effects on vitamin K synthesis and CYP 2C9 inhibition, making options A, C, and D correct. Rifampin decreases the risk of hemorrhage by inducing CYP 2C9, and St. John’s wort decreases warfarin's effectiveness, making options B and E incorrect.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18586,7 +18586,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["497313d7", "d61da17f", "9bbd875a", "531d1153"],
-		"explanation": "Rivaroxaban and apixaban inhibit platelet activation and fibrin clot formation, making option A correct. Dabigatran is a direct thrombin inhibitor and a prodrug, making options B and D correct. Factor Xa inhibitors are alternatives to warfarin, making option E correct. Unlike warfarin, Factor Xa inhibitors do not require frequent INR monitoring, making option C incorrect.",
+		"rationale": "Rivaroxaban and apixaban inhibit platelet activation and fibrin clot formation, making option A correct. Dabigatran is a direct thrombin inhibitor and a prodrug, making options B and D correct. Factor Xa inhibitors are alternatives to warfarin, making option E correct. Unlike warfarin, Factor Xa inhibitors do not require frequent INR monitoring, making option C incorrect.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18620,7 +18620,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5f97b2a9", "442b14f6", "f88726cb"],
-		"explanation": "Foods high in vitamin K, such as broccoli, spinach, and kale, should be moderated or avoided while on warfarin therapy, making options A, B, and D correct. Grapefruit and bananas do not have high vitamin K content, making options C and E incorrect.",
+		"rationale": "Foods high in vitamin K, such as broccoli, spinach, and kale, should be moderated or avoided while on warfarin therapy, making options A, B, and D correct. Grapefruit and bananas do not have high vitamin K content, making options C and E incorrect.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18654,7 +18654,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["599b0c57", "0aa6aea9", "c71d563e", "ea5fb226"],
-		"explanation": "Warfarin use is associated with adverse effects such as necrosis, purple toe syndrome, osteoporosis, and valve and artery calcification, making options A, B, C, and E correct. Hyperkalemia is not a documented adverse effect of warfarin, making option D incorrect.",
+		"rationale": "Warfarin use is associated with adverse effects such as necrosis, purple toe syndrome, osteoporosis, and valve and artery calcification, making options A, B, C, and E correct. Hyperkalemia is not a documented adverse effect of warfarin, making option D incorrect.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18688,7 +18688,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["25347d12", "93205b19"],
-		"explanation": "Streptokinase is a bacterial enzyme, not a recombinant version of t-PA (A is incorrect). Alteplase binds to fibrinogen and fibrin (B is correct). Tenecteplase has a longer duration of action than endogenous t-PA (C is correct). Reteplase has less fibrin specificity compared to tenecteplase (D is incorrect). Thrombolytic drugs are used to dissolve existing clots, not primarily to prevent clot formation (E is incorrect).",
+		"rationale": "Streptokinase is a bacterial enzyme, not a recombinant version of t-PA (A is incorrect). Alteplase binds to fibrinogen and fibrin (B is correct). Tenecteplase has a longer duration of action than endogenous t-PA (C is correct). Reteplase has less fibrin specificity compared to tenecteplase (D is incorrect). Thrombolytic drugs are used to dissolve existing clots, not primarily to prevent clot formation (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18722,7 +18722,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44c92c81", "a5333fa0"],
-		"explanation": "Factor Xa inhibitors do not require routine laboratory monitoring (A is incorrect). They have fewer drug and food interactions (B is correct). They do not affect platelet aggregation (C is incorrect). They are used to reduce the risk of stroke in nonvalvular atrial fibrillation (D is correct). Warfarin is still used primarily for cost factors, not Factor Xa inhibitors (E is incorrect).",
+		"rationale": "Factor Xa inhibitors do not require routine laboratory monitoring (A is incorrect). They have fewer drug and food interactions (B is correct). They do not affect platelet aggregation (C is incorrect). They are used to reduce the risk of stroke in nonvalvular atrial fibrillation (D is correct). Warfarin is still used primarily for cost factors, not Factor Xa inhibitors (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18756,7 +18756,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7607630c"],
-		"explanation": "Aminocaproic acid inhibits the conversion of plasminogen to plasmin (B is correct). It does not activate plasminogen (A is incorrect). It does not stimulate prostacyclin release (C is incorrect). It does not bind to antithrombin III (D is incorrect). It does not enhance platelet aggregation (E is incorrect).",
+		"rationale": "Aminocaproic acid inhibits the conversion of plasminogen to plasmin (B is correct). It does not activate plasminogen (A is incorrect). It does not stimulate prostacyclin release (C is incorrect). It does not bind to antithrombin III (D is incorrect). It does not enhance platelet aggregation (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18790,7 +18790,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4c573d0f", "21eacc5c"],
-		"explanation": "Heparin is not a thrombolytic agent; it does not dissolve clots (A and D are incorrect). Heparin enhances the activity of antithrombin III, leading to inactivation of factors IIa and Xa (B is correct). Heparin does not directly inhibit platelet aggregation (C is incorrect). Heparin prevents the progression of existing clots by inhibiting further clotting (E is correct).",
+		"rationale": "Heparin is not a thrombolytic agent; it does not dissolve clots (A and D are incorrect). Heparin enhances the activity of antithrombin III, leading to inactivation of factors IIa and Xa (B is correct). Heparin does not directly inhibit platelet aggregation (C is incorrect). Heparin prevents the progression of existing clots by inhibiting further clotting (E is correct).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18824,7 +18824,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fbdaa420", "056790b2", "9245dbbe"],
-		"explanation": "Dipyridamole can cause bleeding (A is correct), GI upset (B is correct), and dizziness (C is correct). It is not associated with hyperfibrinolysis (D is incorrect). It is being investigated for ocular hypertension management, but it is not known to cause hypertension (E is incorrect).",
+		"rationale": "Dipyridamole can cause bleeding (A is correct), GI upset (B is correct), and dizziness (C is correct). It is not associated with hyperfibrinolysis (D is incorrect). It is being investigated for ocular hypertension management, but it is not known to cause hypertension (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18858,7 +18858,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["51065382", "ad6cfa87"],
-		"explanation": "Niacin decreases LDL and triglyceride production by 10-15% and increases HDL production by the same percentage. It is converted into NAD and NADP, which are active coenzymes. It is not primarily used to treat pancreatitis.",
+		"rationale": "Niacin decreases LDL and triglyceride production by 10-15% and increases HDL production by the same percentage. It is converted into NAD and NADP, which are active coenzymes. It is not primarily used to treat pancreatitis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18888,7 +18888,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6ba24ba0", "8397af71"],
-		"explanation": "Statins reduce LDL cholesterol levels by inhibiting HMG-CoA reductase and increasing LDL receptor expression on liver cells. Activation of PPARa and decreased synthesis of apo B are mechanisms associated with other lipid-lowering agents, not statins.",
+		"rationale": "Statins reduce LDL cholesterol levels by inhibiting HMG-CoA reductase and increasing LDL receptor expression on liver cells. Activation of PPARa and decreased synthesis of apo B are mechanisms associated with other lipid-lowering agents, not statins.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18918,7 +18918,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e8961530", "7cafd1ec"],
-		"explanation": "Common side effects of gemfibrozil include GI upset and dizziness. Cystoid macular edema is a rare side effect of niacin, and dry cough is associated with ACE inhibitors, not gemfibrozil.",
+		"rationale": "Common side effects of gemfibrozil include GI upset and dizziness. Cystoid macular edema is a rare side effect of niacin, and dry cough is associated with ACE inhibitors, not gemfibrozil.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18948,7 +18948,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9da85d1e", "051e1828"],
-		"explanation": "Pravastatin and rosuvastatin are hydrophilic statins. Atorvastatin and simvastatin are lipophilic.",
+		"rationale": "Pravastatin and rosuvastatin are hydrophilic statins. Atorvastatin and simvastatin are lipophilic.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -18978,7 +18978,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["78286401", "d6e9c200"],
-		"explanation": "Statins have pleiotropic effects such as anti-inflammatory effects and stabilization of atherosclerotic plaques. They do not increase triglyceride synthesis or the risk of dementia; in fact, they may reduce the risk of dementia.",
+		"rationale": "Statins have pleiotropic effects such as anti-inflammatory effects and stabilization of atherosclerotic plaques. They do not increase triglyceride synthesis or the risk of dementia; in fact, they may reduce the risk of dementia.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19008,7 +19008,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["80941e1d", "0a4c7dde"],
-		"explanation": "Gemfibrozil activates PPARa and increases apo AI and apo AII. It does not inhibit HMG-CoA reductase, which is the mechanism of statins, and it actually increases peripheral lipolysis.",
+		"rationale": "Gemfibrozil activates PPARa and increases apo AI and apo AII. It does not inhibit HMG-CoA reductase, which is the mechanism of statins, and it actually increases peripheral lipolysis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19038,7 +19038,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3f3dbb90", "f8366102", "80422850"],
-		"explanation": "Niacin is converted into NAD, which is further converted into NADP. NADP decreases liver cholesterol production. It does not increase triglyceride production.",
+		"rationale": "Niacin is converted into NAD, which is further converted into NADP. NADP decreases liver cholesterol production. It does not increase triglyceride production.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19068,7 +19068,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2437cb47", "9d472b0a", "7230368a"],
-		"explanation": "Statins may improve endothelial function, have immunomodulatory effects, and affect bone metabolism. They do not increase LDL synthesis; instead, they reduce it.",
+		"rationale": "Statins may improve endothelial function, have immunomodulatory effects, and affect bone metabolism. They do not increase LDL synthesis; instead, they reduce it.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19098,7 +19098,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dae47d77"],
-		"explanation": "Cystoid macular edema is a rare side effect associated with niacin, not with gemfibrozil or statins like atorvastatin and rosuvastatin.",
+		"rationale": "Cystoid macular edema is a rare side effect associated with niacin, not with gemfibrozil or statins like atorvastatin and rosuvastatin.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19128,7 +19128,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["23fcd1e8", "47499d79"],
-		"explanation": "Statins increase LDL receptor expression on liver cells, which enhances LDL clearance from the bloodstream. This does not lead to decreased LDL clearance or decreased synthesis of LDL receptors.",
+		"rationale": "Statins increase LDL receptor expression on liver cells, which enhances LDL clearance from the bloodstream. This does not lead to decreased LDL clearance or decreased synthesis of LDL receptors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19158,7 +19158,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b2d1d891", "cfdda5d1", "1757749c"],
-		"explanation": "Clonidine and guanfacine are used for hypertension and ADHD. Tizanidine is used for muscle relaxation. Methyldopa is primarily used for hypertension, and apraclonidine is used topically for eye conditions, not systemic hypertension.",
+		"rationale": "Clonidine and guanfacine are used for hypertension and ADHD. Tizanidine is used for muscle relaxation. Methyldopa is primarily used for hypertension, and apraclonidine is used topically for eye conditions, not systemic hypertension.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19192,7 +19192,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3cf1fb2d", "4fc9c697"],
-		"explanation": "Minoxidil is used topically for hair loss, and hydralazine is used for eclampsia. Vasodilators are reserved for severe hypertension, not mild cases. Isosorbide mononitrate reduces cardiac preload, not increases it. Vasodilators act on cyclic AMP and ATP-sensitive potassium channels, not sodium channels.",
+		"rationale": "Minoxidil is used topically for hair loss, and hydralazine is used for eclampsia. Vasodilators are reserved for severe hypertension, not mild cases. Isosorbide mononitrate reduces cardiac preload, not increases it. Vasodilators act on cyclic AMP and ATP-sensitive potassium channels, not sodium channels.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19226,7 +19226,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["efd4d9cf", "bf6ed3d7", "ca74a6bd"],
-		"explanation": "Antiarrhythmic drugs can cause dizziness, chest pain, and shortness of breath. Blue tinge to vision and increased sensitivity to light are associated with vasodilators affecting choroidal blood flow, not antiarrhythmics.",
+		"rationale": "Antiarrhythmic drugs can cause dizziness, chest pain, and shortness of breath. Blue tinge to vision and increased sensitivity to light are associated with vasodilators affecting choroidal blood flow, not antiarrhythmics.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19260,7 +19260,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fc6ab311", "6e4f4f11", "dfce3926"],
-		"explanation": "Eplerenone and spironolactone are potassium-sparing diuretics used in CHF. Hydralazine is a vasodilator used to decrease cardiac preload in CHF. Apraclonidine is used for eye conditions, and methyldopa is primarily for hypertension.",
+		"rationale": "Eplerenone and spironolactone are potassium-sparing diuretics used in CHF. Hydralazine is a vasodilator used to decrease cardiac preload in CHF. Apraclonidine is used for eye conditions, and methyldopa is primarily for hypertension.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19294,7 +19294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["706d7526", "649e409c"],
-		"explanation": "Apraclonidine and brimonidine are used topically in the eye to inhibit aqueous production and may increase ganglion cell survivability. Clonidine and guanfacine are used systemically, and methyldopa is not used for eye conditions.",
+		"rationale": "Apraclonidine and brimonidine are used topically in the eye to inhibit aqueous production and may increase ganglion cell survivability. Clonidine and guanfacine are used systemically, and methyldopa is not used for eye conditions.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19328,7 +19328,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e0923116"],
-		"explanation": "Amiodarone is a well-known cause of corneal verticillata (whorl-like opacities) due to its deposition in the corneal epithelium. This condition is typically benign and does not significantly affect vision but serves as an important clue for identifying amiodarone use in patients with cardiac arrhythmias.",
+		"rationale": "Amiodarone is a well-known cause of corneal verticillata (whorl-like opacities) due to its deposition in the corneal epithelium. This condition is typically benign and does not significantly affect vision but serves as an important clue for identifying amiodarone use in patients with cardiac arrhythmias.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19362,7 +19362,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e4928397"],
-		"explanation": "Tadalafil, a PDE-5 inhibitor used for erectile dysfunction and pulmonary hypertension, can cause cyanopsia (blue-tinted vision) as a side effect due to its effect on PDE-6 in retinal photoreceptors.",
+		"rationale": "Tadalafil, a PDE-5 inhibitor used for erectile dysfunction and pulmonary hypertension, can cause cyanopsia (blue-tinted vision) as a side effect due to its effect on PDE-6 in retinal photoreceptors.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19396,7 +19396,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1929d81d"],
-		"explanation": "Niacin is known to cause cystoid macular edema (CME), a condition characterized by fluid accumulation in the macula leading to visual distortion. This is a rare but significant side effect of high-dose niacin therapy, commonly used for lipid management.",
+		"rationale": "Niacin is known to cause cystoid macular edema (CME), a condition characterized by fluid accumulation in the macula leading to visual distortion. This is a rare but significant side effect of high-dose niacin therapy, commonly used for lipid management.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19430,7 +19430,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7ea3cabe", "33834531"],
-		"explanation": "Methazolamide and acetazolamide are carbonic anhydrase inhibitors commonly used to reduce macular edema in conditions like retinitis pigmentosa by decreasing fluid accumulation in the retina.",
+		"rationale": "Methazolamide and acetazolamide are carbonic anhydrase inhibitors commonly used to reduce macular edema in conditions like retinitis pigmentosa by decreasing fluid accumulation in the retina.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19464,7 +19464,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c2413c68"],
-		"explanation": "Digoxin toxicity is known to cause xanthopsia (yellow vision), a classic visual side effect due to its effects on retinal function and color perception.",
+		"rationale": "Digoxin toxicity is known to cause xanthopsia (yellow vision), a classic visual side effect due to its effects on retinal function and color perception.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19498,7 +19498,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["19d33d46"],
-		"explanation": "Tamsulosin, an alpha-1 blocker used for benign prostatic hyperplasia, is associated with intraoperative floppy iris syndrome (IFIS), which increases the risk of iris prolapse during cataract surgery.",
+		"rationale": "Tamsulosin, an alpha-1 blocker used for benign prostatic hyperplasia, is associated with intraoperative floppy iris syndrome (IFIS), which increases the risk of iris prolapse during cataract surgery.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19532,7 +19532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7140afb3", "be5f9ebb", "89ccafa8", "5af72327"],
-		"explanation": "Sjogren’s syndrome is an autoimmune disorder causing severe dry eye and dry mouth. Additionally, medications such as hydrochlorothiazide, furosemide (diuretics), and disopyramide (an antiarrhythmic with anticholinergic properties) can exacerbate ocular dryness by reducing tear production.",
+		"rationale": "Sjogren’s syndrome is an autoimmune disorder causing severe dry eye and dry mouth. Additionally, medications such as hydrochlorothiazide, furosemide (diuretics), and disopyramide (an antiarrhythmic with anticholinergic properties) can exacerbate ocular dryness by reducing tear production.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19570,7 +19570,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b7645bb4", "083942f8"],
-		"explanation": "Propranolol (a beta-blocker) and lisinopril (an ACE inhibitor) have been reported to cause ocular surface irritation and dry eye, which can lead to superficial punctate keratitis.",
+		"rationale": "Propranolol (a beta-blocker) and lisinopril (an ACE inhibitor) have been reported to cause ocular surface irritation and dry eye, which can lead to superficial punctate keratitis.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19604,7 +19604,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dce0cb4d"],
-		"explanation": "Spironolactone, an aldosterone antagonist, has been found to be beneficial in the treatment of Central Serous Chorioretinopathy by reducing choroidal vascular permeability and subretinal fluid accumulation.",
+		"rationale": "Spironolactone, an aldosterone antagonist, has been found to be beneficial in the treatment of Central Serous Chorioretinopathy by reducing choroidal vascular permeability and subretinal fluid accumulation.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19638,7 +19638,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["33ed0a05"],
-		"explanation": "Aspirin, an antiplatelet medication, increases the risk of spontaneous bleeding, including subconjunctival hemorrhages. Patients on aspirin therapy often present with minor, painless red patches in the eye due to small blood vessel rupture.",
+		"rationale": "Aspirin, an antiplatelet medication, increases the risk of spontaneous bleeding, including subconjunctival hemorrhages. Patients on aspirin therapy often present with minor, painless red patches in the eye due to small blood vessel rupture.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19672,7 +19672,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["939b6cd8"],
-		"explanation": "Ivabradine, a heart rate-lowering medication, is known to cause visual disturbances such as phosphenes (perceived flashes of light) due to its interaction with retinal ion channels.",
+		"rationale": "Ivabradine, a heart rate-lowering medication, is known to cause visual disturbances such as phosphenes (perceived flashes of light) due to its interaction with retinal ion channels.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19706,7 +19706,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c6d8e694"],
-		"explanation": "Muscle pain (myalgia) is a common side effect of statin medications like atorvastatin due to its effect on muscle metabolism. In severe cases, it can progress to rhabdomyolysis, requiring discontinuation of the drug.",
+		"rationale": "Muscle pain (myalgia) is a common side effect of statin medications like atorvastatin due to its effect on muscle metabolism. In severe cases, it can progress to rhabdomyolysis, requiring discontinuation of the drug.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19740,7 +19740,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7f5d3e10"],
-		"explanation": "Glycerin is a hyperosmotic agent that helps to reduce intraocular pressure and clear corneal edema in acute angle closure glaucoma by drawing fluid out of the eye.",
+		"rationale": "Glycerin is a hyperosmotic agent that helps to reduce intraocular pressure and clear corneal edema in acute angle closure glaucoma by drawing fluid out of the eye.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19774,7 +19774,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1cb0220d"],
-		"explanation": "Aminocaproic acid is an antifibrinolytic agent used to stabilize clot formation and reduce re-bleeding in cases of traumatic hyphema, preventing complications such as increased intraocular pressure and corneal staining.",
+		"rationale": "Aminocaproic acid is an antifibrinolytic agent used to stabilize clot formation and reduce re-bleeding in cases of traumatic hyphema, preventing complications such as increased intraocular pressure and corneal staining.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19808,7 +19808,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["64854dfe", "e6bf4a3c"],
-		"explanation": "Dorzolamide, a carbonic anhydrase inhibitor, and apraclonidine, an alpha agonist, are both effective in reducing intraocular pressure in glaucoma by decreasing aqueous humor production.",
+		"rationale": "Dorzolamide, a carbonic anhydrase inhibitor, and apraclonidine, an alpha agonist, are both effective in reducing intraocular pressure in glaucoma by decreasing aqueous humor production.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19842,7 +19842,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["30c4b6e6"],
-		"explanation": "Acetazolamide, a carbonic anhydrase inhibitor, is the first-line systemic treatment for acute intraocular pressure elevation. It reduces aqueous humor production and rapidly lowers IOP in cases like acute angle closure glaucoma.",
+		"rationale": "Acetazolamide, a carbonic anhydrase inhibitor, is the first-line systemic treatment for acute intraocular pressure elevation. It reduces aqueous humor production and rapidly lowers IOP in cases like acute angle closure glaucoma.",
 		"metadata": {},
 		"moduleId": "js73pvjn8jr2yd82qsa5kfq9g57m8rkg",
 		"options": [
@@ -19876,7 +19876,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1804b220", "27e955af"],
-		"explanation": "Gout is caused by the deposition of monosodium urate crystals, primarily affecting the joints. It is related to elevated uric acid levels, not calcium pyrophosphate crystals.",
+		"rationale": "Gout is caused by the deposition of monosodium urate crystals, primarily affecting the joints. It is related to elevated uric acid levels, not calcium pyrophosphate crystals.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -19906,7 +19906,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ce46e92d"],
-		"explanation": "Probenecid works by competitively inhibiting the active reabsorption of urate in the proximal tubule of the kidney, increasing urinary excretion of uric acid and lowering serum urate concentrations.",
+		"rationale": "Probenecid works by competitively inhibiting the active reabsorption of urate in the proximal tubule of the kidney, increasing urinary excretion of uric acid and lowering serum urate concentrations.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -19936,7 +19936,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["26715ee1", "280da6d7"],
-		"explanation": "Probenecid can cause nausea, vomiting, and, rarely, bone marrow suppression. Stevens-Johnson syndrome and cataracts are associated with allopurinol, not probenecid.",
+		"rationale": "Probenecid can cause nausea, vomiting, and, rarely, bone marrow suppression. Stevens-Johnson syndrome and cataracts are associated with allopurinol, not probenecid.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -19966,7 +19966,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bea4ce4a", "34a39707", "9433d297"],
-		"explanation": "Probenecid interacts with NSAIDs, acyclovir, and ACE inhibitors, potentially leading to toxic levels. Allopurinol is not listed as interacting with probenecid.",
+		"rationale": "Probenecid interacts with NSAIDs, acyclovir, and ACE inhibitors, potentially leading to toxic levels. Allopurinol is not listed as interacting with probenecid.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -19996,7 +19996,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c28691ee", "05362d9d"],
-		"explanation": "Allopurinol inhibits xanthine oxidase, preventing the formation of uric acid. It is not a uricosuric agent and does not increase uric acid excretion.",
+		"rationale": "Allopurinol inhibits xanthine oxidase, preventing the formation of uric acid. It is not a uricosuric agent and does not increase uric acid excretion.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20026,7 +20026,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["57f506b8", "c7e4029a"],
-		"explanation": "Allopurinol is used to prevent specific types of kidney stones and high uric acid levels during chemotherapy. It is not used to prevent cataracts or bone marrow suppression.",
+		"rationale": "Allopurinol is used to prevent specific types of kidney stones and high uric acid levels during chemotherapy. It is not used to prevent cataracts or bone marrow suppression.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20056,7 +20056,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["afe0a5d3", "87fa6787"],
-		"explanation": "Allopurinol is associated with Stevens-Johnson syndrome and an increased risk of cataracts. Bone marrow suppression and frequent urination are not typical side effects of allopurinol.",
+		"rationale": "Allopurinol is associated with Stevens-Johnson syndrome and an increased risk of cataracts. Bone marrow suppression and frequent urination are not typical side effects of allopurinol.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20086,7 +20086,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["75401507", "28cf7ef8", "bbfda973"],
-		"explanation": "Allopurinol has serious interactions with azathioprine, theophylline, and warfarin. Probenecid is not listed as having a serious interaction with allopurinol.",
+		"rationale": "Allopurinol has serious interactions with azathioprine, theophylline, and warfarin. Probenecid is not listed as having a serious interaction with allopurinol.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20116,7 +20116,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d138c0ca", "2cf9d378"],
-		"explanation": "Sulfinpyrazone is a uricosuric agent with a similar mechanism of action to probenecid. It does not inhibit xanthine oxidase and is not used to treat cataracts.",
+		"rationale": "Sulfinpyrazone is a uricosuric agent with a similar mechanism of action to probenecid. It does not inhibit xanthine oxidase and is not used to treat cataracts.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20146,7 +20146,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b9190f39", "b0052cfc"],
-		"explanation": "Patients taking probenecid might experience sore gums and headache. Rash and GI upset are more commonly associated with allopurinol.",
+		"rationale": "Patients taking probenecid might experience sore gums and headache. Rash and GI upset are more commonly associated with allopurinol.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20176,7 +20176,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a632d9d2", "410277d9"],
-		"explanation": "Probenecid is sometimes used as an adjunctive therapy in cases of gonorrhea and pelvic inflammatory disease. It is not used for cataracts or Stevens-Johnson syndrome.",
+		"rationale": "Probenecid is sometimes used as an adjunctive therapy in cases of gonorrhea and pelvic inflammatory disease. It is not used for cataracts or Stevens-Johnson syndrome.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20206,7 +20206,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d96339a7", "6e691e09"],
-		"explanation": "Allopurinol is metabolized to oxypurinol and is a structural analog of hypoxanthine. It is metabolized in the liver, not the kidney, and inhibits xanthine oxidase, not directly uric acid synthesis.",
+		"rationale": "Allopurinol is metabolized to oxypurinol and is a structural analog of hypoxanthine. It is metabolized in the liver, not the kidney, and inhibits xanthine oxidase, not directly uric acid synthesis.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20236,7 +20236,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["93ee64a0", "7bf26811", "a9a76bb9"],
-		"explanation": "Gout can cause recurrent ocular inflammation such as anterior uveitis, scleritis, and episcleritis. Posterior subcapsular cataracts are associated with allopurinol use.",
+		"rationale": "Gout can cause recurrent ocular inflammation such as anterior uveitis, scleritis, and episcleritis. Posterior subcapsular cataracts are associated with allopurinol use.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20266,7 +20266,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0fc43121", "76e101bc"],
-		"explanation": "Uricosuric agents increase uric acid excretion and are contraindicated in patients with renal impairment. They are not effective in treating acute gout attacks and do not inhibit xanthine oxidase.",
+		"rationale": "Uricosuric agents increase uric acid excretion and are contraindicated in patients with renal impairment. They are not effective in treating acute gout attacks and do not inhibit xanthine oxidase.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20296,7 +20296,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3ae137db", "beddf246", "77a20029"],
-		"explanation": "Allopurinol can cause GI upset, headache, and rash. Frequent urination is not a typical side effect of allopurinol.",
+		"rationale": "Allopurinol can cause GI upset, headache, and rash. Frequent urination is not a typical side effect of allopurinol.",
 		"metadata": {},
 		"moduleId": "js7bx64y8epjbb69q4ssj0wfsd7m9ntt",
 		"options": [
@@ -20326,7 +20326,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e67f2eb6", "2a8b121c"],
-		"explanation": "The sympathetic nervous system is responsible for preparing the body for stress-related activities, often referred to as the fight-or-flight response. It does not manage routine operations (B) or decrease heart rate (C), which are functions of the parasympathetic nervous system. It is part of the autonomic nervous system, not the somatic nervous system (D).",
+		"rationale": "The sympathetic nervous system is responsible for preparing the body for stress-related activities, often referred to as the fight-or-flight response. It does not manage routine operations (B) or decrease heart rate (C), which are functions of the parasympathetic nervous system. It is part of the autonomic nervous system, not the somatic nervous system (D).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20360,7 +20360,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b7f9270a", "ddcac867", "cefdc4d9"],
-		"explanation": "The parasympathetic nervous system is responsible for returning the body to routine operations (B), promoting digestion, and conserving energy (D). It is part of the autonomic nervous system (E). It does not initiate the fight-or-flight response (A) or increase heart rate and dilate pupils (C), which are functions of the sympathetic nervous system.",
+		"rationale": "The parasympathetic nervous system is responsible for returning the body to routine operations (B), promoting digestion, and conserving energy (D). It is part of the autonomic nervous system (E). It does not initiate the fight-or-flight response (A) or increase heart rate and dilate pupils (C), which are functions of the sympathetic nervous system.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20394,7 +20394,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["07aa9206", "29e43cdd", "552d3a35"],
-		"explanation": "The autonomic nervous system controls internal organs and glands (A), includes the sympathetic and parasympathetic divisions (C), and operates independently of the somatic nervous system (E). It is not under voluntary control (B) and is part of the peripheral nervous system, not the central nervous system (D).",
+		"rationale": "The autonomic nervous system controls internal organs and glands (A), includes the sympathetic and parasympathetic divisions (C), and operates independently of the somatic nervous system (E). It is not under voluntary control (B) and is part of the peripheral nervous system, not the central nervous system (D).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20428,7 +20428,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e006cda4", "b2de5863", "9a53821f"],
-		"explanation": "Activation of the sympathetic nervous system increases heart rate (A), inhibits digestion (C), and relaxes airways (D). It dilates pupils (not B) and inhibits saliva production (not E), which are opposite to the effects listed.",
+		"rationale": "Activation of the sympathetic nervous system increases heart rate (A), inhibits digestion (C), and relaxes airways (D). It dilates pupils (not B) and inhibits saliva production (not E), which are opposite to the effects listed.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20462,7 +20462,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f8b3f3f", "65c6d7ea", "ee630c16"],
-		"explanation": "Activation of the parasympathetic nervous system decreases heart rate (A), stimulates digestion (C), and constricts airways (D). It constricts pupils (not B) and stimulates saliva production (not E), which are opposite to the effects listed.",
+		"rationale": "Activation of the parasympathetic nervous system decreases heart rate (A), stimulates digestion (C), and constricts airways (D). It constricts pupils (not B) and stimulates saliva production (not E), which are opposite to the effects listed.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20496,7 +20496,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e448fbd5", "93ed364d", "9de5474d"],
-		"explanation": "The somatic nervous system is involved in voluntary control of body movements (A), consists of motor and sensory neurons (B), and relays signals to and from the central nervous system (E). It is not part of the autonomic nervous system (C) and does not control internal organs and glands (D).",
+		"rationale": "The somatic nervous system is involved in voluntary control of body movements (A), consists of motor and sensory neurons (B), and relays signals to and from the central nervous system (E). It is not part of the autonomic nervous system (C) and does not control internal organs and glands (D).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20530,7 +20530,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1841a935", "855f4c07", "a6d2bade"],
-		"explanation": "The peripheral nervous system includes the autonomic (A) and somatic (D) nervous systems and is made up of thick bundles of axons (B). It does not process information in the brain (C) and is not part of the central nervous system (E).",
+		"rationale": "The peripheral nervous system includes the autonomic (A) and somatic (D) nervous systems and is made up of thick bundles of axons (B). It does not process information in the brain (C) and is not part of the central nervous system (E).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20564,7 +20564,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0d37ae37", "ed5927fd", "e7e77441"],
-		"explanation": "The autonomic nervous system regulates heart rate (A), manages digestive processes (C), and maintains homeostasis (E). It does not control skeletal muscle movement (B) or process sensory information from the environment (D), which are functions of the somatic nervous system.",
+		"rationale": "The autonomic nervous system regulates heart rate (A), manages digestive processes (C), and maintains homeostasis (E). It does not control skeletal muscle movement (B) or process sensory information from the environment (D), which are functions of the somatic nervous system.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20598,7 +20598,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2ecaa730", "7d072862"],
-		"explanation": "Both divisions of the autonomic nervous system work together to maintain homeostasis (C), and the parasympathetic division promotes routine maintenance activities (E). The sympathetic division is not responsible for conserving energy (A) or part of the somatic nervous system (D), and the parasympathetic division is not involved in stress-related activities (B).",
+		"rationale": "Both divisions of the autonomic nervous system work together to maintain homeostasis (C), and the parasympathetic division promotes routine maintenance activities (E). The sympathetic division is not responsible for conserving energy (A) or part of the somatic nervous system (D), and the parasympathetic division is not involved in stress-related activities (B).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20632,7 +20632,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["021eace9", "422b1384", "a6a4434d"],
-		"explanation": "The central nervous system includes the brain and spinal cord (A), and the peripheral nervous system relays signals to and from the central nervous system (C). The peripheral nervous system is responsible for involuntary control of internal organs (E). The peripheral nervous system does not process information in the brain (B), and voluntary movements are controlled through the somatic nervous system, not the autonomic nervous system (D).",
+		"rationale": "The central nervous system includes the brain and spinal cord (A), and the peripheral nervous system relays signals to and from the central nervous system (C). The peripheral nervous system is responsible for involuntary control of internal organs (E). The peripheral nervous system does not process information in the brain (B), and voluntary movements are controlled through the somatic nervous system, not the autonomic nervous system (D).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20666,7 +20666,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["accd0648", "8ce95278"],
-		"explanation": "Alpha-1 adrenergic receptors mediate constriction of arterioles in the skin (A) and contraction of the spleen (D). Bronchodilation (B) and relaxation of the ciliary muscle (E) are mediated by beta-2 receptors, while increased glycogenolysis (C) involves both alpha-1 and beta-2 receptors.",
+		"rationale": "Alpha-1 adrenergic receptors mediate constriction of arterioles in the skin (A) and contraction of the spleen (D). Bronchodilation (B) and relaxation of the ciliary muscle (E) are mediated by beta-2 receptors, while increased glycogenolysis (C) involves both alpha-1 and beta-2 receptors.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20700,7 +20700,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f52c385c", "690a078c"],
-		"explanation": "Sympathetic activation in the liver increases gluconeogenesis (A) and glycogenolysis (C) to provide glucose for energy. Decreased glycogenolysis (B) and gluconeogenesis (D) are incorrect, and increased lipogenesis (E) is not a sympathetic effect.",
+		"rationale": "Sympathetic activation in the liver increases gluconeogenesis (A) and glycogenolysis (C) to provide glucose for energy. Decreased glycogenolysis (B) and gluconeogenesis (D) are incorrect, and increased lipogenesis (E) is not a sympathetic effect.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20734,7 +20734,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2be42cab", "5e6fd8ed"],
-		"explanation": "The salivary glands' sympathetic response involves alpha-1 (A) and beta-2 (C) receptors, leading to small volume potassium and water secretion. Beta-1 (B), muscarinic (D), and nicotinic (E) receptors are not involved in this specific response.",
+		"rationale": "The salivary glands' sympathetic response involves alpha-1 (A) and beta-2 (C) receptors, leading to small volume potassium and water secretion. Beta-1 (B), muscarinic (D), and nicotinic (E) receptors are not involved in this specific response.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20768,7 +20768,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["250d39b3", "15cd5da9"],
-		"explanation": "Sympathetic activation increases the force of contraction (B) and cardiac output (D) in the heart. It increases heart rate, not decreases it (A), and increases the rate of conduction, not decreases it (C). It aims to increase oxygen supply, not decrease it (E).",
+		"rationale": "Sympathetic activation increases the force of contraction (B) and cardiac output (D) in the heart. It increases heart rate, not decreases it (A), and increases the rate of conduction, not decreases it (C). It aims to increase oxygen supply, not decrease it (E).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20802,7 +20802,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["81816e11", "91b5a43e", "96b90e4d", "d40f2bcd"],
-		"explanation": "Sympathetic activation causes mydriasis (A) by contracting the radial muscle of the iris (B). It relaxes the ciliary muscle for far vision, not near vision (C). It increases aqueous production via beta-1 and beta-2 receptors (D) and decreases it via alpha-2 receptors (E).",
+		"rationale": "Sympathetic activation causes mydriasis (A) by contracting the radial muscle of the iris (B). It relaxes the ciliary muscle for far vision, not near vision (C). It increases aqueous production via beta-1 and beta-2 receptors (D) and decreases it via alpha-2 receptors (E).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20836,7 +20836,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b49842cc", "5d43201f", "dac6acfd"],
-		"explanation": "The sympathetic nervous system causes bronchodilation (B) and decreases pulmonary secretions (D) via beta-2 receptors (E). It does not cause bronchoconstriction (A) or increase pulmonary secretions (C).",
+		"rationale": "The sympathetic nervous system causes bronchodilation (B) and decreases pulmonary secretions (D) via beta-2 receptors (E). It does not cause bronchoconstriction (A) or increase pulmonary secretions (C).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20870,7 +20870,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2955ca5a", "64a195fe"],
-		"explanation": "Muscarinic receptors in the sympathetic nervous system mediate increased sweating (A) and erection of hair (B). Increased heart rate (C) and bronchodilation (D) are mediated by beta receptors, while increased glycogenolysis (E) involves alpha-1 and beta-2 receptors.",
+		"rationale": "Muscarinic receptors in the sympathetic nervous system mediate increased sweating (A) and erection of hair (B). Increased heart rate (C) and bronchodilation (D) are mediated by beta receptors, while increased glycogenolysis (E) involves alpha-1 and beta-2 receptors.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20904,7 +20904,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f5866079", "6690d4bd"],
-		"explanation": "The adrenal medulla releases epinephrine and norepinephrine (A) and is activated by nicotinic receptors (D). It is part of the sympathetic nervous system, not parasympathetic (C), and does not decrease sympathetic activity (E). Muscarinic receptors (B) are not involved in its activation.",
+		"rationale": "The adrenal medulla releases epinephrine and norepinephrine (A) and is activated by nicotinic receptors (D). It is part of the sympathetic nervous system, not parasympathetic (C), and does not decrease sympathetic activity (E). Muscarinic receptors (B) are not involved in its activation.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20938,7 +20938,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["22e3b8a3"],
-		"explanation": "Increased digestive activity (C) is not associated with sympathetic activation, which typically decreases digestive functions. Increased heart rate (A), bronchodilation (B), mydriasis (D), and increased sweating (E) are all sympathetic effects.",
+		"rationale": "Increased digestive activity (C) is not associated with sympathetic activation, which typically decreases digestive functions. Increased heart rate (A), bronchodilation (B), mydriasis (D), and increased sweating (E) are all sympathetic effects.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -20972,7 +20972,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f44fbc62", "9722bae8"],
-		"explanation": "The sympathetic nervous system causes weak constriction in skeletal muscle arterioles via both alpha-1 (D) and beta-2 (B) receptors. Strong constriction (A) and dilation (C) are not typical effects in skeletal muscle arterioles, and it does have an effect (E).",
+		"rationale": "The sympathetic nervous system causes weak constriction in skeletal muscle arterioles via both alpha-1 (D) and beta-2 (B) receptors. Strong constriction (A) and dilation (C) are not typical effects in skeletal muscle arterioles, and it does have an effect (E).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21006,7 +21006,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b199237d"],
-		"explanation": "The PNS uses acetylcholine as its neurotransmitter for both pre- and postganglionic neurons. Norepinephrine is primarily used by the sympathetic nervous system (SNS).",
+		"rationale": "The PNS uses acetylcholine as its neurotransmitter for both pre- and postganglionic neurons. Norepinephrine is primarily used by the sympathetic nervous system (SNS).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21040,7 +21040,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0acae0b5", "cb4c75f4"],
-		"explanation": "The vagus nerve carries 75% of all parasympathetic fibers and is involved in regulating the thoracic and abdominal viscera. It does not act on the parotid gland (glossopharyngeal nerve does), and it originates from the brainstem, not the sacral spinal cord.",
+		"rationale": "The vagus nerve carries 75% of all parasympathetic fibers and is involved in regulating the thoracic and abdominal viscera. It does not act on the parotid gland (glossopharyngeal nerve does), and it originates from the brainstem, not the sacral spinal cord.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21070,7 +21070,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["37ec12dd", "ac6a103b", "f73e0fbb"],
-		"explanation": "M1, M3, and M5 muscarinic receptors are coupled to Gq proteins, which signal through the IP3 pathway. M2 and M4 are coupled to Gi proteins.",
+		"rationale": "M1, M3, and M5 muscarinic receptors are coupled to Gq proteins, which signal through the IP3 pathway. M2 and M4 are coupled to Gi proteins.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21104,7 +21104,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5cbcac30", "c0346a5e"],
-		"explanation": "The pelvic splanchnic nerves act on the pelvic cavity viscera and are formed by preganglionic fibers from the sacral cord (S2-S4). They do not innervate the lacrimal gland and do not originate from the thoracic spinal cord.",
+		"rationale": "The pelvic splanchnic nerves act on the pelvic cavity viscera and are formed by preganglionic fibers from the sacral cord (S2-S4). They do not innervate the lacrimal gland and do not originate from the thoracic spinal cord.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21134,7 +21134,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["43c48d4f", "4b75ea8a"],
-		"explanation": "The SNS primarily uses norepinephrine for postganglionic neurons and acts on adrenergic receptors. It has shorter preganglionic axons compared to the PNS, which uses acetylcholine.",
+		"rationale": "The SNS primarily uses norepinephrine for postganglionic neurons and acts on adrenergic receptors. It has shorter preganglionic axons compared to the PNS, which uses acetylcholine.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21164,7 +21164,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["338dae0d", "52055b8a"],
-		"explanation": "The facial nerve (VII) and glossopharyngeal nerve (IX) are responsible for parasympathetic innervation of the salivary glands. The oculomotor nerve (III) and vagus nerve (X) do not innervate the salivary glands.",
+		"rationale": "The facial nerve (VII) and glossopharyngeal nerve (IX) are responsible for parasympathetic innervation of the salivary glands. The oculomotor nerve (III) and vagus nerve (X) do not innervate the salivary glands.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21194,7 +21194,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0f2dc8cb", "4ea1e921"],
-		"explanation": "The parasympathetic nervous system decreases heart rate and increases digestive activity. Pupil dilation and bronchodilation are typically mediated by the sympathetic nervous system.",
+		"rationale": "The parasympathetic nervous system decreases heart rate and increases digestive activity. Pupil dilation and bronchodilation are typically mediated by the sympathetic nervous system.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21224,7 +21224,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7b87898a", "10670139"],
-		"explanation": "M2 and M4 muscarinic receptors are coupled to Gi proteins, which signal through the cAMP pathway. M1, M3, and M5 are coupled to Gq proteins.",
+		"rationale": "M2 and M4 muscarinic receptors are coupled to Gi proteins, which signal through the cAMP pathway. M1, M3, and M5 are coupled to Gq proteins.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21258,7 +21258,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9903a5eb", "b7ae81c2"],
-		"explanation": "Preganglionic neurons of the PNS have longer axons than those of the SNS and synapse with postganglionic neurons near the effector organs. They originate from the brainstem and sacral spinal cord, not the thoracic spinal cord, and use acetylcholine, not norepinephrine, as a neurotransmitter.",
+		"rationale": "Preganglionic neurons of the PNS have longer axons than those of the SNS and synapse with postganglionic neurons near the effector organs. They originate from the brainstem and sacral spinal cord, not the thoracic spinal cord, and use acetylcholine, not norepinephrine, as a neurotransmitter.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21288,7 +21288,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ea0e8b80", "625e81c2", "4e239fee", "dc342425"],
-		"explanation": "Alpha-1 receptors cause contraction of the radial muscle of the iris, leading to mydriasis. Beta-1 and Beta-2 receptors in the ciliary body increase aqueous production, while Alpha-2 receptors decrease secretion. Beta-3 is not involved in these processes.",
+		"rationale": "Alpha-1 receptors cause contraction of the radial muscle of the iris, leading to mydriasis. Beta-1 and Beta-2 receptors in the ciliary body increase aqueous production, while Alpha-2 receptors decrease secretion. Beta-3 is not involved in these processes.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21322,7 +21322,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5028b0ac", "844a0a0a", "0aa16b72", "86cc7412"],
-		"explanation": "The oculomotor, facial, glossopharyngeal, and vagus nerves carry parasympathetic fibers. The trigeminal nerve is not involved in parasympathetic functions.",
+		"rationale": "The oculomotor, facial, glossopharyngeal, and vagus nerves carry parasympathetic fibers. The trigeminal nerve is not involved in parasympathetic functions.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21356,7 +21356,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7aebba57", "487e6570"],
-		"explanation": "Sympathetic activation causes bronchodilation and decreased pulmonary secretions, facilitating airflow. It does not cause bronchoconstriction or increased secretions.",
+		"rationale": "Sympathetic activation causes bronchodilation and decreased pulmonary secretions, facilitating airflow. It does not cause bronchoconstriction or increased secretions.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21390,7 +21390,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4dc0b7d8", "b47d78ed", "088d3b1c"],
-		"explanation": "Preganglionic neurons originate from the brainstem and sacral spinal cord, not the thoracic region. Preganglionic axons are longer in the PNS, and the vagus nerve carries a significant portion of parasympathetic fibers. Postganglionic neurons synapse near effector organs.",
+		"rationale": "Preganglionic neurons originate from the brainstem and sacral spinal cord, not the thoracic region. Preganglionic axons are longer in the PNS, and the vagus nerve carries a significant portion of parasympathetic fibers. Postganglionic neurons synapse near effector organs.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21424,7 +21424,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2f43736c"],
-		"explanation": "Beta-2 adrenergic receptors are primarily responsible for bronchodilation in the lungs. Alpha-1, Beta-1, Alpha-2, and Beta-3 are not involved in this specific function.",
+		"rationale": "Beta-2 adrenergic receptors are primarily responsible for bronchodilation in the lungs. Alpha-1, Beta-1, Alpha-2, and Beta-3 are not involved in this specific function.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21458,7 +21458,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0e41183e", "a1aba2a2"],
-		"explanation": "Sympathetic activation causes relaxation of the ciliary muscle for far vision and increases aqueous humor production. It does not cause contraction for near vision or pupil constriction and is not involved in the production of tears.",
+		"rationale": "Sympathetic activation causes relaxation of the ciliary muscle for far vision and increases aqueous humor production. It does not cause contraction for near vision or pupil constriction and is not involved in the production of tears.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21492,7 +21492,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a7a90790", "69f26928"],
-		"explanation": "The sympathetic nervous system increases cardiac output and decreases pulmonary secretions. It increases heart rate, causes bronchodilation, and leads to mydriasis, not miosis.",
+		"rationale": "The sympathetic nervous system increases cardiac output and decreases pulmonary secretions. It increases heart rate, causes bronchodilation, and leads to mydriasis, not miosis.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21526,7 +21526,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a4c81ef3"],
-		"explanation": "The vagus nerve (X) is primarily responsible for parasympathetic innervation of the thoracic and abdominal viscera. The other nerves do not serve this function.",
+		"rationale": "The vagus nerve (X) is primarily responsible for parasympathetic innervation of the thoracic and abdominal viscera. The other nerves do not serve this function.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21560,7 +21560,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ef34c8c8"],
-		"explanation": "Alpha-2 adrenergic receptors decrease aqueous humor production in the eye. They do not increase production, cause mydriasis or miosis, or relax the ciliary muscle.",
+		"rationale": "Alpha-2 adrenergic receptors decrease aqueous humor production in the eye. They do not increase production, cause mydriasis or miosis, or relax the ciliary muscle.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21594,7 +21594,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["37cc4c60", "01b27735"],
-		"explanation": "Sympathomimetic drugs mimic the sympathetic nervous system, not the parasympathetic (A is incorrect). They can directly activate adrenergic receptors (B is correct) and are chemically similar to catecholamines (D is correct). They increase, not decrease, norepinephrine and epinephrine levels (C is incorrect). They are not used for Sjogren's syndrome (E is incorrect).",
+		"rationale": "Sympathomimetic drugs mimic the sympathetic nervous system, not the parasympathetic (A is incorrect). They can directly activate adrenergic receptors (B is correct) and are chemically similar to catecholamines (D is correct). They increase, not decrease, norepinephrine and epinephrine levels (C is incorrect). They are not used for Sjogren's syndrome (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21628,7 +21628,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["971bbfa8", "a8361b7c", "1605d7a0"],
-		"explanation": "Parasympathomimetic drugs can cause miosis (A is correct), bronchial contraction (C is correct), and vasodilation (E is correct). They decrease heart rate (B is incorrect) and increase gland secretion (D is incorrect).",
+		"rationale": "Parasympathomimetic drugs can cause miosis (A is correct), bronchial contraction (C is correct), and vasodilation (E is correct). They decrease heart rate (B is incorrect) and increase gland secretion (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21662,7 +21662,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e1f93465", "4fe8d916", "549a59c0"],
-		"explanation": "Pilocarpine (A), cevimeline (C), and carbachol (E) are direct parasympathomimetic agents. Epinephrine (B) is a sympathomimetic drug, and atropine (D) is an anticholinergic agent.",
+		"rationale": "Pilocarpine (A), cevimeline (C), and carbachol (E) are direct parasympathomimetic agents. Epinephrine (B) is a sympathomimetic drug, and atropine (D) is an anticholinergic agent.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21696,7 +21696,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["caa382da"],
-		"explanation": "Acetylcholine (C) is the primary neurotransmitter involved in the action of parasympathomimetic drugs. Dopamine (A), norepinephrine (B), serotonin (D), and GABA (E) are not primarily involved.",
+		"rationale": "Acetylcholine (C) is the primary neurotransmitter involved in the action of parasympathomimetic drugs. Dopamine (A), norepinephrine (B), serotonin (D), and GABA (E) are not primarily involved.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21730,7 +21730,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e5c53657", "3d368768"],
-		"explanation": "Pilocarpine is used to treat narrow angle glaucoma (B) and Sjogren's syndrome (C). It is not used for hypertension (A), asthma (D), or depression (E).",
+		"rationale": "Pilocarpine is used to treat narrow angle glaucoma (B) and Sjogren's syndrome (C). It is not used for hypertension (A), asthma (D), or depression (E).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21764,7 +21764,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6f6f958d", "ffeaa339"],
-		"explanation": "The parasympathetic nervous system increases gut motility (B) and salivation (D). It decreases heart rate (A is incorrect), causes pupil constriction (C is incorrect), and bronchoconstriction (E is incorrect).",
+		"rationale": "The parasympathetic nervous system increases gut motility (B) and salivation (D). It decreases heart rate (A is incorrect), causes pupil constriction (C is incorrect), and bronchoconstriction (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21798,7 +21798,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["207d2dcc"],
-		"explanation": "Indirect parasympathomimetic agents inhibit acetylcholinesterase (B is correct). They do not directly bind to muscarinic receptors (A is incorrect), they increase acetylcholine levels (C is incorrect), they are not structurally similar to catecholamines (D is incorrect), and they are not used to treat hypertension (E is incorrect).",
+		"rationale": "Indirect parasympathomimetic agents inhibit acetylcholinesterase (B is correct). They do not directly bind to muscarinic receptors (A is incorrect), they increase acetylcholine levels (C is incorrect), they are not structurally similar to catecholamines (D is incorrect), and they are not used to treat hypertension (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21832,7 +21832,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0115b146"],
-		"explanation": "Parasympathomimetic drugs typically cause increased accommodation (A), decreased heart rate (B), increased sweating (D), and loosened sphincters (E). They cause pupil constriction, not dilation (C is incorrect).",
+		"rationale": "Parasympathomimetic drugs typically cause increased accommodation (A), decreased heart rate (B), increased sweating (D), and loosened sphincters (E). They cause pupil constriction, not dilation (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21866,7 +21866,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bf2bd4f5"],
-		"explanation": "Carbachol (B) has both direct and indirect parasympathomimetic properties. Pilocarpine (A) and cevimeline (E) are direct agents, atropine (C) is an anticholinergic, and epinephrine (D) is a sympathomimetic.",
+		"rationale": "Carbachol (B) has both direct and indirect parasympathomimetic properties. Pilocarpine (A) and cevimeline (E) are direct agents, atropine (C) is an anticholinergic, and epinephrine (D) is a sympathomimetic.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21900,7 +21900,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["af00cd13"],
-		"explanation": "SLUD (salivation, lacrimation, urination, digestion, defecation) is a common acronym used to remember the effects of parasympathomimetic drugs. The other acronyms do not relate to these effects.",
+		"rationale": "SLUD (salivation, lacrimation, urination, digestion, defecation) is a common acronym used to remember the effects of parasympathomimetic drugs. The other acronyms do not relate to these effects.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21934,7 +21934,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a37e8cb4", "45ec55f0"],
-		"explanation": "Parasympathomimetic drugs can cause bronchial contraction (B is correct) and are used to treat glaucoma (E is correct). They mimic the parasympathetic, not sympathetic, nervous system (A is incorrect), decrease heart rate (C is incorrect), and are not chemically similar to catecholamines (D is incorrect).",
+		"rationale": "Parasympathomimetic drugs can cause bronchial contraction (B is correct) and are used to treat glaucoma (E is correct). They mimic the parasympathetic, not sympathetic, nervous system (A is incorrect), decrease heart rate (C is incorrect), and are not chemically similar to catecholamines (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -21968,7 +21968,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f2204e05"],
-		"explanation": "Sympathomimetic drugs increase heart rate (B is correct). They activate adrenergic, not muscarinic, receptors (A is incorrect), increase blood pressure (C is incorrect), decrease gut motility (D is incorrect), and cause bronchodilation, not bronchoconstriction (E is incorrect).",
+		"rationale": "Sympathomimetic drugs increase heart rate (B is correct). They activate adrenergic, not muscarinic, receptors (A is incorrect), increase blood pressure (C is incorrect), decrease gut motility (D is incorrect), and cause bronchodilation, not bronchoconstriction (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22002,7 +22002,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4bfc86ad"],
-		"explanation": "Direct parasympathomimetic agents directly bind to muscarinic receptors (C is correct). They do not inhibit acetylcholinesterase (A is incorrect), do not bind to adrenergic receptors (B is incorrect), increase acetylcholine levels (D is incorrect), and are not used to treat asthma (E is incorrect).",
+		"rationale": "Direct parasympathomimetic agents directly bind to muscarinic receptors (C is correct). They do not inhibit acetylcholinesterase (A is incorrect), do not bind to adrenergic receptors (B is incorrect), increase acetylcholine levels (D is incorrect), and are not used to treat asthma (E is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22036,7 +22036,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9ff3ae0d"],
-		"explanation": "Alpha-adrenoceptor agonists induce smooth muscle contraction and vasoconstriction, not relaxation and vasodilation (A is incorrect). They mimic sympathetic, not parasympathetic, nerve activation (B is incorrect). Epinephrine is a non-specific alpha agonist used for cardiac arrest (C is correct). Dopamine is used to treat hypotension, not hypertension (D is incorrect).",
+		"rationale": "Alpha-adrenoceptor agonists induce smooth muscle contraction and vasoconstriction, not relaxation and vasodilation (A is incorrect). They mimic sympathetic, not parasympathetic, nerve activation (B is incorrect). Epinephrine is a non-specific alpha agonist used for cardiac arrest (C is correct). Dopamine is used to treat hypotension, not hypertension (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22066,7 +22066,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fafdf7d5"],
-		"explanation": "Dobutamine is a beta-1 agonist used for cardiogenic shock (A is correct). Mirabegron is a beta-3 agonist used for overactive bladder (B is incorrect). Epinephrine is a non-specific agonist (C is incorrect). Albuterol is a beta-2 agonist used as a bronchodilator (D is incorrect).",
+		"rationale": "Dobutamine is a beta-1 agonist used for cardiogenic shock (A is correct). Mirabegron is a beta-3 agonist used for overactive bladder (B is incorrect). Epinephrine is a non-specific agonist (C is incorrect). Albuterol is a beta-2 agonist used as a bronchodilator (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22096,7 +22096,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7f0e3933", "cec556a7"],
-		"explanation": "Beta-2 agonists cause bronchial smooth muscle relaxation (B is correct) and increase glycogenolysis in the liver (C is correct). Increased heart rate is primarily associated with beta-1 agonists (A is incorrect). Vasoconstriction is associated with alpha agonists, not beta-2 agonists (D is incorrect).",
+		"rationale": "Beta-2 agonists cause bronchial smooth muscle relaxation (B is correct) and increase glycogenolysis in the liver (C is correct). Increased heart rate is primarily associated with beta-1 agonists (A is incorrect). Vasoconstriction is associated with alpha agonists, not beta-2 agonists (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22126,7 +22126,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["94cbfef6"],
-		"explanation": "Beta-agonists have low bioavailability and must be given by intravenous infusion (B is correct). Long-term exposure causes receptor down-regulation, not up-regulation (A is incorrect). They primarily cause vasodilation, not vasoconstriction (C is incorrect). Mirabegron is used for overactive bladder, not asthma (D is incorrect).",
+		"rationale": "Beta-agonists have low bioavailability and must be given by intravenous infusion (B is correct). Long-term exposure causes receptor down-regulation, not up-regulation (A is incorrect). They primarily cause vasodilation, not vasoconstriction (C is incorrect). Mirabegron is used for overactive bladder, not asthma (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22156,7 +22156,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["662f0188", "420fb850"],
-		"explanation": "Epinephrine is used for the treatment of anaphylaxis (B is correct) and can be used in cases of bradycardia (D is correct). It was once used for glaucoma but is no longer used for this purpose (A is incorrect). Urinary incontinence is treated with beta-3 agonists like mirabegron, not epinephrine (C is incorrect).",
+		"rationale": "Epinephrine is used for the treatment of anaphylaxis (B is correct) and can be used in cases of bradycardia (D is correct). It was once used for glaucoma but is no longer used for this purpose (A is incorrect). Urinary incontinence is treated with beta-3 agonists like mirabegron, not epinephrine (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22186,7 +22186,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4a7c8947", "7a0f72d4"],
-		"explanation": "Dopamine is used to treat hypotension (B is correct) and cardiac arrest (D is correct). It is not a non-specific alpha agonist (A is incorrect). It is not used to treat hypertension (C is incorrect).",
+		"rationale": "Dopamine is used to treat hypotension (B is correct) and cardiac arrest (D is correct). It is not a non-specific alpha agonist (A is incorrect). It is not used to treat hypertension (C is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22216,7 +22216,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["93c2e0c1", "2b1e75c0"],
-		"explanation": "Beta-1 agonists increase heart rate (A is correct) and stimulate renin release (C is correct). Bronchial smooth muscle relaxation is associated with beta-2 agonists (B is incorrect). Vasodilation is primarily associated with beta-2 agonists (D is incorrect).",
+		"rationale": "Beta-1 agonists increase heart rate (A is correct) and stimulate renin release (C is correct). Bronchial smooth muscle relaxation is associated with beta-2 agonists (B is incorrect). Vasodilation is primarily associated with beta-2 agonists (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22246,7 +22246,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["36a5b6b5"],
-		"explanation": "Mirabegron is a beta-3 agonist used for overactive bladder (B is correct). Dobutamine is a beta-1 agonist (A is incorrect). Epinephrine is a non-specific agonist (C is incorrect). Albuterol is a beta-2 agonist (D is incorrect).",
+		"rationale": "Mirabegron is a beta-3 agonist used for overactive bladder (B is correct). Dobutamine is a beta-1 agonist (A is incorrect). Epinephrine is a non-specific agonist (C is incorrect). Albuterol is a beta-2 agonist (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22276,7 +22276,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3eb509ba"],
-		"explanation": "Beta-2 agonists are primarily used as bronchodilators (A is correct). They decrease systemic vascular resistance (B is incorrect). Long-term use can lead to receptor down-regulation, limiting their efficacy (C is incorrect). They cause bronchial smooth muscle relaxation, not contraction (D is incorrect).",
+		"rationale": "Beta-2 agonists are primarily used as bronchodilators (A is correct). They decrease systemic vascular resistance (B is incorrect). Long-term use can lead to receptor down-regulation, limiting their efficacy (C is incorrect). They cause bronchial smooth muscle relaxation, not contraction (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22306,7 +22306,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ae2f0efa"],
-		"explanation": "Long-term beta-agonist use can lead to receptor down-regulation (B is correct). It does not cause receptor up-regulation (A is incorrect). Beta-agonists have low bioavailability, which does not increase with long-term use (C is incorrect). They typically increase heart rate, not decrease it (D is incorrect).",
+		"rationale": "Long-term beta-agonist use can lead to receptor down-regulation (B is correct). It does not cause receptor up-regulation (A is incorrect). Beta-agonists have low bioavailability, which does not increase with long-term use (C is incorrect). They typically increase heart rate, not decrease it (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22336,7 +22336,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4882b693"],
-		"explanation": "The effect of beta-agonists on arterial pressure depends on the balance between cardiac stimulation (which increases pressure) and vascular effects (which decrease pressure) (C is correct). They do not always increase or decrease arterial pressure (A and B are incorrect). They do affect arterial pressure (D is incorrect).",
+		"rationale": "The effect of beta-agonists on arterial pressure depends on the balance between cardiac stimulation (which increases pressure) and vascular effects (which decrease pressure) (C is correct). They do not always increase or decrease arterial pressure (A and B are incorrect). They do affect arterial pressure (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22366,7 +22366,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d97566e2"],
-		"explanation": "Beta-2 agonists are used to treat asthma as bronchodilators (B is correct). Heart failure is treated with beta-1 agonists like dobutamine (A is incorrect). Bradycardia is treated with drugs like epinephrine or dopamine, not beta-2 agonists (C is incorrect). Overactive bladder is treated with beta-3 agonists like mirabegron (D is incorrect).",
+		"rationale": "Beta-2 agonists are used to treat asthma as bronchodilators (B is correct). Heart failure is treated with beta-1 agonists like dobutamine (A is incorrect). Bradycardia is treated with drugs like epinephrine or dopamine, not beta-2 agonists (C is incorrect). Overactive bladder is treated with beta-3 agonists like mirabegron (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22396,7 +22396,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5085ec8c"],
-		"explanation": "Beta-agonists have low bioavailability and are typically administered via intravenous infusion (C is correct). They do not have high oral bioavailability (A is incorrect) and are not typically administered orally (B is incorrect). They are metabolized relatively quickly (D is incorrect).",
+		"rationale": "Beta-agonists have low bioavailability and are typically administered via intravenous infusion (C is correct). They do not have high oral bioavailability (A is incorrect) and are not typically administered orally (B is incorrect). They are metabolized relatively quickly (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22426,7 +22426,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f337c676"],
-		"explanation": "Epinephrine is a non-specific alpha agonist (C is correct). Dobutamine is a beta-1 agonist (A is incorrect). Mirabegron is a beta-3 agonist (B is incorrect). Albuterol is a beta-2 agonist (D is incorrect).",
+		"rationale": "Epinephrine is a non-specific alpha agonist (C is correct). Dobutamine is a beta-1 agonist (A is incorrect). Mirabegron is a beta-3 agonist (B is incorrect). Albuterol is a beta-2 agonist (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22456,7 +22456,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["eb38169a"],
-		"explanation": "Beta-3 agonists, such as mirabegron, are used to treat urinary incontinence (C is correct). Increased heart rate is associated with beta-1 agonists (A is incorrect). Bronchial smooth muscle relaxation is associated with beta-2 agonists (B is incorrect). Vasoconstriction is associated with alpha agonists (D is incorrect).",
+		"rationale": "Beta-3 agonists, such as mirabegron, are used to treat urinary incontinence (C is correct). Increased heart rate is associated with beta-1 agonists (A is incorrect). Bronchial smooth muscle relaxation is associated with beta-2 agonists (B is incorrect). Vasoconstriction is associated with alpha agonists (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22486,7 +22486,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cc389d3d", "5b350893", "3f83c2d1"],
-		"explanation": "Sympathomimetic drugs mimic the effects of sympathetic nerve stimulation by directly activating adrenergic receptors (A) and increasing levels of norepinephrine and epinephrine (C). They are often structurally similar to catecholamines (D). They do not decrease norepinephrine levels (B) or block adrenergic receptors (E), which would be characteristic of sympatholytic drugs.",
+		"rationale": "Sympathomimetic drugs mimic the effects of sympathetic nerve stimulation by directly activating adrenergic receptors (A) and increasing levels of norepinephrine and epinephrine (C). They are often structurally similar to catecholamines (D). They do not decrease norepinephrine levels (B) or block adrenergic receptors (E), which would be characteristic of sympatholytic drugs.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22520,7 +22520,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a3f28590", "30417dcb", "ffb33e6e"],
-		"explanation": "The main side effects of phentolamine when used as an ophthalmic solution include ocular redness (A), stinging sensation (C), and dysgeusia (D). Increased intraocular pressure (B) and blurred vision (E) are not listed as primary side effects in this context.",
+		"rationale": "The main side effects of phentolamine when used as an ophthalmic solution include ocular redness (A), stinging sensation (C), and dysgeusia (D). Increased intraocular pressure (B) and blurred vision (E) are not listed as primary side effects in this context.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22554,7 +22554,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["17eb2895", "c5e83ad3", "db9c40b5"],
-		"explanation": "Sympatholytic agents include phentolamine (A), propranolol (B), and labetalol (D), which are alpha and beta blockers. Phenylephrine (C) and epinephrine (E) are sympathomimetic agents, not sympatholytic.",
+		"rationale": "Sympatholytic agents include phentolamine (A), propranolol (B), and labetalol (D), which are alpha and beta blockers. Phenylephrine (C) and epinephrine (E) are sympathomimetic agents, not sympatholytic.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22588,7 +22588,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cbbcc4f7", "263354cf", "9aa2c7fb"],
-		"explanation": "Sympatholytic drugs are used in the treatment of systemic hypertension (A), prostate hyperplasia (B), and heart failure (D). They are not typically used for asthma (C) or acute allergic reactions (E), where sympathomimetic agents might be more appropriate.",
+		"rationale": "Sympatholytic drugs are used in the treatment of systemic hypertension (A), prostate hyperplasia (B), and heart failure (D). They are not typically used for asthma (C) or acute allergic reactions (E), where sympathomimetic agents might be more appropriate.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22622,7 +22622,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["37cc4c60", "01b27735"],
-		"explanation": "Sympathomimetic drugs mimic the sympathetic nervous system, not the parasympathetic. They can directly activate adrenergic receptors and are chemically similar to catecholamines. They increase, not decrease, norepinephrine and epinephrine levels.",
+		"rationale": "Sympathomimetic drugs mimic the sympathetic nervous system, not the parasympathetic. They can directly activate adrenergic receptors and are chemically similar to catecholamines. They increase, not decrease, norepinephrine and epinephrine levels.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22656,7 +22656,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7cd2055e", "2e380523", "91dc8ae5"],
-		"explanation": "Parasympathomimetic drugs cause miosis, bronchial contraction, and increased gut motility. They decrease heart rate and increase gland secretion, not the opposite.",
+		"rationale": "Parasympathomimetic drugs cause miosis, bronchial contraction, and increased gut motility. They decrease heart rate and increase gland secretion, not the opposite.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22690,7 +22690,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b7abe598"],
-		"explanation": "Indirect parasympathomimetic drugs inhibit acetylcholinesterase, increasing acetylcholine levels. They do not directly activate adrenergic receptors or bind to muscarinic ACh receptors.",
+		"rationale": "Indirect parasympathomimetic drugs inhibit acetylcholinesterase, increasing acetylcholine levels. They do not directly activate adrenergic receptors or bind to muscarinic ACh receptors.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22724,7 +22724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e5c53657", "3d368768"],
-		"explanation": "Pilocarpine is used to treat narrow angle glaucoma and Sjogren's syndrome. It is not used for hypertension, asthma, or tachycardia.",
+		"rationale": "Pilocarpine is used to treat narrow angle glaucoma and Sjogren's syndrome. It is not used for hypertension, asthma, or tachycardia.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22758,7 +22758,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["976b2196", "0573dfd2"],
-		"explanation": "Parasympathomimetic drugs can cause increased accommodation and asthenopia. They cause hypotension, increased sweating, and increased gut motility, not the opposite.",
+		"rationale": "Parasympathomimetic drugs can cause increased accommodation and asthenopia. They cause hypotension, increased sweating, and increased gut motility, not the opposite.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22792,7 +22792,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["40328ebc"],
-		"explanation": "Carbachol is used to reduce pupil size after cataract extraction. It has both direct and indirect parasympathomimetic properties. It is not a sympathomimetic drug and is not used for asthma. It can increase gland secretion.",
+		"rationale": "Carbachol is used to reduce pupil size after cataract extraction. It has both direct and indirect parasympathomimetic properties. It is not a sympathomimetic drug and is not used for asthma. It can increase gland secretion.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22826,7 +22826,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["62c6cc89", "caeaf369", "ceac18a7"],
-		"explanation": "Sympathomimetic drugs increase heart rate, cause bronchial relaxation, and decrease gut motility. They typically cause vasoconstriction and decreased gland secretion.",
+		"rationale": "Sympathomimetic drugs increase heart rate, cause bronchial relaxation, and decrease gut motility. They typically cause vasoconstriction and decreased gland secretion.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22860,7 +22860,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d4ad270d", "e941e60b"],
-		"explanation": "Cevimeline and pilocarpine are used to increase saliva and tear production in Sjogren's syndrome. Atropine, epinephrine, and norepinephrine are not used for this purpose.",
+		"rationale": "Cevimeline and pilocarpine are used to increase saliva and tear production in Sjogren's syndrome. Atropine, epinephrine, and norepinephrine are not used for this purpose.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22894,7 +22894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c70ddbc6", "664cd6fd"],
-		"explanation": "Benztropine and trihexyphenidyl are anticholinergic drugs used to relieve symptoms of Parkinson's disease by countering reduced dopamine levels. Ipratropium is used for COPD, oxybutynin for urge incontinence, and scopolamine for motion sickness.",
+		"rationale": "Benztropine and trihexyphenidyl are anticholinergic drugs used to relieve symptoms of Parkinson's disease by countering reduced dopamine levels. Ipratropium is used for COPD, oxybutynin for urge incontinence, and scopolamine for motion sickness.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22928,7 +22928,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["971bbfa8", "6d18237f"],
-		"explanation": "Parasympathomimetic drugs can cause miosis and increased gland secretion due to their action on the parasympathetic nervous system. They cause bronchial contraction, decreased heart rate, and increased gut motility, not bronchodilation, increased heart rate, or constipation.",
+		"rationale": "Parasympathomimetic drugs can cause miosis and increased gland secretion due to their action on the parasympathetic nervous system. They cause bronchial contraction, decreased heart rate, and increased gut motility, not bronchodilation, increased heart rate, or constipation.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22962,7 +22962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["08b4b05b", "492030a9"],
-		"explanation": "Parasympatholytic drugs, such as ipratropium and tiotropium, are used to treat COPD by causing bronchodilation, not bronchoconstriction. Oxybutynin and tolterodine are used for urge incontinence. They block acetylcholine receptors, not increase acetylcholine levels or act as direct agonists.",
+		"rationale": "Parasympatholytic drugs, such as ipratropium and tiotropium, are used to treat COPD by causing bronchodilation, not bronchoconstriction. Oxybutynin and tolterodine are used for urge incontinence. They block acetylcholine receptors, not increase acetylcholine levels or act as direct agonists.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -22996,7 +22996,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7cc605f9", "2c371da6"],
-		"explanation": "Parasympathomimetic drugs cause bronchial contraction and loosened sphincters. They decrease heart rate, increase gland secretion, and cause miosis, not mydriasis.",
+		"rationale": "Parasympathomimetic drugs cause bronchial contraction and loosened sphincters. They decrease heart rate, increase gland secretion, and cause miosis, not mydriasis.",
 		"metadata": {},
 		"moduleId": "js7ajsxpe52svzggfd964j48hh7m8afb",
 		"options": [
@@ -23030,7 +23030,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["71791e91", "a1208bbf", "ce0478e2"],
-		"explanation": "Alkylating agents are cell-cycle nonspecific (A is incorrect) and work by binding to negatively charged sites on DNA (B is correct), particularly targeting the N7 atom of guanine (C is correct). They impair DNA replication by causing DNA cross-linking inhibition (E is correct), not enhancing it (D is incorrect).",
+		"rationale": "Alkylating agents are cell-cycle nonspecific (A is incorrect) and work by binding to negatively charged sites on DNA (B is correct), particularly targeting the N7 atom of guanine (C is correct). They impair DNA replication by causing DNA cross-linking inhibition (E is correct), not enhancing it (D is incorrect).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23064,7 +23064,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cba4f8ad", "682deaca", "57b6ce80"],
-		"explanation": "Alkylating agents commonly cause severe nausea and vomiting (A), alopecia (B), and pancytopenia (C). Increased appetite (D) and hyperactivity (E) are not typical side effects.",
+		"rationale": "Alkylating agents commonly cause severe nausea and vomiting (A), alopecia (B), and pancytopenia (C). Increased appetite (D) and hyperactivity (E) are not typical side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23098,7 +23098,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0ea75329", "4c4ecd5c", "db58e405", "f6a2dd86"],
-		"explanation": "Ifosfamide can cause neurotoxic effects such as acute confusion and delirium (A), seizures (B), paralysis (C), and coma (D). Euphoria (E) is not a typical neurotoxic effect.",
+		"rationale": "Ifosfamide can cause neurotoxic effects such as acute confusion and delirium (A), seizures (B), paralysis (C), and coma (D). Euphoria (E) is not a typical neurotoxic effect.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23132,7 +23132,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44aa716e", "47d1fcf0", "4070b423", "67bf7ffd"],
-		"explanation": "Long-term risks of alkylating agents include secondary cancers like Acute Myeloid Leukemia (A), pulmonary fibrosis (B), veno-occlusive disease of the liver (C), and renal failure (D). Cardiomyopathy (E) is not typically associated with alkylating agents.",
+		"rationale": "Long-term risks of alkylating agents include secondary cancers like Acute Myeloid Leukemia (A), pulmonary fibrosis (B), veno-occlusive disease of the liver (C), and renal failure (D). Cardiomyopathy (E) is not typically associated with alkylating agents.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23166,7 +23166,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4139387d", "e7c3e716"],
-		"explanation": "Alkylating agents increase toxicity in the gastrointestinal tract (A) and are bactericidal to the gut microbiome (B). They do not enhance nutrient absorption (C), cause constipation (D), or reduce gastric acid secretion (E).",
+		"rationale": "Alkylating agents increase toxicity in the gastrointestinal tract (A) and are bactericidal to the gut microbiome (B). They do not enhance nutrient absorption (C), cause constipation (D), or reduce gastric acid secretion (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23200,7 +23200,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1cb1903b", "3ff573b0"],
-		"explanation": "Ocular side effects of alkylating agents include dry eye (A) and opportunistic infections like herpes simplex keratitis (B). Cataracts (C), glaucoma (D), and retinal detachment (E) are not commonly associated with these agents.",
+		"rationale": "Ocular side effects of alkylating agents include dry eye (A) and opportunistic infections like herpes simplex keratitis (B). Cataracts (C), glaucoma (D), and retinal detachment (E) are not commonly associated with these agents.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23234,7 +23234,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ce03acb5", "bc88c3e0"],
-		"explanation": "Alkylating agents are toxic to both cancerous and normal rapidly dividing cells (B) and can cause apoptosis in these cells (D). They do not selectively target cancer cells only (A), enhance proliferation of normal cells (C), or have no effect on normal cells (E).",
+		"rationale": "Alkylating agents are toxic to both cancerous and normal rapidly dividing cells (B) and can cause apoptosis in these cells (D). They do not selectively target cancer cells only (A), enhance proliferation of normal cells (C), or have no effect on normal cells (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23268,7 +23268,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2238feba"],
-		"explanation": "The use of nitrosoureas has been associated with renal failure (A). Hypertension (B), diabetes mellitus (C), hyperlipidemia (D), and osteoporosis (E) are not specifically exacerbated by nitrosoureas.",
+		"rationale": "The use of nitrosoureas has been associated with renal failure (A). Hypertension (B), diabetes mellitus (C), hyperlipidemia (D), and osteoporosis (E) are not specifically exacerbated by nitrosoureas.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23302,7 +23302,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["44bc4a4f"],
-		"explanation": "The primary target of alkylation in DNA by alkylating agents is guanine (D), specifically the N7 atom. Adenine (A), thymine (B), cytosine (C), and uracil (E) are not the primary targets.",
+		"rationale": "The primary target of alkylation in DNA by alkylating agents is guanine (D), specifically the N7 atom. Adenine (A), thymine (B), cytosine (C), and uracil (E) are not the primary targets.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23336,7 +23336,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["00019fb0"],
-		"explanation": "Alkylating agents are cell-cycle nonspecific agents (B), meaning they can attack DNA at any point in the cell cycle. They do not specifically target cells in the S phase (C), M phase (D), or G1 phase (E).",
+		"rationale": "Alkylating agents are cell-cycle nonspecific agents (B), meaning they can attack DNA at any point in the cell cycle. They do not specifically target cells in the S phase (C), M phase (D), or G1 phase (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23370,7 +23370,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["20fc8ab3", "1a4797d3", "7b107f63"],
-		"explanation": "Common hematological side effects of alkylating agents include thrombocytopenia (B), anemia (C), and pancytopenia (D). Leukocytosis (A) and polycythemia (E) are not typical side effects.",
+		"rationale": "Common hematological side effects of alkylating agents include thrombocytopenia (B), anemia (C), and pancytopenia (D). Leukocytosis (A) and polycythemia (E) are not typical side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23404,7 +23404,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["25b711ca", "89e3f53c", "abf8f96d"],
-		"explanation": "Potential acute side effects of alkylating agents on the central nervous system include confusion (B), delirium (C), and seizures (D). Euphoria (A) and hallucinations (E) are not typical acute side effects.",
+		"rationale": "Potential acute side effects of alkylating agents on the central nervous system include confusion (B), delirium (C), and seizures (D). Euphoria (A) and hallucinations (E) are not typical acute side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23438,7 +23438,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e9fcfaf3", "bf1fda3c"],
-		"explanation": "Alkylating agents are bactericidal to the gut microbiome (B) and can cause dysbiosis (D). They do not promote the growth of beneficial bacteria (A), have no effect (C), or enhance gut flora diversity (E).",
+		"rationale": "Alkylating agents are bactericidal to the gut microbiome (B) and can cause dysbiosis (D). They do not promote the growth of beneficial bacteria (A), have no effect (C), or enhance gut flora diversity (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23472,7 +23472,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["915103b1"],
-		"explanation": "Pulmonary fibrosis (A) is a potential long-term effect of alkylating agents. Asthma (B), COPD (C), pulmonary embolism (D), and pneumonia (E) are not specifically associated with long-term use of alkylating agents.",
+		"rationale": "Pulmonary fibrosis (A) is a potential long-term effect of alkylating agents. Asthma (B), COPD (C), pulmonary embolism (D), and pneumonia (E) are not specifically associated with long-term use of alkylating agents.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23506,7 +23506,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e59f6e09"],
-		"explanation": "Veno-occlusive disease (B) is a potential hepatic effect of alkylating agents. Hepatitis (A), cirrhosis (C), fatty liver (D), and liver cancer (E) are not specifically associated with alkylating agents.",
+		"rationale": "Veno-occlusive disease (B) is a potential hepatic effect of alkylating agents. Hepatitis (A), cirrhosis (C), fatty liver (D), and liver cancer (E) are not specifically associated with alkylating agents.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23540,7 +23540,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["10b5ca13", "0e17b595", "675ef172"],
-		"explanation": "Mechlorethamine is used topically for mycosis fungoides and as a palliative therapy for breast and lung cancers. It is also known to cause alopecia. It is not administered orally for Hodgkin's disease (it is given by injection) and is effective against non-Hodgkin's lymphoma.",
+		"rationale": "Mechlorethamine is used topically for mycosis fungoides and as a palliative therapy for breast and lung cancers. It is also known to cause alopecia. It is not administered orally for Hodgkin's disease (it is given by injection) and is effective against non-Hodgkin's lymphoma.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23574,7 +23574,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["016bd566", "a6c80581", "0d13fe0d"],
-		"explanation": "Chlorambucil is used to treat chronic lymphocytic leukemia, Hodgkin's disease, and Waldenstrom's macroglobulinemia. It is not used for islet cell pancreatic cancer (treated with Streptozocin) or chronic myelogenous leukemia (treated with Busulfan).",
+		"rationale": "Chlorambucil is used to treat chronic lymphocytic leukemia, Hodgkin's disease, and Waldenstrom's macroglobulinemia. It is not used for islet cell pancreatic cancer (treated with Streptozocin) or chronic myelogenous leukemia (treated with Busulfan).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23608,7 +23608,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["08d4c9db", "901fe236"],
-		"explanation": "Nitrosoureas are lipophilic and can cross the blood-brain barrier, making them useful for treating brain cancer. Streptozocin is a type of Nitrosourea used for islet cell pancreatic cancer. They are not administered orally.",
+		"rationale": "Nitrosoureas are lipophilic and can cross the blood-brain barrier, making them useful for treating brain cancer. Streptozocin is a type of Nitrosourea used for islet cell pancreatic cancer. They are not administered orally.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23642,7 +23642,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["336dfa2f"],
-		"explanation": "Cataracts are a potential ocular side effect of Busulfan. Dry eye and herpes simplex keratitis are associated with other alkylating agents, not specifically Busulfan. Glaucoma and retinal detachment are not mentioned as side effects.",
+		"rationale": "Cataracts are a potential ocular side effect of Busulfan. Dry eye and herpes simplex keratitis are associated with other alkylating agents, not specifically Busulfan. Glaucoma and retinal detachment are not mentioned as side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23676,7 +23676,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["80ef57e0"],
-		"explanation": "Busulfan forms DNA-DNA intrastrand crosslinks. Mechlorethamine, Chlorambucil, Streptozocin, and Procarbazine do not specifically form these types of crosslinks.",
+		"rationale": "Busulfan forms DNA-DNA intrastrand crosslinks. Mechlorethamine, Chlorambucil, Streptozocin, and Procarbazine do not specifically form these types of crosslinks.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23710,7 +23710,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cf1ad6d8", "41646a0b", "b1bb6a6e", "de21abbf"],
-		"explanation": "Triazenes and Hydrazines are used to treat metastatic malignant melanoma, Hodgkin's disease, islet cell carcinoma, and medullary thyroid carcinoma. They are not used for chronic myelogenous leukemia.",
+		"rationale": "Triazenes and Hydrazines are used to treat metastatic malignant melanoma, Hodgkin's disease, islet cell carcinoma, and medullary thyroid carcinoma. They are not used for chronic myelogenous leukemia.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23744,7 +23744,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4f000114", "b376359f"],
-		"explanation": "Streptozocin is given intravenously and can cause tissue damage if it escapes from the vein. It is not used for chronic lymphocytic leukemia or Hodgkin's disease.",
+		"rationale": "Streptozocin is given intravenously and can cause tissue damage if it escapes from the vein. It is not used for chronic lymphocytic leukemia or Hodgkin's disease.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23778,7 +23778,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c3c6dc61", "131b52d4", "a95e0660", "b036bf91"],
-		"explanation": "Ifosfamide can cause acute confusion and delirium, seizures, paralysis, and coma as neurotoxic effects. Hyperactivity is not a known effect.",
+		"rationale": "Ifosfamide can cause acute confusion and delirium, seizures, paralysis, and coma as neurotoxic effects. Hyperactivity is not a known effect.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23812,7 +23812,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["19210a48", "38bbee0f"],
-		"explanation": "Alkylating agents increase toxicity in the gastrointestinal tract and are bactericidal to the gut microbiome. They do not cause hypermotility, protect against ulcers, or reduce the risk of infections.",
+		"rationale": "Alkylating agents increase toxicity in the gastrointestinal tract and are bactericidal to the gut microbiome. They do not cause hypermotility, protect against ulcers, or reduce the risk of infections.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23846,7 +23846,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["40121f1e", "160c6c07"],
-		"explanation": "Chlorambucil is used to treat chronic lymphocytic leukemia and is well tolerated compared to other alkylating agents. It is administered in tablet form, not by injection, and can be used to treat Hodgkin's disease. It does not cross the blood-brain barrier, so it is not used for brain cancer.",
+		"rationale": "Chlorambucil is used to treat chronic lymphocytic leukemia and is well tolerated compared to other alkylating agents. It is administered in tablet form, not by injection, and can be used to treat Hodgkin's disease. It does not cross the blood-brain barrier, so it is not used for brain cancer.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23880,7 +23880,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bdfe6075", "af720906", "e87797a5"],
-		"explanation": "Alkylating agents can cause secondary cancers like Acute Myeloid Leukemia, pulmonary fibrosis, and opportunistic infections, especially herpetic keratitis. ",
+		"rationale": "Alkylating agents can cause secondary cancers like Acute Myeloid Leukemia, pulmonary fibrosis, and opportunistic infections, especially herpetic keratitis. ",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23914,7 +23914,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f21d5208", "07fe3b5c", "8b04f2e6"],
-		"explanation": "Nitrosoureas are lipophilic, allowing them to cross the blood-brain barrier and be used in treating brain cancer. They decompose to produce alkylating compounds under physiological conditions. They do not require specialized membrane transporters for cell entry, unlike pyrimidine analogues.",
+		"rationale": "Nitrosoureas are lipophilic, allowing them to cross the blood-brain barrier and be used in treating brain cancer. They decompose to produce alkylating compounds under physiological conditions. They do not require specialized membrane transporters for cell entry, unlike pyrimidine analogues.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23948,7 +23948,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3530abfb", "a3a33399", "85aa0222"],
-		"explanation": "Pyrimidine analogues interfere with nucleic acid synthesis, require intracellular enzymes for activation, and cause chain termination and inhibition of DNA synthesis. They are hydrophilic, not lipophilic, and are not used to treat renal failure.",
+		"rationale": "Pyrimidine analogues interfere with nucleic acid synthesis, require intracellular enzymes for activation, and cause chain termination and inhibition of DNA synthesis. They are hydrophilic, not lipophilic, and are not used to treat renal failure.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -23982,7 +23982,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2474dddd", "1e7813e1", "aeb1514e"],
-		"explanation": "Mechlorethamine is used to treat Hodgkin's disease, non-Hodgkin's lymphoma, and mycosis fungoides. It is not used for brain cancer or chronic lymphocytic leukemia.",
+		"rationale": "Mechlorethamine is used to treat Hodgkin's disease, non-Hodgkin's lymphoma, and mycosis fungoides. It is not used for brain cancer or chronic lymphocytic leukemia.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24016,7 +24016,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["986069d6", "c34a7acf"],
-		"explanation": "Busulfan is used to treat chronic myelogenous leukemia and can cause cataracts as a potential ocular side effect. It forms DNA-DNA intrastrand crosslinks between guanine and adenine, not adenine and thymine, and acts through an SN2 reaction mechanism, not SN1. It is not used to treat Hodgkin's disease.",
+		"rationale": "Busulfan is used to treat chronic myelogenous leukemia and can cause cataracts as a potential ocular side effect. It forms DNA-DNA intrastrand crosslinks between guanine and adenine, not adenine and thymine, and acts through an SN2 reaction mechanism, not SN1. It is not used to treat Hodgkin's disease.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24050,7 +24050,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["33c681fd", "b33c92ed", "2d85878b"],
-		"explanation": "Triazenes and hydrazines are used to treat metastatic malignant melanoma, Hodgkin's disease, and soft tissue sarcomas. They are not used for chronic myelogenous leukemia, which is treated with Busulfan, nor are they used to treat cataracts.",
+		"rationale": "Triazenes and hydrazines are used to treat metastatic malignant melanoma, Hodgkin's disease, and soft tissue sarcomas. They are not used for chronic myelogenous leukemia, which is treated with Busulfan, nor are they used to treat cataracts.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24084,7 +24084,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b83a189", "0272c4a0"],
-		"explanation": "Busulfan forms DNA-DNA intrastrand crosslinks and acts through an SN2 reaction mechanism. It does not inhibit topoisomerase II or protein synthesis, and it does not act via alkyl diazonium intermediates, which is the mechanism of triazenes and hydrazines.",
+		"rationale": "Busulfan forms DNA-DNA intrastrand crosslinks and acts through an SN2 reaction mechanism. It does not inhibit topoisomerase II or protein synthesis, and it does not act via alkyl diazonium intermediates, which is the mechanism of triazenes and hydrazines.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24118,7 +24118,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8b417bef", "7dcb014a"],
-		"explanation": "Cataracts and neurotoxicity are potential side effects of Busulfan. Neurotoxicity is a potential side effect of all alkylating agents, but cataracts are specifically noted with Busulfan use. ",
+		"rationale": "Cataracts and neurotoxicity are potential side effects of Busulfan. Neurotoxicity is a potential side effect of all alkylating agents, but cataracts are specifically noted with Busulfan use. ",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24152,7 +24152,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d2da1100", "444a321c"],
-		"explanation": "Triazenes and hydrazines are metabolized to produce alkyl diazonium intermediates and can be used to treat neuroblastoma. They do not form DNA-DNA intrastrand crosslinks, which is a mechanism of Busulfan, and they do not act through an SN2 reaction mechanism. They are not used to treat chronic myelogenous leukemia.",
+		"rationale": "Triazenes and hydrazines are metabolized to produce alkyl diazonium intermediates and can be used to treat neuroblastoma. They do not form DNA-DNA intrastrand crosslinks, which is a mechanism of Busulfan, and they do not act through an SN2 reaction mechanism. They are not used to treat chronic myelogenous leukemia.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24186,7 +24186,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8a6a8c17", "28dc7064", "c4366076", "26906644"],
-		"explanation": "Mitomycin C alkylates DNA, induces DNA cross-links, and inhibits both RNA and protein synthesis at high concentrations. It does not catalyze DNA cross-linking without alkyl group donation; this is a characteristic of platinum drugs, not mitomycin C.",
+		"rationale": "Mitomycin C alkylates DNA, induces DNA cross-links, and inhibits both RNA and protein synthesis at high concentrations. It does not catalyze DNA cross-linking without alkyl group donation; this is a characteristic of platinum drugs, not mitomycin C.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24220,7 +24220,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cabcdc3e", "5db12956", "5d23f0e5"],
-		"explanation": "Mitomycin C is used in the treatment of advanced stomach cancer and in ocular surgeries to prevent scarring, as well as in PRK to reduce corneal haze. It is not typically used for testicular or colorectal cancer, which are more commonly treated with platinum drugs like cisplatin and oxaliplatin, respectively.",
+		"rationale": "Mitomycin C is used in the treatment of advanced stomach cancer and in ocular surgeries to prevent scarring, as well as in PRK to reduce corneal haze. It is not typically used for testicular or colorectal cancer, which are more commonly treated with platinum drugs like cisplatin and oxaliplatin, respectively.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24254,7 +24254,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["603a13dc", "77d2b6f3", "84e87dad"],
-		"explanation": "Cisplatin is referred to as the \"penicillin of cancer\" due to its widespread use. Oxaliplatin is approved for colorectal cancer, and carboplatin was designed to have fewer side effects than cisplatin. Platinum drugs do not donate an alkyl group; they act as catalysts for DNA cross-linking.",
+		"rationale": "Cisplatin is referred to as the \"penicillin of cancer\" due to its widespread use. Oxaliplatin is approved for colorectal cancer, and carboplatin was designed to have fewer side effects than cisplatin. Platinum drugs do not donate an alkyl group; they act as catalysts for DNA cross-linking.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24288,7 +24288,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cc074098", "9d02f391", "4edd72a6"],
-		"explanation": "Cisplatin is formally approved for the treatment of bladder, ovarian, and testicular cancers. It is not formally approved for pancreatic or stomach cancer, although it may be used off-label in some cases.",
+		"rationale": "Cisplatin is formally approved for the treatment of bladder, ovarian, and testicular cancers. It is not formally approved for pancreatic or stomach cancer, although it may be used off-label in some cases.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24322,7 +24322,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4d40ea7d"],
-		"explanation": "Mitomycin C is used in ocular surgeries primarily to prevent fibroblast proliferation and scarring, which can improve surgical outcomes. It is not used to treat infections, reduce intraocular pressure, enhance visual acuity, or treat ocular cancers.",
+		"rationale": "Mitomycin C is used in ocular surgeries primarily to prevent fibroblast proliferation and scarring, which can improve surgical outcomes. It is not used to treat infections, reduce intraocular pressure, enhance visual acuity, or treat ocular cancers.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24356,7 +24356,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["57998800", "28ca60aa", "0646e008"],
-		"explanation": "Pemetrexed inhibits thymidylate synthase (A), dihydrofolate reductase (B), and glycinamide ribonucleotide formyltransferase (C), which are involved in purine and pyrimidine synthesis. It does not inhibit DNA polymerase (D) or RNA polymerase (E).",
+		"rationale": "Pemetrexed inhibits thymidylate synthase (A), dihydrofolate reductase (B), and glycinamide ribonucleotide formyltransferase (C), which are involved in purine and pyrimidine synthesis. It does not inhibit DNA polymerase (D) or RNA polymerase (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24390,7 +24390,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7d449dde", "d3088e08", "f94be765"],
-		"explanation": "Cisplatin is used for bladder, testicular, and ovarian cancers (A) and is often referred to as the \"penicillin of cancer\" (E). Carboplatin was designed to have less severe side effects than cisplatin (B). Oxaliplatin is approved for colorectal cancer (C). Platinum drugs induce DNA cross-linking but are not considered alkylating agents (D).",
+		"rationale": "Cisplatin is used for bladder, testicular, and ovarian cancers (A) and is often referred to as the \"penicillin of cancer\" (E). Carboplatin was designed to have less severe side effects than cisplatin (B). Oxaliplatin is approved for colorectal cancer (C). Platinum drugs induce DNA cross-linking but are not considered alkylating agents (D).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24424,7 +24424,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["15fe43b4", "60c0ae71", "9057208c"],
-		"explanation": "Methotrexate inhibits dihydrofolate reductase (A), which leads to reduced folate production (D) and ultimately inhibits DNA production in rapidly replicating cells (E). It does not inhibit thymidylate synthase (B) or glycinamide ribonucleotide formyltransferase (C), which are inhibited by pemetrexed.",
+		"rationale": "Methotrexate inhibits dihydrofolate reductase (A), which leads to reduced folate production (D) and ultimately inhibits DNA production in rapidly replicating cells (E). It does not inhibit thymidylate synthase (B) or glycinamide ribonucleotide formyltransferase (C), which are inhibited by pemetrexed.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24458,7 +24458,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bb38bc03", "63c398d7", "1ed9ce3c", "fe6246e2"],
-		"explanation": "Pemetrexed can cause conjunctivitis (A), dry eye (B), optic neuropathy (C) and ectropion (D). Cataracts (E) are not listed as a side effect of pemetrexed.",
+		"rationale": "Pemetrexed can cause conjunctivitis (A), dry eye (B), optic neuropathy (C) and ectropion (D). Cataracts (E) are not listed as a side effect of pemetrexed.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24492,7 +24492,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["05c4e215", "655c9fdc", "acdb5236"],
-		"explanation": "Methotrexate can cause hepatotoxicity (A), leukopenia (B), and neurological damage (D). Hyperkalemia (C) and hyperglycemia (E) are not listed as side effects of methotrexate.",
+		"rationale": "Methotrexate can cause hepatotoxicity (A), leukopenia (B), and neurological damage (D). Hyperkalemia (C) and hyperglycemia (E) are not listed as side effects of methotrexate.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24526,7 +24526,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["20f888e0", "51d15d9a"],
-		"explanation": "Pemetrexed is used to treat pleural mesothelioma (B) and non-small cell lung cancer (C). It is not indicated for breast cancer (A), prostate cancer (D), or colorectal cancer (E).",
+		"rationale": "Pemetrexed is used to treat pleural mesothelioma (B) and non-small cell lung cancer (C). It is not indicated for breast cancer (A), prostate cancer (D), or colorectal cancer (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24560,7 +24560,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["01a7fcfc", "992f0e93"],
-		"explanation": "Folic acid analogs can cause myelosuppression and pancytopenia (B) and inhibit enzymes involved in purine and pyrimidine synthesis (D). They do not enhance DNA synthesis (A), are not primarily used for bacterial infections (C), and do have reported ocular side effects (E).",
+		"rationale": "Folic acid analogs can cause myelosuppression and pancytopenia (B) and inhibit enzymes involved in purine and pyrimidine synthesis (D). They do not enhance DNA synthesis (A), are not primarily used for bacterial infections (C), and do have reported ocular side effects (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24594,7 +24594,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f21ae62f", "d2a188f5"],
-		"explanation": "Pyrimidine analogues are hydrophilic, not hydrophobic, and require specialized transporters for cell entry. They interfere with nucleic acid synthesis, which is why they are used as antineoplastic agents. They are not used to treat bacterial infections and can cause bone marrow suppression.",
+		"rationale": "Pyrimidine analogues are hydrophilic, not hydrophobic, and require specialized transporters for cell entry. They interfere with nucleic acid synthesis, which is why they are used as antineoplastic agents. They are not used to treat bacterial infections and can cause bone marrow suppression.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24628,7 +24628,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2e2d5ceb"],
-		"explanation": "Capecitabine is a prodrug that is converted to fluorouracil in the body, where it inhibits DNA synthesis. 5-Fluorouracil is not a prodrug; it is the active form. Cytarabine, gemcitabine, and mercaptopurine are not converted to fluorouracil.",
+		"rationale": "Capecitabine is a prodrug that is converted to fluorouracil in the body, where it inhibits DNA synthesis. 5-Fluorouracil is not a prodrug; it is the active form. Cytarabine, gemcitabine, and mercaptopurine are not converted to fluorouracil.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24662,7 +24662,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["43982f92"],
-		"explanation": "Cytarabine is primarily used in the treatment of acute non-lymphoblastic leukemia. 5-Fluorouracil and capecitabine are used for other types of cancers, while gemcitabine is used for various carcinomas, and mercaptopurine is used in leukemia treatment but not specifically for acute non-lymphoblastic leukemia.",
+		"rationale": "Cytarabine is primarily used in the treatment of acute non-lymphoblastic leukemia. 5-Fluorouracil and capecitabine are used for other types of cancers, while gemcitabine is used for various carcinomas, and mercaptopurine is used in leukemia treatment but not specifically for acute non-lymphoblastic leukemia.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24696,7 +24696,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4f1841d7", "70f8f733"],
-		"explanation": "Both capecitabine and cytarabine can cause corneal deposits and verticillata (whorl opacities). 5-Fluorouracil, gemcitabine, and mercaptopurine are not associated with these ocular side effects.",
+		"rationale": "Both capecitabine and cytarabine can cause corneal deposits and verticillata (whorl opacities). 5-Fluorouracil, gemcitabine, and mercaptopurine are not associated with these ocular side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24730,7 +24730,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ce4cce42"],
-		"explanation": "Mercaptopurine is used to treat Crohn's disease and ulcerative colitis due to its immunosuppressant properties. The other drugs listed are primarily used as chemotherapeutic agents.",
+		"rationale": "Mercaptopurine is used to treat Crohn's disease and ulcerative colitis due to its immunosuppressant properties. The other drugs listed are primarily used as chemotherapeutic agents.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24764,7 +24764,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["703a232d"],
-		"explanation": "5-Fluorouracil is used in ocular surgeries, such as pterygium and trabeculotomy, to prevent fibroblast proliferation and scarring. The other drugs are not used for this purpose.",
+		"rationale": "5-Fluorouracil is used in ocular surgeries, such as pterygium and trabeculotomy, to prevent fibroblast proliferation and scarring. The other drugs are not used for this purpose.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24798,7 +24798,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cfb25d51"],
-		"explanation": "Gemcitabine is being investigated for use in esophageal cancer. The other drugs are not currently being investigated for this specific type of cancer.",
+		"rationale": "Gemcitabine is being investigated for use in esophageal cancer. The other drugs are not currently being investigated for this specific type of cancer.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24832,7 +24832,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3bfcb58b", "45100dc7"],
-		"explanation": "5-Fluorouracil and its prodrug capecitabine inhibit the enzyme thymidylate synthetase, which is crucial for DNA synthesis. Cytarabine, gemcitabine, and mercaptopurine do not inhibit this enzyme.",
+		"rationale": "5-Fluorouracil and its prodrug capecitabine inhibit the enzyme thymidylate synthetase, which is crucial for DNA synthesis. Cytarabine, gemcitabine, and mercaptopurine do not inhibit this enzyme.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24866,7 +24866,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["546f9a63"],
-		"explanation": "Cytarabine is associated with uveitis as a side effect. The other drugs do not have this specific side effect.",
+		"rationale": "Cytarabine is associated with uveitis as a side effect. The other drugs do not have this specific side effect.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24900,7 +24900,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c4d8874a"],
-		"explanation": "Gemcitabine is used in the treatment of non-small cell lung cancer. The other drugs are not used for this specific type of cancer.",
+		"rationale": "Gemcitabine is used in the treatment of non-small cell lung cancer. The other drugs are not used for this specific type of cancer.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24934,7 +24934,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["92de0774"],
-		"explanation": "Lucentis (ranibizumab) is specifically approved for wet macular degeneration. Rituximab is used for non-Hodgkin's B cell lymphoma and rheumatoid arthritis, Trastuzumab for HER2+ breast cancer, Daratumumab for multiple myeloma, and Tisotumab vedotin-tftv for cervical cancer.",
+		"rationale": "Lucentis (ranibizumab) is specifically approved for wet macular degeneration. Rituximab is used for non-Hodgkin's B cell lymphoma and rheumatoid arthritis, Trastuzumab for HER2+ breast cancer, Daratumumab for multiple myeloma, and Tisotumab vedotin-tftv for cervical cancer.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -24968,7 +24968,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["64a824c7"],
-		"explanation": "Trastuzumab is linked with an increased risk of cardiac damage. Lucentis is associated with vascular side effects, Rituximab with immune suppression, Daratumumab with choroidal effusion and acute angle closure and Tisotumab vedotin-tftv with ocular surface disease and severe dry eye. ",
+		"rationale": "Trastuzumab is linked with an increased risk of cardiac damage. Lucentis is associated with vascular side effects, Rituximab with immune suppression, Daratumumab with choroidal effusion and acute angle closure and Tisotumab vedotin-tftv with ocular surface disease and severe dry eye. ",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25002,7 +25002,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["291e4b49"],
-		"explanation": "Rituximab has a black box warning for severe immune suppression and mucocutaneous reactions. The other drugs have different side effect profiles and warnings.",
+		"rationale": "Rituximab has a black box warning for severe immune suppression and mucocutaneous reactions. The other drugs have different side effect profiles and warnings.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25036,7 +25036,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f0559d4b"],
-		"explanation": "Avastin (bevacizumab) is used off-label for wet AMD and is known for being cost-effective compared to Lucentis. Lucentis is approved for wet AMD, while the other drugs are used for different conditions.",
+		"rationale": "Avastin (bevacizumab) is used off-label for wet AMD and is known for being cost-effective compared to Lucentis. Lucentis is approved for wet AMD, while the other drugs are used for different conditions.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25070,7 +25070,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["38315bfd"],
-		"explanation": "Daratumumab is linked to choroidal effusion and acute angle closure. The other drugs have different side effect profiles.",
+		"rationale": "Daratumumab is linked to choroidal effusion and acute angle closure. The other drugs have different side effect profiles.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25104,7 +25104,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8fa60dac"],
-		"explanation": "Tisotumab vedotin-tftv requires an eye exam prior to treatment due to potential ocular side effects. The other drugs do not have this specific requirement.",
+		"rationale": "Tisotumab vedotin-tftv requires an eye exam prior to treatment due to potential ocular side effects. The other drugs do not have this specific requirement.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25138,7 +25138,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2fb7f99b"],
-		"explanation": "Relatlimab blocks the LAG-3 receptor and is used in combination with other checkpoint inhibitors. The other drugs block different receptors.",
+		"rationale": "Relatlimab blocks the LAG-3 receptor and is used in combination with other checkpoint inhibitors. The other drugs block different receptors.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25172,7 +25172,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["127ff335"],
-		"explanation": "Elahere (mirvetuximab) is associated with corneal flattening and refractive changes. The other drugs have different ocular side effects.",
+		"rationale": "Elahere (mirvetuximab) is associated with corneal flattening and refractive changes. The other drugs have different ocular side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25206,7 +25206,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8233fc1b"],
-		"explanation": "Trastuzumab is used for HER2+ metastatic breast cancer. The other drugs are used for different conditions.",
+		"rationale": "Trastuzumab is used for HER2+ metastatic breast cancer. The other drugs are used for different conditions.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25240,7 +25240,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0e25f22a"],
-		"explanation": "Tisotumab vedotin-tftv is associated with potential ocular side effects such as corneal and conjunctival inflammation. The other drugs have different side effect profiles.",
+		"rationale": "Tisotumab vedotin-tftv is associated with potential ocular side effects such as corneal and conjunctival inflammation. The other drugs have different side effect profiles.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25274,7 +25274,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["75249749", "bf5a42ee"],
-		"explanation": "Opdivo (nivolumab) and Keytruda (pembrolizumab) are PD-1 inhibitors. Yervoy blocks CTLA-4, Tecentriq blocks PD-L1, and Relatlimab blocks LAG-3.",
+		"rationale": "Opdivo (nivolumab) and Keytruda (pembrolizumab) are PD-1 inhibitors. Yervoy blocks CTLA-4, Tecentriq blocks PD-L1, and Relatlimab blocks LAG-3.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25308,7 +25308,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8b0b78ce"],
-		"explanation": "Daratumumab is used for multiple myeloma. The other drugs are used for different conditions.",
+		"rationale": "Daratumumab is used for multiple myeloma. The other drugs are used for different conditions.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25342,7 +25342,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d38559b1"],
-		"explanation": "Avastin (bevacizumab) is associated with high blood pressure, bleeding, and poor wound healing when used systemically. The other drugs have different side effect profiles.",
+		"rationale": "Avastin (bevacizumab) is associated with high blood pressure, bleeding, and poor wound healing when used systemically. The other drugs have different side effect profiles.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25376,7 +25376,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2e674a66"],
-		"explanation": "Tisotumab vedotin-tftv is used for cervical cancer treatment and has a black box warning for ocular side effects. The other drugs are used for different conditions.",
+		"rationale": "Tisotumab vedotin-tftv is used for cervical cancer treatment and has a black box warning for ocular side effects. The other drugs are used for different conditions.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25410,7 +25410,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5b7ab91a"],
-		"explanation": "Yervoy (ipilimumab) is a CTLA-4 inhibitor. The other drugs block different receptors.",
+		"rationale": "Yervoy (ipilimumab) is a CTLA-4 inhibitor. The other drugs block different receptors.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25444,7 +25444,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2a91d9b4", "e7b13333", "79bc03bd"],
-		"explanation": "Tamoxifen is a SERM with antiestrogenic effects in breast tissue, not estrogenic. It is contraindicated in women with a history of endometrial cancer and thrombotic vascular disease. Raloxifene, not tamoxifen, is primarily used for osteoporosis prevention.",
+		"rationale": "Tamoxifen is a SERM with antiestrogenic effects in breast tissue, not estrogenic. It is contraindicated in women with a history of endometrial cancer and thrombotic vascular disease. Raloxifene, not tamoxifen, is primarily used for osteoporosis prevention.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25478,7 +25478,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a9da9738", "ff072bd4", "60ec61a4"],
-		"explanation": "Tamoxifen is associated with crystalline maculopathy, corneal verticillata, and cataracts. Retinal hemorrhages and dry eye are not listed as side effects of tamoxifen but are associated with other drugs.",
+		"rationale": "Tamoxifen is associated with crystalline maculopathy, corneal verticillata, and cataracts. Retinal hemorrhages and dry eye are not listed as side effects of tamoxifen but are associated with other drugs.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25512,7 +25512,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5f353ddf", "e1425485", "c10c5838"],
-		"explanation": "Anastrozole is a non-steroidal aromatase inhibitor, not steroidal. It increases the risk of ischemic vascular events and can cause mood changes, GI upset, dry eye, and retinal detachments. It increases, not decreases, serum cholesterol levels.",
+		"rationale": "Anastrozole is a non-steroidal aromatase inhibitor, not steroidal. It increases the risk of ischemic vascular events and can cause mood changes, GI upset, dry eye, and retinal detachments. It increases, not decreases, serum cholesterol levels.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25546,7 +25546,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6f7bbf23", "45bfc73f"],
-		"explanation": "Bicalutamide and leuprolide are used for prostate cancer treatment. Tamoxifen and anastrozole are used for breast cancer, while raloxifene is used for osteoporosis.",
+		"rationale": "Bicalutamide and leuprolide are used for prostate cancer treatment. Tamoxifen and anastrozole are used for breast cancer, while raloxifene is used for osteoporosis.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25580,7 +25580,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a1a609d6", "ddee7e3e"],
-		"explanation": "Anastrozole and bicalutamide can cause dry eye. Tamoxifen, leuprolide, and goserelin are not associated with dry eye as a side effect.",
+		"rationale": "Anastrozole and bicalutamide can cause dry eye. Tamoxifen, leuprolide, and goserelin are not associated with dry eye as a side effect.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25614,7 +25614,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e1126848", "031bc007"],
-		"explanation": "Leuprolide and goserelin are GnRH analogs. Tamoxifen is a SERM, anastrozole is an aromatase inhibitor, and bicalutamide is an anti-androgen.",
+		"rationale": "Leuprolide and goserelin are GnRH analogs. Tamoxifen is a SERM, anastrozole is an aromatase inhibitor, and bicalutamide is an anti-androgen.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25648,7 +25648,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["34d64be2"],
-		"explanation": "Raloxifene is used to treat osteoporosis in postmenopausal women. Tamoxifen, anastrozole, bicalutamide, and leuprolide are not used for this purpose.",
+		"rationale": "Raloxifene is used to treat osteoporosis in postmenopausal women. Tamoxifen, anastrozole, bicalutamide, and leuprolide are not used for this purpose.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25682,7 +25682,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b5b9c36e"],
-		"explanation": "Anastrozole can lead to mood changes. Tamoxifen, bicalutamide, leuprolide, and goserelin are not specifically noted for causing mood changes.",
+		"rationale": "Anastrozole can lead to mood changes. Tamoxifen, bicalutamide, leuprolide, and goserelin are not specifically noted for causing mood changes.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25716,7 +25716,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["caf4345e"],
-		"explanation": "Tamoxifen is associated with corneal verticillata. Anastrozole, bicalutamide, leuprolide, and goserelin are not associated with this condition.",
+		"rationale": "Tamoxifen is associated with corneal verticillata. Anastrozole, bicalutamide, leuprolide, and goserelin are not associated with this condition.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25750,7 +25750,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7a45fc7a", "7a5111b1", "17187b9c"],
-		"explanation": "Vincristine inhibits mitosis by interacting with tubulin (B) and is used to treat acute leukemia and Hodgkin's disease (E). It can cause peripheral neuropathy (D). It is not primarily used for bone marrow suppression (A), and it is derived from Vinca Rosea, not the Pacific yew tree (C).",
+		"rationale": "Vincristine inhibits mitosis by interacting with tubulin (B) and is used to treat acute leukemia and Hodgkin's disease (E). It can cause peripheral neuropathy (D). It is not primarily used for bone marrow suppression (A), and it is derived from Vinca Rosea, not the Pacific yew tree (C).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25784,7 +25784,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c14e17ab", "18e7321d", "c822a20c"],
-		"explanation": "Vincristine can cause constipation (B), sodium deficiency (C), and various ocular side effects (D). It does not cause significant bone marrow suppression (A) or nephrotoxicity (E).",
+		"rationale": "Vincristine can cause constipation (B), sodium deficiency (C), and various ocular side effects (D). It does not cause significant bone marrow suppression (A) or nephrotoxicity (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25818,7 +25818,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f65257cd", "9b1dc115", "189403ff"],
-		"explanation": "Vincristine (A), vinblastine (C), and vinorelbine (E) are derived from the pink periwinkle plant. Paclitaxel (B) is derived from the Pacific yew tree, and topotecan (D) is a camptothecin analog.",
+		"rationale": "Vincristine (A), vinblastine (C), and vinorelbine (E) are derived from the pink periwinkle plant. Paclitaxel (B) is derived from the Pacific yew tree, and topotecan (D) is a camptothecin analog.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25852,7 +25852,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["52af1360", "173bd481", "050c8abe"],
-		"explanation": "Paclitaxel is a mitotic inhibitor (A) used to treat various cancers, including ovarian and lung cancers (B). It can cause bone marrow suppression and nephrotoxicity (D). It is derived from the Pacific yew tree, not the pink periwinkle plant (C), and is administered intravenously (E).",
+		"rationale": "Paclitaxel is a mitotic inhibitor (A) used to treat various cancers, including ovarian and lung cancers (B). It can cause bone marrow suppression and nephrotoxicity (D). It is derived from the Pacific yew tree, not the pink periwinkle plant (C), and is administered intravenously (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25886,7 +25886,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["181b4588", "432a21ed"],
-		"explanation": "Both paclitaxel (B) and docetaxel (C) are associated with ocular side effects such as epiphora and optic neuropathy. Vincristine (A) has different ocular side effects, and topotecan (D) and irinotecan (E) are not specifically noted for these side effects.",
+		"rationale": "Both paclitaxel (B) and docetaxel (C) are associated with ocular side effects such as epiphora and optic neuropathy. Vincristine (A) has different ocular side effects, and topotecan (D) and irinotecan (E) are not specifically noted for these side effects.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25920,7 +25920,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f498938b", "c54fed17", "411efc82"],
-		"explanation": "Vincristine (A), paclitaxel (B), and vinblastine (D) inhibit microtubules. Topotecan (C) and irinotecan (E) are camptothecin analogs that inhibit DNA topoisomerases.",
+		"rationale": "Vincristine (A), paclitaxel (B), and vinblastine (D) inhibit microtubules. Topotecan (C) and irinotecan (E) are camptothecin analogs that inhibit DNA topoisomerases.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25954,7 +25954,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["83d56046"],
-		"explanation": "Topotecan (C) is used for ocular injections in the treatment of retinoblastoma in children. Vincristine (A), paclitaxel (B), vinblastine (D), and docetaxel (E) are not used for this indication.",
+		"rationale": "Topotecan (C) is used for ocular injections in the treatment of retinoblastoma in children. Vincristine (A), paclitaxel (B), vinblastine (D), and docetaxel (E) are not used for this indication.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -25988,7 +25988,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["98e8bab6", "f1906081"],
-		"explanation": "Paclitaxel (B) and topotecan (C) are known to cause significant bone marrow suppression. Vincristine (A) does not cause significant bone marrow suppression, and vinblastine (D) and vinorelbine (E) are less neurotoxic but not specifically noted for bone marrow suppression.",
+		"rationale": "Paclitaxel (B) and topotecan (C) are known to cause significant bone marrow suppression. Vincristine (A) does not cause significant bone marrow suppression, and vinblastine (D) and vinorelbine (E) are less neurotoxic but not specifically noted for bone marrow suppression.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26022,7 +26022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c4437ad1", "0d695f3f", "769c70fd"],
-		"explanation": "Camptothecin analogs inhibit DNA topoisomerases (A) and are used to treat ovarian and lung cancers (C). They cause significant GI upset (D). They are not derived from the pink periwinkle plant (B) and are not administered orally (E).",
+		"rationale": "Camptothecin analogs inhibit DNA topoisomerases (A) and are used to treat ovarian and lung cancers (C). They cause significant GI upset (D). They are not derived from the pink periwinkle plant (B) and are not administered orally (E).",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26056,7 +26056,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ac363799"],
-		"explanation": "Vinblastine (A) is similar in function to vincristine but is less neurotoxic. Paclitaxel (B), goserelin (C), topotecan (D), and docetaxel (E) are not specifically noted for being less neurotoxic compared to vincristine.",
+		"rationale": "Vinblastine (A) is similar in function to vincristine but is less neurotoxic. Paclitaxel (B), goserelin (C), topotecan (D), and docetaxel (E) are not specifically noted for being less neurotoxic compared to vincristine.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26090,7 +26090,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e92d34fc", "5886d4b3"],
-		"explanation": "Dactinomycin is derived from Streptomyces parvulus and is used to treat Wilms' tumor and rhabdomyosarcoma. It inhibits DNA-primed RNA synthesis, not protein synthesis, and is administered intravenously, not orally. Cardiac toxicity is not a common side effect of dactinomycin.",
+		"rationale": "Dactinomycin is derived from Streptomyces parvulus and is used to treat Wilms' tumor and rhabdomyosarcoma. It inhibits DNA-primed RNA synthesis, not protein synthesis, and is administered intravenously, not orally. Cardiac toxicity is not a common side effect of dactinomycin.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26124,7 +26124,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["016b76e9", "80703549"],
-		"explanation": "Anthracyclines are known for causing cardiac toxicity and neutropenia. Ocular side effects are rare, and bone marrow suppression is more associated with dactinomycin. Anaphylactic reactions are more common with asparaginase.",
+		"rationale": "Anthracyclines are known for causing cardiac toxicity and neutropenia. Ocular side effects are rare, and bone marrow suppression is more associated with dactinomycin. Anaphylactic reactions are more common with asparaginase.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26158,7 +26158,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bd27896a"],
-		"explanation": "Idarubicin is used for the treatment of acute myeloid leukemia (AML) in adults. Doxorubicin and daunorubicin are used for other types of leukemia, and bleomycin is not typically used for AML.",
+		"rationale": "Idarubicin is used for the treatment of acute myeloid leukemia (AML) in adults. Doxorubicin and daunorubicin are used for other types of leukemia, and bleomycin is not typically used for AML.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26192,7 +26192,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a8351a0a", "f2234e78", "90fda052", "dbf261e7"],
-		"explanation": "Bleomycin is derived from Streptomyces and is used for palliative treatment of malignant neoplasms. It inhibits DNA synthesis and impairs antigen presentation. Cardiac toxicity is a common side effect for most of  the anthracyclines.",
+		"rationale": "Bleomycin is derived from Streptomyces and is used for palliative treatment of malignant neoplasms. It inhibits DNA synthesis and impairs antigen presentation. Cardiac toxicity is a common side effect for most of  the anthracyclines.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26226,7 +26226,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["99fb0c45"],
-		"explanation": "Asparaginase is associated with an increased risk of anaphylactic reactions. The other drugs listed do not commonly cause anaphylactic reactions.",
+		"rationale": "Asparaginase is associated with an increased risk of anaphylactic reactions. The other drugs listed do not commonly cause anaphylactic reactions.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26260,7 +26260,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["75e3dfda", "e7425a1d"],
-		"explanation": "Dactinomycin and doxorubicin are used in the treatment of Wilms' tumor. Bleomycin, asparaginase, and idarubicin are not typically used for this condition.",
+		"rationale": "Dactinomycin and doxorubicin are used in the treatment of Wilms' tumor. Bleomycin, asparaginase, and idarubicin are not typically used for this condition.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26294,7 +26294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ef7f26d7"],
-		"explanation": "Anthracyclines disrupt topoisomerase II. Inhibition of DNA-primed RNA synthesis is associated with dactinomycin, inhibition of DNA synthesis with bleomycin, metabolism of L-asparagine with asparaginase, and inhibition of protein synthesis is not a primary mechanism for these drugs.",
+		"rationale": "Anthracyclines disrupt topoisomerase II. Inhibition of DNA-primed RNA synthesis is associated with dactinomycin, inhibition of DNA synthesis with bleomycin, metabolism of L-asparagine with asparaginase, and inhibition of protein synthesis is not a primary mechanism for these drugs.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26328,7 +26328,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cf93870a"],
-		"explanation": "Asparaginase is derived from Escherichia coli. The other drugs are derived from Streptomyces.",
+		"rationale": "Asparaginase is derived from Escherichia coli. The other drugs are derived from Streptomyces.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26362,7 +26362,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["892663e5"],
-		"explanation": "Bleomycin is used for the treatment of squamous cell carcinoma. The other drugs are not typically used for this condition.",
+		"rationale": "Bleomycin is used for the treatment of squamous cell carcinoma. The other drugs are not typically used for this condition.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26396,7 +26396,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["35428b32", "273502b8", "e5094f60"],
-		"explanation": "Asparaginase catalyzes L-asparagine into L-aspartic acid and ammonia, is associated with mild bone marrow suppression, and is used in the treatment of leukemias. It is derived from Escherichia coli, not Streptomyces, and does not commonly cause cardiac toxicity.",
+		"rationale": "Asparaginase catalyzes L-asparagine into L-aspartic acid and ammonia, is associated with mild bone marrow suppression, and is used in the treatment of leukemias. It is derived from Escherichia coli, not Streptomyces, and does not commonly cause cardiac toxicity.",
 		"metadata": {},
 		"moduleId": "js75c8xppxfckp81wzth6d2kss7m98qd",
 		"options": [
@@ -26430,7 +26430,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["140484a6", "593e5644"],
-		"explanation": "Infiltration involves intradermal or subcutaneous injection, making it more effective than topical application. Central nerve block involves injection near the spinal cord to produce anesthesia above and below the injection site. Topical application results in slow penetration, peripheral nerve block numbs areas distal to the injection site, and intravenous regional anesthesia requires a tourniquet.",
+		"rationale": "Infiltration involves intradermal or subcutaneous injection, making it more effective than topical application. Central nerve block involves injection near the spinal cord to produce anesthesia above and below the injection site. Topical application results in slow penetration, peripheral nerve block numbs areas distal to the injection site, and intravenous regional anesthesia requires a tourniquet.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26464,7 +26464,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c49f45af", "6077fc75"],
-		"explanation": "Epinephrine should be avoided in patients with malignant hypertension and when removing vascular lesions due to the risk of excessive bleeding. It is commonly used in ophthalmic procedures, brachial plexus block anesthesia, and epidural anesthesia during labor to prolong the effect of lidocaine.",
+		"rationale": "Epinephrine should be avoided in patients with malignant hypertension and when removing vascular lesions due to the risk of excessive bleeding. It is commonly used in ophthalmic procedures, brachial plexus block anesthesia, and epidural anesthesia during labor to prolong the effect of lidocaine.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26498,7 +26498,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fe7742ff", "415390bb"],
-		"explanation": "Intravenous regional anesthesia requires a tourniquet to restrict diffusion beyond the target area and is suitable for minor surgical procedures on limbs. It is not used for central nerve block, ophthalmic procedures, or injecting around a nerve trunk.",
+		"rationale": "Intravenous regional anesthesia requires a tourniquet to restrict diffusion beyond the target area and is suitable for minor surgical procedures on limbs. It is not used for central nerve block, ophthalmic procedures, or injecting around a nerve trunk.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26532,7 +26532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7ab86ee9"],
-		"explanation": "Peripheral nerve block, such as a brachial plexus block, is used to numb an entire arm by injecting anesthetics around the nerve trunk. Topical application, infiltration, central nerve block, and intravenous regional anesthesia are not suitable for numbing an entire arm.",
+		"rationale": "Peripheral nerve block, such as a brachial plexus block, is used to numb an entire arm by injecting anesthetics around the nerve trunk. Topical application, infiltration, central nerve block, and intravenous regional anesthesia are not suitable for numbing an entire arm.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26566,7 +26566,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["78c829c5"],
-		"explanation": "Lidocaine is the most widely used injected local anesthetic for infiltration procedures due to its effectiveness and safety profile. Bupivacaine, procaine, ropivacaine, and tetracaine are other local anesthetics but are not as commonly used for infiltration.",
+		"rationale": "Lidocaine is the most widely used injected local anesthetic for infiltration procedures due to its effectiveness and safety profile. Bupivacaine, procaine, ropivacaine, and tetracaine are other local anesthetics but are not as commonly used for infiltration.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26600,7 +26600,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b06f1581", "564a3e5e"],
-		"explanation": "Stage 2 is characterized by erratic breathing and heart rate. Stage 3 involves muscle relaxation and blunted motor reflexes. Stage 1 is the induction stage, Stage 3 is surgical anesthesia, and Stage 4 is the overdose stage.",
+		"rationale": "Stage 2 is characterized by erratic breathing and heart rate. Stage 3 involves muscle relaxation and blunted motor reflexes. Stage 1 is the induction stage, Stage 3 is surgical anesthesia, and Stage 4 is the overdose stage.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26634,7 +26634,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["acf808e6", "3779ac83", "570bd39b"],
-		"explanation": "General anesthetics target GABA receptors, NMDA receptors, and voltage-gated ion channels. Dopamine and histamine receptors are not primary targets of general anesthetics.",
+		"rationale": "General anesthetics target GABA receptors, NMDA receptors, and voltage-gated ion channels. Dopamine and histamine receptors are not primary targets of general anesthetics.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26668,7 +26668,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["51e588d6"],
-		"explanation": "Dantrolene sodium is used to treat malignant hyperthermia. Propofol, thiopental sodium, etomidate, and ketamine are anesthetics, not treatments for malignant hyperthermia.",
+		"rationale": "Dantrolene sodium is used to treat malignant hyperthermia. Propofol, thiopental sodium, etomidate, and ketamine are anesthetics, not treatments for malignant hyperthermia.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26702,7 +26702,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7108069f", "0a86c2a4"],
-		"explanation": "Ketamine raises intraocular pressure and produces a dissociative state. It increases heart rate and blood pressure, acts mainly as an NMDA receptor antagonist, and has profound analgesic properties.",
+		"rationale": "Ketamine raises intraocular pressure and produces a dissociative state. It increases heart rate and blood pressure, acts mainly as an NMDA receptor antagonist, and has profound analgesic properties.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26736,7 +26736,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1dd30077"],
-		"explanation": "Etomidate is associated with rapid recovery and reduced risk of hypotension. Propofol and thiopental sodium have different profiles, and ketamine is not primarily used for its hypotensive effects. Ancuronium is a neuromuscular blocker, not an anesthetic.",
+		"rationale": "Etomidate is associated with rapid recovery and reduced risk of hypotension. Propofol and thiopental sodium have different profiles, and ketamine is not primarily used for its hypotensive effects. Ancuronium is a neuromuscular blocker, not an anesthetic.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26770,7 +26770,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9658eff2"],
-		"explanation": "Propofol can be used for both induction and maintenance of anesthesia. It is an intravenous anesthetic, not inhalational, and is associated with rapid recovery compared to thiopental sodium.",
+		"rationale": "Propofol can be used for both induction and maintenance of anesthesia. It is an intravenous anesthetic, not inhalational, and is associated with rapid recovery compared to thiopental sodium.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26804,7 +26804,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8d2ec074", "926f7ef9", "35e2a53c"],
-		"explanation": "Stage 3 surgical anesthesia is characterized by muscle relaxation, blunted motor reflexes, and depressed breathing. Erratic breathing and vomiting risk are associated with stage 2.",
+		"rationale": "Stage 3 surgical anesthesia is characterized by muscle relaxation, blunted motor reflexes, and depressed breathing. Erratic breathing and vomiting risk are associated with stage 2.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26838,7 +26838,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b89ba3e3"],
-		"explanation": "Etomidate requires co-administration of an opioid analgesic or a short-acting benzodiazepine due to its propensity to produce extraneous muscle movements. Propofol, thiopental sodium, and ketamine do not have this requirement, and ancuronium is a neuromuscular blocker.",
+		"rationale": "Etomidate requires co-administration of an opioid analgesic or a short-acting benzodiazepine due to its propensity to produce extraneous muscle movements. Propofol, thiopental sodium, and ketamine do not have this requirement, and ancuronium is a neuromuscular blocker.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26872,7 +26872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5642580e", "dbae7ad6"],
-		"explanation": "Thiopental sodium has no analgesic action and has a cumulative effect with repeated doses. It is used for induction, not maintenance, and is an intravenous anesthetic, not inhalational.",
+		"rationale": "Thiopental sodium has no analgesic action and has a cumulative effect with repeated doses. It is used for induction, not maintenance, and is an intravenous anesthetic, not inhalational.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26906,7 +26906,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d196d347", "5d935919"],
-		"explanation": "General anesthetics can be delivered by inhalation and require monitoring by specially trained anesthesiologists. They affect the central nervous system and require careful monitoring of the patient's vital signs.",
+		"rationale": "General anesthetics can be delivered by inhalation and require monitoring by specially trained anesthesiologists. They affect the central nervous system and require careful monitoring of the patient's vital signs.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26940,7 +26940,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d4e72a13", "50eee6a2"],
-		"explanation": "Muscle relaxants can be reversed by anticholinesterase drugs and include drugs like succinylcholine and rocuronium. They are used alongside anesthetics, not for induction, and do not have analgesic properties.",
+		"rationale": "Muscle relaxants can be reversed by anticholinesterase drugs and include drugs like succinylcholine and rocuronium. They are used alongside anesthetics, not for induction, and do not have analgesic properties.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -26974,7 +26974,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bdb0c049", "e4f23588", "c668dcbf"],
-		"explanation": "Potential complications of general anesthesia include malignant hyperthermia, cardiovascular collapse, and muscle rigidity. Increased intraocular pressure is specific to ketamine, and rapid recovery is not a complication.",
+		"rationale": "Potential complications of general anesthesia include malignant hyperthermia, cardiovascular collapse, and muscle rigidity. Increased intraocular pressure is specific to ketamine, and rapid recovery is not a complication.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27008,7 +27008,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["309dac6d", "0eb9abc6"],
-		"explanation": "Ketamine interacts with opioid receptors and has local anesthetic effects. It acts as a noncompetitive antagonist of the NMDA receptor and increases cardiac output.",
+		"rationale": "Ketamine interacts with opioid receptors and has local anesthetic effects. It acts as a noncompetitive antagonist of the NMDA receptor and increases cardiac output.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27042,7 +27042,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["04dfc00a", "d7c2a780"],
-		"explanation": "Ketamine raises intraocular pressure, while general anesthetics typically lower it. Intraocular pressure is considered in cases of glaucoma.",
+		"rationale": "Ketamine raises intraocular pressure, while general anesthetics typically lower it. Intraocular pressure is considered in cases of glaucoma.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27076,7 +27076,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0342693e", "9cd1f3b2"],
-		"explanation": "General anesthetics are used in combination with other drugs and are used to achieve a reversible loss of consciousness. They are administered by anesthesiologists, not surgeons, and are effective in providing analgesia.",
+		"rationale": "General anesthetics are used in combination with other drugs and are used to achieve a reversible loss of consciousness. They are administered by anesthesiologists, not surgeons, and are effective in providing analgesia.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27110,7 +27110,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ea472414", "b9cb724d"],
-		"explanation": "Isoflurane is preferred in obstetrics and causes muscle relaxation, enhancing the effects of muscle relaxants. It is more potent than desflurane and is a volatile liquid, not a gas.",
+		"rationale": "Isoflurane is preferred in obstetrics and causes muscle relaxation, enhancing the effects of muscle relaxants. It is more potent than desflurane and is a volatile liquid, not a gas.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27144,7 +27144,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5c2fb58d", "028ca920"],
-		"explanation": "Desflurane is less potent than isoflurane but has rapid onset and recovery. It irritates the airway, making it unsuitable for induction. It is a volatile liquid anesthetic.",
+		"rationale": "Desflurane is less potent than isoflurane but has rapid onset and recovery. It irritates the airway, making it unsuitable for induction. It is a volatile liquid anesthetic.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27178,7 +27178,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["de9cbb05", "cb0e68ea"],
-		"explanation": "Sevoflurane is more potent than isoflurane and desflurane and is non-irritant. It is moderately slower acting and has little effect on heart rhythm. It is a volatile liquid, not a gas.",
+		"rationale": "Sevoflurane is more potent than isoflurane and desflurane and is non-irritant. It is moderately slower acting and has little effect on heart rhythm. It is a volatile liquid, not a gas.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27212,7 +27212,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["407ceaaf", "3cbb8cb7", "a2f792dd"],
-		"explanation": "Malignant hyperthermia is a rare but serious complication linked to volatile anesthetics, not nitrous oxide. It involves a rapid temperature rise and muscle rigidity, treated with dantrolene sodium.",
+		"rationale": "Malignant hyperthermia is a rare but serious complication linked to volatile anesthetics, not nitrous oxide. It involves a rapid temperature rise and muscle rigidity, treated with dantrolene sodium.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27246,7 +27246,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9e36b466", "1a0aafba"],
-		"explanation": "Nitrous oxide is not used alone but in combination for maintenance. A 50:50 mixture provides analgesia without full anesthesia. It is a gas, not a volatile liquid, and not typically used for induction.",
+		"rationale": "Nitrous oxide is not used alone but in combination for maintenance. A 50:50 mixture provides analgesia without full anesthesia. It is a gas, not a volatile liquid, and not typically used for induction.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27280,7 +27280,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["36978e07"],
-		"explanation": "Sevoflurane is non-irritant to the airway, making it suitable for patients with airway sensitivity. Desflurane is known to irritate the airway.",
+		"rationale": "Sevoflurane is non-irritant to the airway, making it suitable for patients with airway sensitivity. Desflurane is known to irritate the airway.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27314,7 +27314,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["176adf67"],
-		"explanation": "Sevoflurane is moderately slower acting compared to desflurane, which is known for rapid onset and recovery.",
+		"rationale": "Sevoflurane is moderately slower acting compared to desflurane, which is known for rapid onset and recovery.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27348,7 +27348,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1c127cf5"],
-		"explanation": "Isoflurane is preferred in obstetrics because it provides muscle relaxation and potentiates muscle relaxants, beneficial during childbirth.",
+		"rationale": "Isoflurane is preferred in obstetrics because it provides muscle relaxation and potentiates muscle relaxants, beneficial during childbirth.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27382,7 +27382,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f4950243"],
-		"explanation": "Malignant hyperthermia is characterized by acidosis, along with tachycardia, increased muscle rigidity, and hyperthermia, not bradycardia or hypotension.",
+		"rationale": "Malignant hyperthermia is characterized by acidosis, along with tachycardia, increased muscle rigidity, and hyperthermia, not bradycardia or hypotension.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27416,7 +27416,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["943247c9"],
-		"explanation": "Sevoflurane has little effect on heart rhythm compared to other volatile anesthetics, making it a safer choice for patients with cardiac concerns.",
+		"rationale": "Sevoflurane has little effect on heart rhythm compared to other volatile anesthetics, making it a safer choice for patients with cardiac concerns.",
 		"metadata": {},
 		"moduleId": "js76zcmzk0m6bg71pwtjsb1zcd7m8rxr",
 		"options": [
@@ -27450,7 +27450,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3d6e19a7"],
-		"explanation": "Triiodothyronine (T3) is the primary active thyroid hormone and exerts most of the physiological effects. It is approximately 4 times more potent than thyroxine (T4).",
+		"rationale": "Triiodothyronine (T3) is the primary active thyroid hormone and exerts most of the physiological effects. It is approximately 4 times more potent than thyroxine (T4).",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27480,7 +27480,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9638aa91"],
-		"explanation": "Levothyroxine is a synthetically produced form of thyroxine (T4), the primary hormone secreted by the thyroid gland, used mainly to treat hypothyroidism.",
+		"rationale": "Levothyroxine is a synthetically produced form of thyroxine (T4), the primary hormone secreted by the thyroid gland, used mainly to treat hypothyroidism.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27510,7 +27510,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dd0b2dc1"],
-		"explanation": "Levothyroxine has a narrow therapeutic index, and dosing is titrated based on maintaining Thyroid Stimulating Hormone (TSH) levels within the therapeutic range (typically 0.4–4.0 mIU/L) to achieve a euthyroid state.",
+		"rationale": "Levothyroxine has a narrow therapeutic index, and dosing is titrated based on maintaining Thyroid Stimulating Hormone (TSH) levels within the therapeutic range (typically 0.4–4.0 mIU/L) to achieve a euthyroid state.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27540,7 +27540,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["daf09627"],
-		"explanation": "Thyroid hormones (T3 and T4) act on nearly every cell but have a particularly strong effect on the cardiac system. Heart rate, cardiac output, and systemic vascular resistance are significantly influenced by thyroid status.",
+		"rationale": "Thyroid hormones (T3 and T4) act on nearly every cell but have a particularly strong effect on the cardiac system. Heart rate, cardiac output, and systemic vascular resistance are significantly influenced by thyroid status.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27570,7 +27570,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aa23edbe"],
-		"explanation": "Excessive doses of levothyroxine can suppress TSH below the normal range (<0.1 mIU/L) and lead to symptoms of hyperthyroidism, such as increased heart rate, diarrhea, tremor, and weakness.",
+		"rationale": "Excessive doses of levothyroxine can suppress TSH below the normal range (<0.1 mIU/L) and lead to symptoms of hyperthyroidism, such as increased heart rate, diarrhea, tremor, and weakness.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27600,7 +27600,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c25f01e1", "c765af7b", "a1c8ac8e"],
-		"explanation": "Thyroid eye disease, often associated with autoimmune thyroid conditions, can cause several ocular changes including proptosis (bulging eyes), lid retraction (staring appearance), and diplopia (double vision). While optic nerve involvement can occur (optic neuropathy), optic atrophy and cataracts are not primary, direct manifestations.",
+		"rationale": "Thyroid eye disease, often associated with autoimmune thyroid conditions, can cause several ocular changes including proptosis (bulging eyes), lid retraction (staring appearance), and diplopia (double vision). While optic nerve involvement can occur (optic neuropathy), optic atrophy and cataracts are not primary, direct manifestations.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27634,7 +27634,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["833fc101", "32593ced", "0dd4a396"],
-		"explanation": "Levothyroxine requires careful management because it has a narrow therapeutic index (A). Dosing too high can cause hyperthyroidism with cardiac risks (B), while dosing too low leaves hypothyroidism unmanaged, affecting multiple body systems (C). Severe allergies are uncommon, and metabolism is primarily via deiodination and liver conjugation, not kidneys.",
+		"rationale": "Levothyroxine requires careful management because it has a narrow therapeutic index (A). Dosing too high can cause hyperthyroidism with cardiac risks (B), while dosing too low leaves hypothyroidism unmanaged, affecting multiple body systems (C). Severe allergies are uncommon, and metabolism is primarily via deiodination and liver conjugation, not kidneys.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27668,7 +27668,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2094670d", "f492b5f3"],
-		"explanation": "While extremely rare, ptosis (drooping eyelid) and diplopia (double vision) have been reported with levothyroxine use. Thyroid hormone toxicity can sometimes mimic symptoms seen in myasthenia gravis, which include ptosis and diplopia. Ophthalmoplegia has also been reported.",
+		"rationale": "While extremely rare, ptosis (drooping eyelid) and diplopia (double vision) have been reported with levothyroxine use. Thyroid hormone toxicity can sometimes mimic symptoms seen in myasthenia gravis, which include ptosis and diplopia. Ophthalmoplegia has also been reported.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27702,7 +27702,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d0e41e73"],
-		"explanation": "Thyroxine (T4) is a prohormone that must be converted to its active metabolite, triiodothyronine (T3). This conversion occurs through deiodination (removal of an iodine atom) by 5'-deiodinase enzymes located in peripheral tissues, blood, and the liver.",
+		"rationale": "Thyroxine (T4) is a prohormone that must be converted to its active metabolite, triiodothyronine (T3). This conversion occurs through deiodination (removal of an iodine atom) by 5'-deiodinase enzymes located in peripheral tissues, blood, and the liver.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27732,7 +27732,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c23527a0"],
-		"explanation": "Desiccated thyroid USP contains a mixture of T4 and T3 from animal sources. Its use has declined because synthetic options like levothyroxine offer more consistent potency, a standardized formulation primarily of T4 (allowing physiological conversion to T3), and potentially fewer side effects compared to the variable hormone ratio in desiccated thyroid.",
+		"rationale": "Desiccated thyroid USP contains a mixture of T4 and T3 from animal sources. Its use has declined because synthetic options like levothyroxine offer more consistent potency, a standardized formulation primarily of T4 (allowing physiological conversion to T3), and potentially fewer side effects compared to the variable hormone ratio in desiccated thyroid.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27762,7 +27762,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["92efbca5"],
-		"explanation": "Thionamides, including methimazole and propylthiouracil (PTU), exert their anti-thyroid effects by being actively transported into the thyroid gland where they inhibit key steps in thyroid hormone synthesis: the organification of iodine to tyrosine residues in thyroglobulin and the coupling of iodotyrosines.",
+		"rationale": "Thionamides, including methimazole and propylthiouracil (PTU), exert their anti-thyroid effects by being actively transported into the thyroid gland where they inhibit key steps in thyroid hormone synthesis: the organification of iodine to tyrosine residues in thyroglobulin and the coupling of iodotyrosines.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27796,7 +27796,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["99b0a6a7", "b66bb5bc"],
-		"explanation": "Both propranolol and intravenous hydrocortisone are indicated in severe hyperthyroidism partly because they inhibit the peripheral conversion of thyroxine (T4) to the more potent triiodothyronine (T3). Thionamides (Methimazole, Carbimazole) primarily work within the thyroid gland, and Lugol's solution mainly affects iodine uptake and hormone release prior to surgery.",
+		"rationale": "Both propranolol and intravenous hydrocortisone are indicated in severe hyperthyroidism partly because they inhibit the peripheral conversion of thyroxine (T4) to the more potent triiodothyronine (T3). Thionamides (Methimazole, Carbimazole) primarily work within the thyroid gland, and Lugol's solution mainly affects iodine uptake and hormone release prior to surgery.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27830,7 +27830,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ab7dc2a8"],
-		"explanation": "Propylthiouracil (PTU) carries an FDA warning regarding potential liver failure, which has led to it no longer being recommended as a front-line medication for hyperthyroidism compared to other thionamides like methimazole.",
+		"rationale": "Propylthiouracil (PTU) carries an FDA warning regarding potential liver failure, which has led to it no longer being recommended as a front-line medication for hyperthyroidism compared to other thionamides like methimazole.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27860,7 +27860,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dd45b484", "fc99961c"],
-		"explanation": "Propranolol is preferred for beta-blockade in thyroid storm due to its dual action on adrenergic symptoms and peripheral T4 to T3 conversion. IV Hydrocortisone is also used to decrease T4 to T3 conversion and manage potential relative adrenal insufficiency. Lugol's solution is typically used pre-operatively, not acutely in thyroid storm management described here. Thioacetamide alone would not address the systemic effects or conversion blockage needed acutely.",
+		"rationale": "Propranolol is preferred for beta-blockade in thyroid storm due to its dual action on adrenergic symptoms and peripheral T4 to T3 conversion. IV Hydrocortisone is also used to decrease T4 to T3 conversion and manage potential relative adrenal insufficiency. Lugol's solution is typically used pre-operatively, not acutely in thyroid storm management described here. Thioacetamide alone would not address the systemic effects or conversion blockage needed acutely.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27890,7 +27890,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["305f4174", "a2321eb7", "d1b9d6f8"],
-		"explanation": "Methimazole, Propylthiouracil (PTU), and Carbimazole are explicitly listed as examples of thionamide anti-thyroid drugs. Propranolol is a beta-blocker, and Lugol's solution is potassium iodide.",
+		"rationale": "Methimazole, Propylthiouracil (PTU), and Carbimazole are explicitly listed as examples of thionamide anti-thyroid drugs. Propranolol is a beta-blocker, and Lugol's solution is potassium iodide.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27924,7 +27924,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["68d49e42"],
-		"explanation": "The most common ocular side effect reported with Premarin (conjugated estrogens) is decreased tear production, leading to symptoms of ocular dryness.",
+		"rationale": "The most common ocular side effect reported with Premarin (conjugated estrogens) is decreased tear production, leading to symptoms of ocular dryness.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27958,7 +27958,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["eff3dab5"],
-		"explanation": "Fulvestrant is classified as a selective estrogen receptor degrader (SERD). It binds to the estrogen receptor, destabilizes it, and triggers cellular mechanisms to destroy the receptor, thereby reducing estrogen signaling.",
+		"rationale": "Fulvestrant is classified as a selective estrogen receptor degrader (SERD). It binds to the estrogen receptor, destabilizes it, and triggers cellular mechanisms to destroy the receptor, thereby reducing estrogen signaling.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -27992,7 +27992,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3d59a41e"],
-		"explanation": "Tamoxifen, particularly in high doses, is known to cause corneal verticillata, which are whorl-like corneal opacities. While it can also cause crystalline maculopathy and increases the risk of hydroxychloroquine maculopathy, the specific finding described is corneal verticillata.",
+		"rationale": "Tamoxifen, particularly in high doses, is known to cause corneal verticillata, which are whorl-like corneal opacities. While it can also cause crystalline maculopathy and increases the risk of hydroxychloroquine maculopathy, the specific finding described is corneal verticillata.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28026,7 +28026,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["728f5fac"],
-		"explanation": "Reduced efficacy and increased incidence of breakthrough bleeding and menstrual irregularities have been associated with the concomitant use of rifampin and synthetic estrogens like ethinyl estradiol, often found in birth control pills. Similar interactions, though less marked, may occur with other enzyme-inducing drugs.",
+		"rationale": "Reduced efficacy and increased incidence of breakthrough bleeding and menstrual irregularities have been associated with the concomitant use of rifampin and synthetic estrogens like ethinyl estradiol, often found in birth control pills. Similar interactions, though less marked, may occur with other enzyme-inducing drugs.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28060,7 +28060,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ab0505e8"],
-		"explanation": "Mifepristone (RU-486) is a synthetic steroid that functions as an anti-progestin. It is used in combination with misoprostol for the medical termination of intrauterine pregnancy through 70 days gestation.",
+		"rationale": "Mifepristone (RU-486) is a synthetic steroid that functions as an anti-progestin. It is used in combination with misoprostol for the medical termination of intrauterine pregnancy through 70 days gestation.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28094,7 +28094,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b1fe31b5"],
-		"explanation": "Clomiphene is a SERM that is the most widely used treatment for fertility enhancement. It works by inhibiting estrogen binding at the receptor, leading to increased FSH and LH release, which stimulates ovarian follicular development.",
+		"rationale": "Clomiphene is a SERM that is the most widely used treatment for fertility enhancement. It works by inhibiting estrogen binding at the receptor, leading to increased FSH and LH release, which stimulates ovarian follicular development.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28128,7 +28128,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2110c7ad"],
-		"explanation": "While uncommon, intracranial hypertension (also known as pseudotumor cerebri) is a recognized potential ocular side effect associated with synthetic estrogens like ethinyl estradiol.",
+		"rationale": "While uncommon, intracranial hypertension (also known as pseudotumor cerebri) is a recognized potential ocular side effect associated with synthetic estrogens like ethinyl estradiol.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28162,7 +28162,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ce3d9215", "92246dba", "c323fc5a"],
-		"explanation": "The use of estrogens alone (solo therapy) or in higher doses is linked to an increased risk of endometrial cancer, stroke, and vein thrombosis (blood clots). Osteoporosis is a condition treated by estrogens, not caused by them. Hyperglycemia in Cushing syndrome is treated by mifepristone.",
+		"rationale": "The use of estrogens alone (solo therapy) or in higher doses is linked to an increased risk of endometrial cancer, stroke, and vein thrombosis (blood clots). Osteoporosis is a condition treated by estrogens, not caused by them. Hyperglycemia in Cushing syndrome is treated by mifepristone.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28196,7 +28196,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cdd88e87", "5bfef534", "5197a8f6"],
-		"explanation": "Raloxifene acts as an anti-estrogen in the uterus and breast but as an estrogen agonist in bone and the liver. Tamoxifen acts as an anti-estrogen in the breast but as an estrogen agonist in the uterus and liver. Neither Raloxifene nor Tamoxifen are SERDs (Selective Estrogen Receptor Degraders); that mechanism describes drugs like Fulvestrant.",
+		"rationale": "Raloxifene acts as an anti-estrogen in the uterus and breast but as an estrogen agonist in bone and the liver. Tamoxifen acts as an anti-estrogen in the breast but as an estrogen agonist in the uterus and liver. Neither Raloxifene nor Tamoxifen are SERDs (Selective Estrogen Receptor Degraders); that mechanism describes drugs like Fulvestrant.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28230,7 +28230,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5b04e915", "4b9f6472"],
-		"explanation": "Tamoxifen use significantly increases the risk of developing maculopathy associated with hydroxychloroquine. Additionally, tamoxifen itself can cause crystalline maculopathy, which could potentially complicate the monitoring and diagnosis of retinal changes.",
+		"rationale": "Tamoxifen use significantly increases the risk of developing maculopathy associated with hydroxychloroquine. Additionally, tamoxifen itself can cause crystalline maculopathy, which could potentially complicate the monitoring and diagnosis of retinal changes.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28264,7 +28264,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fc6dc155", "bdaf83d6"],
-		"explanation": "Testosterone is indicated for replacement therapy in primary hypogonadism (e.g., testicular failure from orchitis) and hypogonadotropic hypogonadism (e.g., pituitary injury affecting LHRH/gonadotropin production).",
+		"rationale": "Testosterone is indicated for replacement therapy in primary hypogonadism (e.g., testicular failure from orchitis) and hypogonadotropic hypogonadism (e.g., pituitary injury affecting LHRH/gonadotropin production).",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28294,7 +28294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["18182f7d"],
-		"explanation": "Topical testosterone application has shown potential to increase tear and meibomian production, suggesting a possible role in managing some forms of dry eye syndrome.",
+		"rationale": "Topical testosterone application has shown potential to increase tear and meibomian production, suggesting a possible role in managing some forms of dry eye syndrome.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28324,7 +28324,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b4abc037"],
-		"explanation": "Reports exist suggesting that injected testosterone might raise intraocular pressure, but this association has not been conclusively proven.",
+		"rationale": "Reports exist suggesting that injected testosterone might raise intraocular pressure, but this association has not been conclusively proven.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28354,7 +28354,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["36d0192d"],
-		"explanation": "Insulin's main function is to facilitate the transport of glucose from the blood into the body's cells, thereby lowering serum glucose levels.",
+		"rationale": "Insulin's main function is to facilitate the transport of glucose from the blood into the body's cells, thereby lowering serum glucose levels.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28384,7 +28384,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ddcf4688", "469c2049"],
-		"explanation": "Insulin analogues are designed to mimic the action profile of endogenous insulin more closely than human insulins (like NPH and regular). Human insulins are generally more affordable.",
+		"rationale": "Insulin analogues are designed to mimic the action profile of endogenous insulin more closely than human insulins (like NPH and regular). Human insulins are generally more affordable.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28414,7 +28414,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3f8db31b", "55c03501", "eabf27b1"],
-		"explanation": "Short-acting insulins, often used as bolus insulin for mealtime coverage, include regular insulin, insulin aspart, and insulin lispro.",
+		"rationale": "Short-acting insulins, often used as bolus insulin for mealtime coverage, include regular insulin, insulin aspart, and insulin lispro.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28448,7 +28448,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["69948c81"],
-		"explanation": "Insulin glargine is a long-acting insulin analogue, often used as basal insulin to provide continuous control of fasting glucose levels.",
+		"rationale": "Insulin glargine is a long-acting insulin analogue, often used as basal insulin to provide continuous control of fasting glucose levels.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28478,7 +28478,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d9e2f005"],
-		"explanation": "Basal insulin, typically longer-acting analogues like glargine or detemir, is used once or twice daily to maintain control over fasting glucose levels.",
+		"rationale": "Basal insulin, typically longer-acting analogues like glargine or detemir, is used once or twice daily to maintain control over fasting glucose levels.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28508,7 +28508,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1f3b8778", "d83d2ef1", "1f1ab2d4"],
-		"explanation": "Insulin analogues are modified forms of human insulin. Examples listed include glargine, aspart, lispro, glulisine, and detemir. NPH and regular insulin are classified as human insulins.",
+		"rationale": "Insulin analogues are modified forms of human insulin. Examples listed include glargine, aspart, lispro, glulisine, and detemir. NPH and regular insulin are classified as human insulins.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28542,7 +28542,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9abe2a9d"],
-		"explanation": "Testosterone may be included in hormone replacement therapy regimens for post-menopausal women, in addition to its primary use in treating male hypogonadism.",
+		"rationale": "Testosterone may be included in hormone replacement therapy regimens for post-menopausal women, in addition to its primary use in treating male hypogonadism.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28572,7 +28572,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ae1e885a"],
-		"explanation": "Sulfonylureas primarily act by increasing both basal and meal-stimulated insulin secretion from the pancreatic beta cells.",
+		"rationale": "Sulfonylureas primarily act by increasing both basal and meal-stimulated insulin secretion from the pancreatic beta cells.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28602,7 +28602,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["09df9b95", "d11d9289"],
-		"explanation": "Sulfonylureas can cause hypoglycemia due to increased insulin secretion and are associated with weight gain. Lactic acidosis is primarily a concern with metformin, and while GI upset can occur, it's the main side effect noted for metformin in the text.",
+		"rationale": "Sulfonylureas can cause hypoglycemia due to increased insulin secretion and are associated with weight gain. Lactic acidosis is primarily a concern with metformin, and while GI upset can occur, it's the main side effect noted for metformin in the text.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28632,7 +28632,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["72aed2f7"],
-		"explanation": "Sulfonylureas, as a class, are contraindicated in patients with sulfa allergies.",
+		"rationale": "Sulfonylureas, as a class, are contraindicated in patients with sulfa allergies.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28662,7 +28662,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3ae87ce6"],
-		"explanation": "Unlike sulfonylureas, metformin does not typically cause hypoglycemia in patients with type 2 diabetes or in normal subjects because its mechanism does not directly stimulate insulin secretion in the same manner.",
+		"rationale": "Unlike sulfonylureas, metformin does not typically cause hypoglycemia in patients with type 2 diabetes or in normal subjects because its mechanism does not directly stimulate insulin secretion in the same manner.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28692,7 +28692,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["deb20abd", "b2b16cdd", "c2271f93"],
-		"explanation": "Metformin works by decreasing hepatic glucose production, decreasing intestinal glucose absorption, and improving insulin sensitivity by increasing peripheral glucose uptake and utilization. It does not primarily increase insulin secretion like sulfonylureas.",
+		"rationale": "Metformin works by decreasing hepatic glucose production, decreasing intestinal glucose absorption, and improving insulin sensitivity by increasing peripheral glucose uptake and utilization. It does not primarily increase insulin secretion like sulfonylureas.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28722,7 +28722,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["309f98d3"],
-		"explanation": "The co-administration of metformin and iodinated contrast dye can decrease renal clearance of metformin, increasing the risk of drug accumulation and subsequent lactic acidosis.",
+		"rationale": "The co-administration of metformin and iodinated contrast dye can decrease renal clearance of metformin, increasing the risk of drug accumulation and subsequent lactic acidosis.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28752,7 +28752,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fedbead4"],
-		"explanation": "Due to the risk of drug accumulation in patients with renal impairment, glyburide is not recommended. Glipizide and glimepiride should be used with caution in this population.",
+		"rationale": "Due to the risk of drug accumulation in patients with renal impairment, glyburide is not recommended. Glipizide and glimepiride should be used with caution in this population.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28782,7 +28782,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["351ae99a"],
-		"explanation": "Metformin fits this profile: it decreases hepatic glucose production, improves insulin sensitivity, does not cause hypoglycemia typically, and studies have shown mortality benefits.",
+		"rationale": "Metformin fits this profile: it decreases hepatic glucose production, improves insulin sensitivity, does not cause hypoglycemia typically, and studies have shown mortality benefits.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28812,7 +28812,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0f78a57b"],
-		"explanation": "Chlorpropamide is a long-acting, first-generation sulfonylurea with an increased risk of prolonged hypoglycemia due to its long half-life.",
+		"rationale": "Chlorpropamide is a long-acting, first-generation sulfonylurea with an increased risk of prolonged hypoglycemia due to its long half-life.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28842,7 +28842,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["40deee38"],
-		"explanation": "Glimepiride is noted for being very potent with a long duration of action, and clinical trials indicated a lower risk of hypoglycemia and weight gain compared to other drugs in the sulfonylurea class.",
+		"rationale": "Glimepiride is noted for being very potent with a long duration of action, and clinical trials indicated a lower risk of hypoglycemia and weight gain compared to other drugs in the sulfonylurea class.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28872,7 +28872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6f42b000"],
-		"explanation": "Thiazolidinediones (TZDs) act as insulin sensitizers by activating intracellular PPAR receptors, which enhances insulin action and sensitivity in tissues like muscle and fat.",
+		"rationale": "Thiazolidinediones (TZDs) act as insulin sensitizers by activating intracellular PPAR receptors, which enhances insulin action and sensitivity in tissues like muscle and fat.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28902,7 +28902,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e3b42aa6"],
-		"explanation": "Rosiglitazone has been linked to increased retinal endothelial cell permeability and vascular endothelial growth factor (VEGF) expression, potentially leading to intraretinal edema and subsequent vision changes.",
+		"rationale": "Rosiglitazone has been linked to increased retinal endothelial cell permeability and vascular endothelial growth factor (VEGF) expression, potentially leading to intraretinal edema and subsequent vision changes.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28932,7 +28932,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["03c48363"],
-		"explanation": "Meglitinides stimulate insulin secretion from pancreatic beta cells, similar to sulfonylureas, but have a rapid onset and short duration of action, making them suitable for controlling postprandial glucose when taken before meals.",
+		"rationale": "Meglitinides stimulate insulin secretion from pancreatic beta cells, similar to sulfonylureas, but have a rapid onset and short duration of action, making them suitable for controlling postprandial glucose when taken before meals.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28962,7 +28962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cae8aea8"],
-		"explanation": "Nateglinide is less effective at lowering A1C compared to repaglinide but offers a lower risk of inducing hypoglycemia. Both primarily target postprandial glucose.",
+		"rationale": "Nateglinide is less effective at lowering A1C compared to repaglinide but offers a lower risk of inducing hypoglycemia. Both primarily target postprandial glucose.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -28992,7 +28992,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["32a4c697", "850cdc15", "ebfd9576"],
-		"explanation": "SGLT-2 inhibitors block glucose reabsorption in the kidney, leading to increased urinary glucose excretion. This mechanism can also contribute to weight loss and has shown cardiovascular benefits in clinical studies. They decrease, not increase, glucose reabsorption.",
+		"rationale": "SGLT-2 inhibitors block glucose reabsorption in the kidney, leading to increased urinary glucose excretion. This mechanism can also contribute to weight loss and has shown cardiovascular benefits in clinical studies. They decrease, not increase, glucose reabsorption.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29022,7 +29022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9d0a2349", "44942cee", "03f7b6a1"],
-		"explanation": "SGLT-2 inhibitors are associated with risks including genital/urinary infections, euglycemic ketoacidosis, and necrotizing fasciitis. Canagliflozin specifically carries a warning for increased lower limb amputation risk. Acute pancreatitis is more commonly associated with DPP-4 inhibitors.",
+		"rationale": "SGLT-2 inhibitors are associated with risks including genital/urinary infections, euglycemic ketoacidosis, and necrotizing fasciitis. Canagliflozin specifically carries a warning for increased lower limb amputation risk. Acute pancreatitis is more commonly associated with DPP-4 inhibitors.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29052,7 +29052,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c89e7229"],
-		"explanation": "Acarbose is an alpha-glucosidase inhibitor. It works by inhibiting the enzyme alpha-glucosidase in the intestines, which slows the breakdown of complex carbohydrates into absorbable simple sugars, thus lowering postprandial glucose levels.",
+		"rationale": "Acarbose is an alpha-glucosidase inhibitor. It works by inhibiting the enzyme alpha-glucosidase in the intestines, which slows the breakdown of complex carbohydrates into absorbable simple sugars, thus lowering postprandial glucose levels.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29082,7 +29082,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["de580fa9", "ce1d8e73", "114916e0"],
-		"explanation": "Acarbose is contraindicated in patients with significant intestinal diseases like inflammatory bowel disease, colonic ulcers, or obstruction, as well as those with cirrhosis or diabetic ketoacidosis. Heart failure is not a specific contraindication listed for acarbose, though fluid retention from TZDs can worsen it.",
+		"rationale": "Acarbose is contraindicated in patients with significant intestinal diseases like inflammatory bowel disease, colonic ulcers, or obstruction, as well as those with cirrhosis or diabetic ketoacidosis. Heart failure is not a specific contraindication listed for acarbose, though fluid retention from TZDs can worsen it.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29112,7 +29112,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["569400fe"],
-		"explanation": "DPP-4 inhibitors block the enzyme DPP-4, which normally breaks down incretin hormones (like GLP-1). By preserving incretin levels, these drugs enhance glucose-dependent insulin secretion, suppress glucagon release, slow gastric emptying, and ultimately lower blood glucose.",
+		"rationale": "DPP-4 inhibitors block the enzyme DPP-4, which normally breaks down incretin hormones (like GLP-1). By preserving incretin levels, these drugs enhance glucose-dependent insulin secretion, suppress glucagon release, slow gastric emptying, and ultimately lower blood glucose.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29142,7 +29142,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a34ada37"],
-		"explanation": "Unlike some other anti-diabetic classes (e.g., SGLT-2 inhibitors), DPP-4 inhibitors have not demonstrated significant cardiovascular benefits and may carry an increased risk of hospitalization for heart failure. Lower limb amputation risk is associated with canagliflozin (an SGLT-2 inhibitor), and significant weight gain is not a typical side effect of gliptins.",
+		"rationale": "Unlike some other anti-diabetic classes (e.g., SGLT-2 inhibitors), DPP-4 inhibitors have not demonstrated significant cardiovascular benefits and may carry an increased risk of hospitalization for heart failure. Lower limb amputation risk is associated with canagliflozin (an SGLT-2 inhibitor), and significant weight gain is not a typical side effect of gliptins.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29172,7 +29172,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["68c24f5f"],
-		"explanation": "Pramlintide is derived from amylin and modulates the rate of gastric emptying and prevents the post-prandial rise in glucagon levels.",
+		"rationale": "Pramlintide is derived from amylin and modulates the rate of gastric emptying and prevents the post-prandial rise in glucagon levels.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29202,7 +29202,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cc0fef56"],
-		"explanation": "Gastrointestinal side effects are common with GLP-1 receptor agonists, particularly when initiating treatment.",
+		"rationale": "Gastrointestinal side effects are common with GLP-1 receptor agonists, particularly when initiating treatment.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29232,7 +29232,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["87647299"],
-		"explanation": "Tirzepatide binds avidly to GIP receptors and also has GLP-1R agonist activity.",
+		"rationale": "Tirzepatide binds avidly to GIP receptors and also has GLP-1R agonist activity.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29262,7 +29262,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e0f94d2e", "269ca4bc"],
-		"explanation": "There have been reports of increased diabetic retinopathy and an increased risk of non-arteritic ischemic optic neuropathy (NAION) associated with these agents, although the NAION risk is noted as disputed.",
+		"rationale": "There have been reports of increased diabetic retinopathy and an increased risk of non-arteritic ischemic optic neuropathy (NAION) associated with these agents, although the NAION risk is noted as disputed.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29292,7 +29292,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b379142a", "57ee134b", "b570351a"],
-		"explanation": "Pramlintide modulates gastric emptying, prevents post-prandial glucagon rise, and increases satiety.",
+		"rationale": "Pramlintide modulates gastric emptying, prevents post-prandial glucagon rise, and increases satiety.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29322,7 +29322,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a37376c3"],
-		"explanation": "Semaglutide (Rybelsus) is specifically mentioned as an oral formulation, whereas Ozempic and Wegovy are injected formulations of semaglutide.",
+		"rationale": "Semaglutide (Rybelsus) is specifically mentioned as an oral formulation, whereas Ozempic and Wegovy are injected formulations of semaglutide.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29352,7 +29352,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["779e690e"],
-		"explanation": "Semaglutide is noted as being increasingly used as a weight-loss medication, especially in obese pediatric patients.",
+		"rationale": "Semaglutide is noted as being increasingly used as a weight-loss medication, especially in obese pediatric patients.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29382,7 +29382,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1819c8bc"],
-		"explanation": "Tirzepatide is administered via subcutaneous injection on a weekly basis.",
+		"rationale": "Tirzepatide is administered via subcutaneous injection on a weekly basis.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29412,7 +29412,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d65fe587"],
-		"explanation": "Tirzepatide increases levels of adiponectin, an adipokine involved in glucose and lipid metabolism.",
+		"rationale": "Tirzepatide increases levels of adiponectin, an adipokine involved in glucose and lipid metabolism.",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29442,7 +29442,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f653dca0", "621b66ad", "4b491c0f"],
-		"explanation": "Serious side effects reported include inflammation of the gallbladder, pancreas, and/or kidneys, myopathy (muscle wasting), and an increased risk of thyroid tumors (rare).",
+		"rationale": "Serious side effects reported include inflammation of the gallbladder, pancreas, and/or kidneys, myopathy (muscle wasting), and an increased risk of thyroid tumors (rare).",
 		"metadata": {},
 		"moduleId": "js75wec6rw96egvarhsapgzcv17m8td6",
 		"options": [
@@ -29472,7 +29472,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d6fc5318"],
-		"explanation": "Beta-carotene, included in the original AREDS formula, was associated with an increased risk of lung cancer in smokers and was therefore removed in the AREDS2 formulation.",
+		"rationale": "Beta-carotene, included in the original AREDS formula, was associated with an increased risk of lung cancer in smokers and was therefore removed in the AREDS2 formulation.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29502,7 +29502,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a164adb9", "e8f3c27f"],
-		"explanation": "The AREDS2 formulation introduced Lutein (10 mg) and Zeaxanthin (2 mg), which were not part of the original AREDS formula.",
+		"rationale": "The AREDS2 formulation introduced Lutein (10 mg) and Zeaxanthin (2 mg), which were not part of the original AREDS formula.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29532,7 +29532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["770a71fe"],
-		"explanation": "Copper was added to both AREDS formulations specifically to prevent copper deficiency anemia, a potential side effect of the high dose of zinc (80 mg) included in the supplements.",
+		"rationale": "Copper was added to both AREDS formulations specifically to prevent copper deficiency anemia, a potential side effect of the high dose of zinc (80 mg) included in the supplements.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29562,7 +29562,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["339db144"],
-		"explanation": "The AREDS 1 study found that the combination of Antioxidants (Vitamin C, Vitamin E, Beta-carotene) plus Zinc Oxide resulted in the highest risk reduction (25%) for developing advanced AMD compared to placebo.",
+		"rationale": "The AREDS 1 study found that the combination of Antioxidants (Vitamin C, Vitamin E, Beta-carotene) plus Zinc Oxide resulted in the highest risk reduction (25%) for developing advanced AMD compared to placebo.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29592,7 +29592,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["65d85045"],
-		"explanation": "The AREDS2 formulation contains 10 mg of Lutein and 2 mg of Zeaxanthin per daily dose.",
+		"rationale": "The AREDS2 formulation contains 10 mg of Lutein and 2 mg of Zeaxanthin per daily dose.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29622,7 +29622,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3ade1b6b"],
-		"explanation": "In the AREDS 1 study, Zinc Oxide alone provided a 21% risk reduction, while Antioxidants (Vitamin C, Vitamin E, Beta-carotene) alone provided a 17% risk reduction compared to placebo, indicating a greater effect from Zinc Oxide alone.",
+		"rationale": "In the AREDS 1 study, Zinc Oxide alone provided a 21% risk reduction, while Antioxidants (Vitamin C, Vitamin E, Beta-carotene) alone provided a 17% risk reduction compared to placebo, indicating a greater effect from Zinc Oxide alone.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29652,7 +29652,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["55fe9997"],
-		"explanation": "Beta-carotene, found in the original AREDS formula, was associated with an increased incidence of lung cancer among smokers, leading to its removal in AREDS2.",
+		"rationale": "Beta-carotene, found in the original AREDS formula, was associated with an increased incidence of lung cancer among smokers, leading to its removal in AREDS2.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29682,7 +29682,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f3e31147"],
-		"explanation": "The high dose of Zinc (80 mg) used in both AREDS formulations can potentially lead to copper deficiency anemia, necessitating the inclusion of copper (2 mg) to prevent this side effect.",
+		"rationale": "The high dose of Zinc (80 mg) used in both AREDS formulations can potentially lead to copper deficiency anemia, necessitating the inclusion of copper (2 mg) to prevent this side effect.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29712,7 +29712,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["21ee4e59", "c562a32a", "f63f9996"],
-		"explanation": "The 'Antioxidants Only' arm in the AREDS 1 study specifically included Vitamin C, Vitamin E, and Beta-carotene. Lutein and Zeaxanthin were not part of the original AREDS formulation.",
+		"rationale": "The 'Antioxidants Only' arm in the AREDS 1 study specifically included Vitamin C, Vitamin E, and Beta-carotene. Lutein and Zeaxanthin were not part of the original AREDS formulation.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29746,7 +29746,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d30bef61"],
-		"explanation": "The original AREDS formulation demonstrated a 25% reduction in the progression of advanced AMD in the studied population.",
+		"rationale": "The original AREDS formulation demonstrated a 25% reduction in the progression of advanced AMD in the studied population.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29776,7 +29776,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["809ab878"],
-		"explanation": "Adding Lutein and Zeaxanthin to the AREDS formulation resulted in an additional 10% reduction in advanced AMD progression compared to the original AREDS formulation alone, leading to a total reduction of 27.5% in the study population.",
+		"rationale": "Adding Lutein and Zeaxanthin to the AREDS formulation resulted in an additional 10% reduction in advanced AMD progression compared to the original AREDS formulation alone, leading to a total reduction of 27.5% in the study population.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29806,7 +29806,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a11eb71"],
-		"explanation": "Supplementing the original AREDS formulation with DHA and EPA showed no additional change in disease progression.",
+		"rationale": "Supplementing the original AREDS formulation with DHA and EPA showed no additional change in disease progression.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29836,7 +29836,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["45d5a42e", "34c18a57"],
-		"explanation": "The AREDS2 study used dosages of 10 mg Lutein / 2 mg Zeaxanthin and 350 mg DHA / 650 mg EPA in the relevant study arms evaluating these supplements.",
+		"rationale": "The AREDS2 study used dosages of 10 mg Lutein / 2 mg Zeaxanthin and 350 mg DHA / 650 mg EPA in the relevant study arms evaluating these supplements.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29866,7 +29866,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["84748b46"],
-		"explanation": "Adding Lutein and Zeaxanthin reduced the progression specifically to wet AMD by 11% compared to the original AREDS formulation, although this finding alone was not statistically significant.",
+		"rationale": "Adding Lutein and Zeaxanthin reduced the progression specifically to wet AMD by 11% compared to the original AREDS formulation, although this finding alone was not statistically significant.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29896,7 +29896,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4f083bd6"],
-		"explanation": "The study suggested that adding Lutein and Zeaxanthin to the AREDS formula reduced the progression to legal blindness by 18% compared to the original formulation.",
+		"rationale": "The study suggested that adding Lutein and Zeaxanthin to the AREDS formula reduced the progression to legal blindness by 18% compared to the original formulation.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29926,7 +29926,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["48e54266"],
-		"explanation": "The subset group receiving the AREDS formulation without beta-carotene (Group 2) showed an additional 22% reduction in AMD progression compared to the original AREDS formulation which included beta-carotene, resulting in a total reduction of 31.5%.",
+		"rationale": "The subset group receiving the AREDS formulation without beta-carotene (Group 2) showed an additional 22% reduction in AMD progression compared to the original AREDS formulation which included beta-carotene, resulting in a total reduction of 31.5%.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29956,7 +29956,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["70723c4f", "e280ba44", "d29fc4c2"],
-		"explanation": "The original AREDS formula (Group 1) used 80 mg Zinc oxide. Reducing zinc to 25 mg when beta-carotene was absent (Group 3 vs Group 2) resulted in the same efficacy. Lowering zinc to 25 mg when beta-carotene was present (Group 4 vs Group 1) also did not affect disease progression compared to the original high-zinc, beta-carotene containing formula.",
+		"rationale": "The original AREDS formula (Group 1) used 80 mg Zinc oxide. Reducing zinc to 25 mg when beta-carotene was absent (Group 3 vs Group 2) resulted in the same efficacy. Lowering zinc to 25 mg when beta-carotene was present (Group 4 vs Group 1) also did not affect disease progression compared to the original high-zinc, beta-carotene containing formula.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -29986,7 +29986,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["171eb7ee", "ee5ec723"],
-		"explanation": "Removing beta-carotene (Group 2 vs Group 1) resulted in an additional reduction in AMD progression. Reducing the zinc oxide dosage to 25 mg while beta-carotene was also absent (Group 3 vs Group 2) showed equivalent efficacy. Reducing zinc to 25mg while beta-carotene was present (Group 4 vs Group 1) also showed equivalent efficacy to the original formula.",
+		"rationale": "Removing beta-carotene (Group 2 vs Group 1) resulted in an additional reduction in AMD progression. Reducing the zinc oxide dosage to 25 mg while beta-carotene was also absent (Group 3 vs Group 2) showed equivalent efficacy. Reducing zinc to 25mg while beta-carotene was present (Group 4 vs Group 1) also showed equivalent efficacy to the original formula.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30016,7 +30016,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d1731686"],
-		"explanation": "The description of the original AREDS formulation results specifically states that patients with early AMD were not part of the study population for whom the 25% reduction in progression was reported.",
+		"rationale": "The description of the original AREDS formulation results specifically states that patients with early AMD were not part of the study population for whom the 25% reduction in progression was reported.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30046,7 +30046,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9a995f68"],
-		"explanation": "The RDI table lists Potassium at 4,700 mg for adults and children ≥ 4 years.",
+		"rationale": "The RDI table lists Potassium at 4,700 mg for adults and children ≥ 4 years.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30076,7 +30076,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["54ee94a4"],
-		"explanation": "The RDI for Iron is 18 mg for adults and 27 mg for pregnant/lactating women, a substantial increase. Vitamin D is lower (15 vs 20 mcg), Calcium is the same (1300 mg), and Magnesium is slightly lower (400 vs 420 mg) for pregnant/lactating women compared to adults.",
+		"rationale": "The RDI for Iron is 18 mg for adults and 27 mg for pregnant/lactating women, a substantial increase. Vitamin D is lower (15 vs 20 mcg), Calcium is the same (1300 mg), and Magnesium is slightly lower (400 vs 420 mg) for pregnant/lactating women compared to adults.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30106,7 +30106,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1b67f401", "cb33f3bf", "dc002bb8"],
-		"explanation": "The RDI table indicates Vitamin K, Folate (as DFE), and Vitamin B12 are measured in mcg. Vitamin C and Iron are measured in mg.",
+		"rationale": "The RDI table indicates Vitamin K, Folate (as DFE), and Vitamin B12 are measured in mcg. Vitamin C and Iron are measured in mg.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30140,7 +30140,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["50cc6c71"],
-		"explanation": "The UL table explicitly links exceeding the 35 mg/d UL for Niacin with flushing and gastrointestinal distress.",
+		"rationale": "The UL table explicitly links exceeding the 35 mg/d UL for Niacin with flushing and gastrointestinal distress.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30170,7 +30170,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["855f3c4a"],
-		"explanation": "The footnote indicates that 1 mcg of Vitamin D equals 40 IU. Therefore, 20 mcg multiplied by 40 IU/mcg equals 800 IU.",
+		"rationale": "The footnote indicates that 1 mcg of Vitamin D equals 40 IU. Therefore, 20 mcg multiplied by 40 IU/mcg equals 800 IU.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30200,7 +30200,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["eddaa02a", "e474e2c3", "bf79d457", "0e757077"],
-		"explanation": "Excess Vitamin D can cause hypercalcemia leading to soft tissue calcification. Excess Vitamin C can cause kidney stones. Excess Calcium can cause kidney stones and soft tissue calcification. Excess Phosphorus can cause metastatic calcification. Niacin toxicity manifests differently (flushing, GI distress).",
+		"rationale": "Excess Vitamin D can cause hypercalcemia leading to soft tissue calcification. Excess Vitamin C can cause kidney stones. Excess Calcium can cause kidney stones and soft tissue calcification. Excess Phosphorus can cause metastatic calcification. Niacin toxicity manifests differently (flushing, GI distress).",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30234,7 +30234,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d6a64bfa"],
-		"explanation": "The UL table identifies sensory neuropathy as the primary toxicity associated with exceeding the Vitamin B6 UL of 100 mg/d.",
+		"rationale": "The UL table identifies sensory neuropathy as the primary toxicity associated with exceeding the Vitamin B6 UL of 100 mg/d.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30264,7 +30264,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c4f56a0a"],
-		"explanation": "The UL table for Folate specifically notes that intakes above 1,000 µg/d (from synthetic forms) can mask the neurological complications associated with Vitamin B12 deficiency, potentially delaying diagnosis and appropriate treatment.",
+		"rationale": "The UL table for Folate specifically notes that intakes above 1,000 µg/d (from synthetic forms) can mask the neurological complications associated with Vitamin B12 deficiency, potentially delaying diagnosis and appropriate treatment.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30294,7 +30294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f9059c9b", "1c2afdcf", "3efc4021"],
-		"explanation": "Option A is incorrect; Vitamin A RDI is measured in mcg RAE. Option B is correct (11 mg vs 7 mg). Option C is correct (1300 mg vs 1300 mg). Option D is correct (2.8 mcg vs 2.4 mcg). Option E is incorrect; Choline RDI is measured in mg.",
+		"rationale": "Option A is incorrect; Vitamin A RDI is measured in mcg RAE. Option B is correct (11 mg vs 7 mg). Option C is correct (1300 mg vs 1300 mg). Option D is correct (2.8 mcg vs 2.4 mcg). Option E is incorrect; Choline RDI is measured in mg.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30328,7 +30328,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5884c0e5"],
-		"explanation": "The UL table lists the maximum dose for Vitamin E as 1,000 mg/d and the associated toxicity as hemorrhagic toxicity.",
+		"rationale": "The UL table lists the maximum dose for Vitamin E as 1,000 mg/d and the associated toxicity as hemorrhagic toxicity.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30358,7 +30358,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["31158071"],
-		"explanation": "Retinol, the active form of Vitamin A, is the direct precursor to retinal, essential for rhodopsin structure. Vitamin A is also necessary for goblet cell mucin production.",
+		"rationale": "Retinol, the active form of Vitamin A, is the direct precursor to retinal, essential for rhodopsin structure. Vitamin A is also necessary for goblet cell mucin production.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30388,7 +30388,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["479d42ac"],
-		"explanation": "Vitamin B2 (riboflavin), combined with UV light, is utilized in the corneal cross-linking procedure to treat keratoconus.",
+		"rationale": "Vitamin B2 (riboflavin), combined with UV light, is utilized in the corneal cross-linking procedure to treat keratoconus.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30418,7 +30418,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9c2e6f3a"],
-		"explanation": "Vitamin B3 (niacin) may offer protection against glaucoma, but excessive amounts are linked to cystoid macular edema.",
+		"rationale": "Vitamin B3 (niacin) may offer protection against glaucoma, but excessive amounts are linked to cystoid macular edema.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30448,7 +30448,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0f668a68", "975293c3", "97a83800"],
-		"explanation": "Vitamin B6, Vitamin B9 (folate), and Vitamin D are all associated with a lower risk or reduced risk of developing AMD.",
+		"rationale": "Vitamin B6, Vitamin B9 (folate), and Vitamin D are all associated with a lower risk or reduced risk of developing AMD.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30478,7 +30478,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e6b1f5a7"],
-		"explanation": "Vitamin C (ascorbic acid) is the main antioxidant in the aqueous humor and is required for the synthesis of collagen.",
+		"rationale": "Vitamin C (ascorbic acid) is the main antioxidant in the aqueous humor and is required for the synthesis of collagen.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30508,7 +30508,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6a4165af", "fc8b02b0", "486d1dd4"],
-		"explanation": "Vitamin E is a potent antioxidant, crucial for T cell/immune function, and possesses blood-thinning properties that can be additive with other anticoagulants like aspirin. It is not a structural component of rhodopsin (that's retinal from Vitamin A).",
+		"rationale": "Vitamin E is a potent antioxidant, crucial for T cell/immune function, and possesses blood-thinning properties that can be additive with other anticoagulants like aspirin. It is not a structural component of rhodopsin (that's retinal from Vitamin A).",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30538,7 +30538,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["774f7911", "a2418d62", "d0bdeb9c", "440906a4"],
-		"explanation": "The provided text lists Vitamin A (beta-carotene form), Vitamin C, Zinc, Copper, and Vitamin E as components of AREDS formulations. Niacin is not listed as an AREDS component.",
+		"rationale": "The provided text lists Vitamin A (beta-carotene form), Vitamin C, Zinc, Copper, and Vitamin E as components of AREDS formulations. Niacin is not listed as an AREDS component.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30572,7 +30572,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["103e2195"],
-		"explanation": "The material explicitly identifies Vitamins A, D, E, and K as fat-soluble. Option C includes A, D, and E, which were discussed in the context of ocular relevance.",
+		"rationale": "The material explicitly identifies Vitamins A, D, E, and K as fat-soluble. Option C includes A, D, and E, which were discussed in the context of ocular relevance.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30602,7 +30602,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9c14b78d", "72d91d2d", "4e3b397c"],
-		"explanation": "Copper is identified as being used for mitochondrial energy, collagen/elastin synthesis, and endothelial progenitor cell production, all stated as critical for Bruch's and other basement membranes. Mucin production involves Vitamin A.",
+		"rationale": "Copper is identified as being used for mitochondrial energy, collagen/elastin synthesis, and endothelial progenitor cell production, all stated as critical for Bruch's and other basement membranes. Mucin production involves Vitamin A.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30632,7 +30632,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e7653ec9"],
-		"explanation": "While Zinc is an antioxidant and supports T cell function (and is in AREDS), the text notes that high concentrations have been linked to a possible increased risk of wet AMD.",
+		"rationale": "While Zinc is an antioxidant and supports T cell function (and is in AREDS), the text notes that high concentrations have been linked to a possible increased risk of wet AMD.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30662,7 +30662,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ffacb8e7"],
-		"explanation": "EPA and DHA are predominantly found in fish and other seafood, distinguishing them from ALA which is mainly sourced from plants.",
+		"rationale": "EPA and DHA are predominantly found in fish and other seafood, distinguishing them from ALA which is mainly sourced from plants.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30692,7 +30692,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5ffde6a3"],
-		"explanation": "The term \"long-chain\" refers to the molecular structure, specifically the number of carbon atoms. EPA has 20 carbons and DHA has 22, distinguishing them from shorter-chain omega-3s like ALA (18 carbons).",
+		"rationale": "The term \"long-chain\" refers to the molecular structure, specifically the number of carbon atoms. EPA has 20 carbons and DHA has 22, distinguishing them from shorter-chain omega-3s like ALA (18 carbons).",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30722,7 +30722,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["25996205"],
-		"explanation": "Omega-3 fatty acids are essential components that, along with other fats, enable the meibomian glands to produce the lipid layer of the tear film, which is crucial for managing dry eye and lid disease.",
+		"rationale": "Omega-3 fatty acids are essential components that, along with other fats, enable the meibomian glands to produce the lipid layer of the tear film, which is crucial for managing dry eye and lid disease.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30752,7 +30752,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b46117d2", "f004f239", "e6e17f17"],
-		"explanation": "Omega-3 fatty acids are known to decrease platelet aggregation, reduce the risk of thrombosis, and improve cholesterol and triglyceride levels. They do not enhance blood coagulation; rather, they tend to reduce it.",
+		"rationale": "Omega-3 fatty acids are known to decrease platelet aggregation, reduce the risk of thrombosis, and improve cholesterol and triglyceride levels. They do not enhance blood coagulation; rather, they tend to reduce it.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30782,7 +30782,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f2c4b943"],
-		"explanation": "Omega-3 PUFAs are critical structural components of neuronal membranes, influencing cellular function and are vital for normal visual function and the development of the nervous system.",
+		"rationale": "Omega-3 PUFAs are critical structural components of neuronal membranes, influencing cellular function and are vital for normal visual function and the development of the nervous system.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30812,7 +30812,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b5e3bc34"],
-		"explanation": "By reducing platelet aggregation, coagulation, and thrombosis, and improving lipid profiles, omega-3s can positively impact cardiovascular health, which in turn may help mitigate ocular ischemic diseases linked to poor cardiovascular status.",
+		"rationale": "By reducing platelet aggregation, coagulation, and thrombosis, and improving lipid profiles, omega-3s can positively impact cardiovascular health, which in turn may help mitigate ocular ischemic diseases linked to poor cardiovascular status.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30842,7 +30842,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["86708de1"],
-		"explanation": "While the body can convert small amounts of ALA to EPA and DHA, this conversion is inefficient. Therefore, direct dietary intake of all three main omega-3 fatty acids (ALA, EPA, DHA) is generally necessary to ensure adequate levels.",
+		"rationale": "While the body can convert small amounts of ALA to EPA and DHA, this conversion is inefficient. Therefore, direct dietary intake of all three main omega-3 fatty acids (ALA, EPA, DHA) is generally necessary to ensure adequate levels.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30872,7 +30872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["24921a97", "729c4dd3"],
-		"explanation": "Evidence suggests potential benefits of EPA and DHA intake in neurodegenerative conditions. Within the eye, this includes potential roles in managing degenerative diseases like macular degeneration and glaucoma.",
+		"rationale": "Evidence suggests potential benefits of EPA and DHA intake in neurodegenerative conditions. Within the eye, this includes potential roles in managing degenerative diseases like macular degeneration and glaucoma.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30902,7 +30902,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9ebedc95"],
-		"explanation": "Alpha-linolenic acid (ALA) is an omega-3 fatty acid predominantly found in plant-based oils, such as flaxseed oil, soybean oil, and canola oil.",
+		"rationale": "Alpha-linolenic acid (ALA) is an omega-3 fatty acid predominantly found in plant-based oils, such as flaxseed oil, soybean oil, and canola oil.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30932,7 +30932,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8de88cbd", "e538e2a9", "9b836d95"],
-		"explanation": "ALA has 18 carbons. EPA (20 carbons) and DHA (22 carbons) are considered long-chain omega-3 fatty acids. Therefore, EPA is not short-chain.",
+		"rationale": "ALA has 18 carbons. EPA (20 carbons) and DHA (22 carbons) are considered long-chain omega-3 fatty acids. Therefore, EPA is not short-chain.",
 		"metadata": {},
 		"moduleId": "js72g9k0xwvk3qvmfdb0xye2r57m8aq0",
 		"options": [
@@ -30962,7 +30962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0e363402"],
-		"explanation": "Glutamate is explicitly identified as the main excitatory neurotransmitter in the central nervous system, present in the vast majority of synapses.",
+		"rationale": "Glutamate is explicitly identified as the main excitatory neurotransmitter in the central nervous system, present in the vast majority of synapses.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -30992,7 +30992,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c4bbb387"],
-		"explanation": "GABA is the main inhibitory neurotransmitter, reducing central nervous system activity and enabling relaxation and sleep. Medications enhancing relaxation often target the GABA system.",
+		"rationale": "GABA is the main inhibitory neurotransmitter, reducing central nervous system activity and enabling relaxation and sleep. Medications enhancing relaxation often target the GABA system.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31022,7 +31022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["39bb9e8f"],
-		"explanation": "Dopamine is involved in coordinating voluntary movement (implicated in Parkinson's disease when deficient) and the brain's reward center (implicated in addiction and pleasure).",
+		"rationale": "Dopamine is involved in coordinating voluntary movement (implicated in Parkinson's disease when deficient) and the brain's reward center (implicated in addiction and pleasure).",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31052,7 +31052,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c368d73d"],
-		"explanation": "Norepinephrine acts more specifically on alpha receptors to maintain blood pressure, whereas epinephrine has broader effects. Epinephrine is released during stress, while norepinephrine is released continuously at low levels.",
+		"rationale": "Norepinephrine acts more specifically on alpha receptors to maintain blood pressure, whereas epinephrine has broader effects. Epinephrine is released during stress, while norepinephrine is released continuously at low levels.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31082,7 +31082,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3b55a7d3"],
-		"explanation": "Serotonin is involved in regulating sleep (as a precursor to melatonin), mood (emotional control), and appetite (promotes satisfaction after eating).",
+		"rationale": "Serotonin is involved in regulating sleep (as a precursor to melatonin), mood (emotional control), and appetite (promotes satisfaction after eating).",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31112,7 +31112,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["77ecbd9d", "68be2ce6"],
-		"explanation": "Both dopamine and serotonin are mentioned as controlling nausea and vomiting signals. Dopamine stimulates the nausea/vomiting centers, and serotonin is also involved.",
+		"rationale": "Both dopamine and serotonin are mentioned as controlling nausea and vomiting signals. Dopamine stimulates the nausea/vomiting centers, and serotonin is also involved.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31146,7 +31146,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cc543e12", "a24236ac", "87a8da43"],
-		"explanation": "Dopamine, epinephrine (adrenaline), and norepinephrine (noradrenaline) are explicitly referred to together as the catecholamines.",
+		"rationale": "Dopamine, epinephrine (adrenaline), and norepinephrine (noradrenaline) are explicitly referred to together as the catecholamines.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31180,7 +31180,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2e1b1081", "927bdb1c"],
-		"explanation": "Glutamate is the main excitatory neurotransmitter, increasing neuronal activity, while GABA is the main inhibitory neurotransmitter, decreasing neuronal activity. They have opposing functions in regulating CNS excitability.",
+		"rationale": "Glutamate is the main excitatory neurotransmitter, increasing neuronal activity, while GABA is the main inhibitory neurotransmitter, decreasing neuronal activity. They have opposing functions in regulating CNS excitability.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31214,7 +31214,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["70066588"],
-		"explanation": "Glutamate transporters remove excess glutamate from the synapse. Blocking these transporters would lead to an accumulation of glutamate, causing over-excitation (excitotoxicity) and potentially neuronal apoptosis (cell death).",
+		"rationale": "Glutamate transporters remove excess glutamate from the synapse. Blocking these transporters would lead to an accumulation of glutamate, causing over-excitation (excitotoxicity) and potentially neuronal apoptosis (cell death).",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31244,7 +31244,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7021309d"],
-		"explanation": "Adrenaline (Epinephrine) is responsible for the 'fight or flight' response, triggered by stress, leading to physiological changes like increased heart rate and breathing rate.",
+		"rationale": "Adrenaline (Epinephrine) is responsible for the 'fight or flight' response, triggered by stress, leading to physiological changes like increased heart rate and breathing rate.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31274,7 +31274,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e622cf5f"],
-		"explanation": "The text explicitly states that acetylcholine works at the neuro-muscular junction, where its binding to receptors on muscle fibers triggers an action potential.",
+		"rationale": "The text explicitly states that acetylcholine works at the neuro-muscular junction, where its binding to receptors on muscle fibers triggers an action potential.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31304,7 +31304,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ed7d8393"],
-		"explanation": "The material indicates that acetylcholine is central for learning and memory functions in the brain, in addition to its role at the neuromuscular junction.",
+		"rationale": "The material indicates that acetylcholine is central for learning and memory functions in the brain, in addition to its role at the neuromuscular junction.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31334,7 +31334,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5fd1a8a5"],
-		"explanation": "The text defines endorphins as serving a primary function in blocking the perception of pain.",
+		"rationale": "The text defines endorphins as serving a primary function in blocking the perception of pain.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31364,7 +31364,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7995eae0", "1d593a62"],
-		"explanation": "The material states that endorphins function as neurotransmitters in the central nervous system and as peptide hormones released into the circulatory system by the pituitary gland.",
+		"rationale": "The material states that endorphins function as neurotransmitters in the central nervous system and as peptide hormones released into the circulatory system by the pituitary gland.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31394,7 +31394,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0b8a6ad9", "eea26e6a", "84426d05"],
-		"explanation": "The text links endorphins clinically to mental issues like autism and depression (implying association with the condition itself, C), and also to activities like vigorous aerobic exercise (A) and laughter (D).",
+		"rationale": "The text links endorphins clinically to mental issues like autism and depression (implying association with the condition itself, C), and also to activities like vigorous aerobic exercise (A) and laughter (D).",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31428,7 +31428,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1fdd8810"],
-		"explanation": "According to the text, the brain synthesizes oxytocin in the hypothalamus and releases it via the pituitary gland.",
+		"rationale": "According to the text, the brain synthesizes oxytocin in the hypothalamus and releases it via the pituitary gland.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31458,7 +31458,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d5539e13", "db9952a1", "ee5eeca7"],
-		"explanation": "The provided material describes oxytocin's role in urging uterine contractions during delivery (A), stimulating milk release from mammary glands (B), and reinforcing bonds, such as between mothers and infants (D).",
+		"rationale": "The provided material describes oxytocin's role in urging uterine contractions during delivery (A), stimulating milk release from mammary glands (B), and reinforcing bonds, such as between mothers and infants (D).",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31492,7 +31492,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a393dfcd"],
-		"explanation": "The text identifies acetylcholine as the neurotransmitter released at the neuro-muscular junction that triggers action potentials in muscle fibers.",
+		"rationale": "The text identifies acetylcholine as the neurotransmitter released at the neuro-muscular junction that triggers action potentials in muscle fibers.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31522,7 +31522,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f77f0d59", "77970973"],
-		"explanation": "The material explicitly states endorphins act as both neurotransmitters and peptide hormones (B). It describes oxytocin being released via the pituitary to trigger body-wide responses (hormonal action) and also mentions its association with brain functions like pair bonding (implying neurotransmitter roles) (C). Acetylcholine is primarily described as a neurotransmitter at the NMJ and in the brain.",
+		"rationale": "The material explicitly states endorphins act as both neurotransmitters and peptide hormones (B). It describes oxytocin being released via the pituitary to trigger body-wide responses (hormonal action) and also mentions its association with brain functions like pair bonding (implying neurotransmitter roles) (C). Acetylcholine is primarily described as a neurotransmitter at the NMJ and in the brain.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31552,7 +31552,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["452b1490"],
-		"explanation": "The text mentions that oxytocin has been called 'the cuddle hormone' or 'the love hormone' due to its association with pair bonding.",
+		"rationale": "The text mentions that oxytocin has been called 'the cuddle hormone' or 'the love hormone' due to its association with pair bonding.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31582,7 +31582,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ae413d8b", "08910f96", "7750f370"],
-		"explanation": "Opioids exert their effects by binding to mu, delta, and kappa opioid receptors within and outside the central nervous system.",
+		"rationale": "Opioids exert their effects by binding to mu, delta, and kappa opioid receptors within and outside the central nervous system.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31616,7 +31616,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["401cbb12"],
-		"explanation": "The Mu₂ opioid receptor subtype is primarily associated with respiratory depression, cardiovascular effects, gastrointestinal effects, miosis, and urinary retention.",
+		"rationale": "The Mu₂ opioid receptor subtype is primarily associated with respiratory depression, cardiovascular effects, gastrointestinal effects, miosis, and urinary retention.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31646,7 +31646,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b481a79"],
-		"explanation": "Fentanyl is classified as a synthetic opioid, belonging to the phenylpiperidine class.",
+		"rationale": "Fentanyl is classified as a synthetic opioid, belonging to the phenylpiperidine class.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31676,7 +31676,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5a72bfda"],
-		"explanation": "Opioid receptor binding activates a signaling cascade that leads to a decrease in cyclic AMP (cAMP) and subsequent inhibition of nociceptive neurotransmitter release.",
+		"rationale": "Opioid receptor binding activates a signaling cascade that leads to a decrease in cyclic AMP (cAMP) and subsequent inhibition of nociceptive neurotransmitter release.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31706,7 +31706,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["69d86b3f"],
-		"explanation": "Oral administration of many opioids results in significant metabolism in the liver (first-pass effect) before reaching systemic circulation, reducing bioavailability compared to parenteral routes.",
+		"rationale": "Oral administration of many opioids results in significant metabolism in the liver (first-pass effect) before reaching systemic circulation, reducing bioavailability compared to parenteral routes.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31736,7 +31736,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["525cd5f2", "5fa551e9", "dcc2e194"],
-		"explanation": "Activation of Mu opioid receptors is associated with various effects including euphoria (Mu₁), supraspinal analgesia (Mu₁), respiratory depression (Mu₂), and miosis (Mu₂). Dysphoria is primarily linked to kappa receptors.",
+		"rationale": "Activation of Mu opioid receptors is associated with various effects including euphoria (Mu₁), supraspinal analgesia (Mu₁), respiratory depression (Mu₂), and miosis (Mu₂). Dysphoria is primarily linked to kappa receptors.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31766,7 +31766,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2e96f39b", "4a4eb7bf", "9a74b70a"],
-		"explanation": "Endogenous opioids are naturally occurring peptides within the body. These include endorphins (specifically β-endorphin), enkephalins, and dynorphins. Morphine is an opium alkaloid, and fentanyl is synthetic.",
+		"rationale": "Endogenous opioids are naturally occurring peptides within the body. These include endorphins (specifically β-endorphin), enkephalins, and dynorphins. Morphine is an opium alkaloid, and fentanyl is synthetic.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31800,7 +31800,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c20b100d", "b0af9153", "1a9b30bb"],
-		"explanation": "Opioid receptor activation inhibits the release of several neurotransmitters, including dopamine, acetylcholine, and substance P, contributing to analgesia and other effects.",
+		"rationale": "Opioid receptor activation inhibits the release of several neurotransmitters, including dopamine, acetylcholine, and substance P, contributing to analgesia and other effects.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31834,7 +31834,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["38842a11"],
-		"explanation": "Transdermal administration, particularly with fentanyl patches, provides stable drug plasma levels suitable for managing constant pain, such as that associated with malignancies, especially when oral routes are difficult.",
+		"rationale": "Transdermal administration, particularly with fentanyl patches, provides stable drug plasma levels suitable for managing constant pain, such as that associated with malignancies, especially when oral routes are difficult.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31864,7 +31864,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["18861239", "c1c62624", "1d7dde2f"],
-		"explanation": "Semi-synthetic opioids are derived from natural opium alkaloids like morphine or thebaine. Examples include heroin, oxycodone, and hydrocodone. Codeine is a natural opium alkaloid, and methadone is synthetic.",
+		"rationale": "Semi-synthetic opioids are derived from natural opium alkaloids like morphine or thebaine. Examples include heroin, oxycodone, and hydrocodone. Codeine is a natural opium alkaloid, and methadone is synthetic.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31898,7 +31898,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a3ae1d91", "f0fdc80b"],
-		"explanation": "Hydrocodone and codeine are explicitly mentioned as the most commonly used opioids in eye care for acute pain management.",
+		"rationale": "Hydrocodone and codeine are explicitly mentioned as the most commonly used opioids in eye care for acute pain management.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31932,7 +31932,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f968e3b4"],
-		"explanation": "Morphine helps relieve dyspnea from pulmonary edema by reducing cardiac preload and afterload, in addition to reducing anxiety and awareness of shortness of breath.",
+		"rationale": "Morphine helps relieve dyspnea from pulmonary edema by reducing cardiac preload and afterload, in addition to reducing anxiety and awareness of shortness of breath.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -31966,7 +31966,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4e5613ce"],
-		"explanation": "Miosis (pupillary constriction) is listed as a characteristic adverse effect of opioid use.",
+		"rationale": "Miosis (pupillary constriction) is listed as a characteristic adverse effect of opioid use.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32000,7 +32000,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e5cd63b9", "0cd9d962", "b8c5c979", "266ba585"],
-		"explanation": "Constipation is the most common side effect with chronic use, but nausea, vomiting, sedation, and pruritus are also listed as common adverse effects.",
+		"rationale": "Constipation is the most common side effect with chronic use, but nausea, vomiting, sedation, and pruritus are also listed as common adverse effects.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32034,7 +32034,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a4b8fcc1"],
-		"explanation": "Naloxone is explicitly identified as the specific antidote for reversing opioid-induced central nervous system and respiratory depression.",
+		"rationale": "Naloxone is explicitly identified as the specific antidote for reversing opioid-induced central nervous system and respiratory depression.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32068,7 +32068,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ae811168"],
-		"explanation": "Dextromethorphan (DXM) is structurally similar to opioids but acts primarily as an NMDA receptor blocker, not on mu opioid receptors like morphine.",
+		"rationale": "Dextromethorphan (DXM) is structurally similar to opioids but acts primarily as an NMDA receptor blocker, not on mu opioid receptors like morphine.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32102,7 +32102,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["38243cd5"],
-		"explanation": "The text explicitly states that co-administration of opioids with sedative-hypnotics increases the risk of central nervous system depression, particularly respiratory depression.",
+		"rationale": "The text explicitly states that co-administration of opioids with sedative-hypnotics increases the risk of central nervous system depression, particularly respiratory depression.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32136,7 +32136,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d668bd24", "f9bce271"],
-		"explanation": "The material cautions against opioid use in patients with severe asthma and COPD due to the risk of potentially fatal respiratory depression.",
+		"rationale": "The material cautions against opioid use in patients with severe asthma and COPD due to the risk of potentially fatal respiratory depression.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32170,7 +32170,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["023a531c", "01c66077"],
-		"explanation": "Diphenoxylate and loperamide are phenylpiperidine opioids noted for their selective gastrointestinal effects used to control diarrhea.",
+		"rationale": "Diphenoxylate and loperamide are phenylpiperidine opioids noted for their selective gastrointestinal effects used to control diarrhea.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32204,7 +32204,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7f7ac906", "994ede3d", "57f9b71a"],
-		"explanation": "Opioids are used perioperatively (before, during, after surgery) for their sedative, anxiolytic (anxiety-reducing), and analgesic (pain-relieving) properties.",
+		"rationale": "Opioids are used perioperatively (before, during, after surgery) for their sedative, anxiolytic (anxiety-reducing), and analgesic (pain-relieving) properties.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32238,7 +32238,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e36ce7c4"],
-		"explanation": "The material classifies Fentanyl and Meperidine as strong agonist Phenylpiperidines. Morphine is a strong agonist Phenanthrene, and Methadone is a strong agonist Phenylheptylamine.",
+		"rationale": "The material classifies Fentanyl and Meperidine as strong agonist Phenylpiperidines. Morphine is a strong agonist Phenanthrene, and Methadone is a strong agonist Phenylheptylamine.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32268,7 +32268,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d342d961"],
-		"explanation": "The text states that Hydrocodone (Vicodin, Lortab) is a Schedule II drug that may be prescribed by optometrists in some states like Oklahoma for a limited time (1 week or less). Oxycodone is Schedule II but not prescribed by ODs. Codeine combinations (Tylenol 3/4) are Schedule III (or II at high doses). Tramadol is Schedule IV.",
+		"rationale": "The text states that Hydrocodone (Vicodin, Lortab) is a Schedule II drug that may be prescribed by optometrists in some states like Oklahoma for a limited time (1 week or less). Oxycodone is Schedule II but not prescribed by ODs. Codeine combinations (Tylenol 3/4) are Schedule III (or II at high doses). Tramadol is Schedule IV.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32298,7 +32298,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["739f21d7", "0a585588"],
-		"explanation": "The text explicitly mentions that hydrocodone is typically mixed with 325 mg acetaminophen (e.g., Vicodin, Lortab) or supplied as 7.5 mg hydrocodone with 200 mg ibuprofen (Vicoprofen).",
+		"rationale": "The text explicitly mentions that hydrocodone is typically mixed with 325 mg acetaminophen (e.g., Vicodin, Lortab) or supplied as 7.5 mg hydrocodone with 200 mg ibuprofen (Vicoprofen).",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32328,7 +32328,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ab90143e"],
-		"explanation": "The material identifies Vicoprofen specifically as the formulation containing 7.5 mg hydrocodone with 200 mg ibuprofen.",
+		"rationale": "The material identifies Vicoprofen specifically as the formulation containing 7.5 mg hydrocodone with 200 mg ibuprofen.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32358,7 +32358,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["576644e0"],
-		"explanation": "Loperamide and Diphenoxylate are listed as mild to moderate Phenylpiperidines. Fentanyl is a strong Phenylpiperidine. Codeine is a mild to moderate Phenanthrene. Methadone is a strong Phenylheptylamine.",
+		"rationale": "Loperamide and Diphenoxylate are listed as mild to moderate Phenylpiperidines. Fentanyl is a strong Phenylpiperidine. Codeine is a mild to moderate Phenanthrene. Methadone is a strong Phenylheptylamine.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32388,7 +32388,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4044aa25"],
-		"explanation": "The text clearly states that Tramadol (Ultram) is a Schedule IV drug.",
+		"rationale": "The text clearly states that Tramadol (Ultram) is a Schedule IV drug.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32418,7 +32418,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3ff7eda2", "dcfc2b34", "20e99894"],
-		"explanation": "The text indicates that optometrists with DEA privileges may prescribe Schedule III Tylenol 3 (codeine/acetaminophen), Schedule III Tylenol 4 (codeine/acetaminophen), Schedule II Hydrocodone combinations (e.g., Vicodin, Vicoprofen) in certain states for limited durations, and Schedule IV Tramadol.",
+		"rationale": "The text indicates that optometrists with DEA privileges may prescribe Schedule III Tylenol 3 (codeine/acetaminophen), Schedule III Tylenol 4 (codeine/acetaminophen), Schedule II Hydrocodone combinations (e.g., Vicodin, Vicoprofen) in certain states for limited durations, and Schedule IV Tramadol.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32448,7 +32448,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b9ea3c7e"],
-		"explanation": "The typical dosage for Tramadol is 100 mg every 4-6 hours as needed, with a specific instruction not to exceed 400 mg per day.",
+		"rationale": "The typical dosage for Tramadol is 100 mg every 4-6 hours as needed, with a specific instruction not to exceed 400 mg per day.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32478,7 +32478,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bf1058ae", "a710d603", "ced5487f", "38ebf49f"],
-		"explanation": "The first paragraph explicitly states that when opioids are prescribed, tolerance, potential for dependence, potential for toxicity and its proper treatment, and possible contraindications should always be considered.",
+		"rationale": "The first paragraph explicitly states that when opioids are prescribed, tolerance, potential for dependence, potential for toxicity and its proper treatment, and possible contraindications should always be considered.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32508,7 +32508,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["33a12d43"],
-		"explanation": "The text describes Tylenol 3 as containing 30 mg codeine with 300 mg acetaminophen, and Tylenol 4 as 60 mg codeine with 300 mg acetaminophen. Both are typically dosed as 1 tablet every 4 hours as needed.",
+		"rationale": "The text describes Tylenol 3 as containing 30 mg codeine with 300 mg acetaminophen, and Tylenol 4 as 60 mg codeine with 300 mg acetaminophen. Both are typically dosed as 1 tablet every 4 hours as needed.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32538,7 +32538,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["61d2aae2"],
-		"explanation": "According to the DEA classification, heroin is a Schedule I drug, characterized by a high potential for abuse and no currently accepted medical use.",
+		"rationale": "According to the DEA classification, heroin is a Schedule I drug, characterized by a high potential for abuse and no currently accepted medical use.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32568,7 +32568,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fbd128b7"],
-		"explanation": "Ritalin (methylphenidate) is listed as a Schedule II drug, known for its high potential for abuse despite having accepted medical uses, such as treating ADHD.",
+		"rationale": "Ritalin (methylphenidate) is listed as a Schedule II drug, known for its high potential for abuse despite having accepted medical uses, such as treating ADHD.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32598,7 +32598,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a400ab2e"],
-		"explanation": "Schedule II drugs have a high potential for abuse leading to severe dependence, whereas Schedule III drugs have a moderate to low potential for dependence, representing a lower abuse potential than Schedule II.",
+		"rationale": "Schedule II drugs have a high potential for abuse leading to severe dependence, whereas Schedule III drugs have a moderate to low potential for dependence, representing a lower abuse potential than Schedule II.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32628,7 +32628,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e3f03e2b", "b9d33681", "a300e6da"],
-		"explanation": "Xanax, Ativan, and Tramadol are all listed as examples of Schedule IV drugs, characterized by a low potential for abuse and low risk of dependence. OxyContin is a Schedule II drug.",
+		"rationale": "Xanax, Ativan, and Tramadol are all listed as examples of Schedule IV drugs, characterized by a low potential for abuse and low risk of dependence. OxyContin is a Schedule II drug.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32658,7 +32658,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["189b66e9"],
-		"explanation": "Acetaminophen (APAP) primarily exerts its analgesic and antipyretic effects by acting centrally within the brain, potentially via COX inhibition in specific brain centers, not through peripheral mechanisms.",
+		"rationale": "Acetaminophen (APAP) primarily exerts its analgesic and antipyretic effects by acting centrally within the brain, potentially via COX inhibition in specific brain centers, not through peripheral mechanisms.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32688,7 +32688,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["64094cb7"],
-		"explanation": "Combining acetaminophen (central action) with NSAIDs (peripheral action) provides enhanced pain relief because they target pain through different mechanisms, resulting in a synergistic or additive effect compared to using either drug alone.",
+		"rationale": "Combining acetaminophen (central action) with NSAIDs (peripheral action) provides enhanced pain relief because they target pain through different mechanisms, resulting in a synergistic or additive effect compared to using either drug alone.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32718,7 +32718,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9f459cd8"],
-		"explanation": "Exceeding 4000-5000 mg of acetaminophen per day increases the risk of liver toxicity. Taking 1000 mg every 4 hours equals 6000 mg/day, which significantly surpasses the recommended maximum (3000 mg/day) and the threshold for potential toxicity.",
+		"rationale": "Exceeding 4000-5000 mg of acetaminophen per day increases the risk of liver toxicity. Taking 1000 mg every 4 hours equals 6000 mg/day, which significantly surpasses the recommended maximum (3000 mg/day) and the threshold for potential toxicity.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32748,7 +32748,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8a874a15", "b0aaa63a", "0c80bb1b"],
-		"explanation": "Acetaminophen toxicity risk increases with doses exceeding 4000 mg/day, concurrent use of multiple APAP-containing products (leading to unintentional overdose), and potentially compromised liver function or depleted glutathione stores.",
+		"rationale": "Acetaminophen toxicity risk increases with doses exceeding 4000 mg/day, concurrent use of multiple APAP-containing products (leading to unintentional overdose), and potentially compromised liver function or depleted glutathione stores.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32778,7 +32778,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["71a7f7ed", "0a1cf2ba", "dc0ec646"],
-		"explanation": "Schedule V drugs have the lowest abuse potential among scheduled drugs, often contain limited amounts of narcotics, and are used for antitussive or antidiarrheal purposes. Lyrica (pregabalin) is also a Schedule V drug. Schedule IV drugs have a lower abuse potential than Schedule III, not V.",
+		"rationale": "Schedule V drugs have the lowest abuse potential among scheduled drugs, often contain limited amounts of narcotics, and are used for antitussive or antidiarrheal purposes. Lyrica (pregabalin) is also a Schedule V drug. Schedule IV drugs have a lower abuse potential than Schedule III, not V.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32808,7 +32808,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["21de4b15"],
-		"explanation": "The DEA scheduling system classifies drugs based on their accepted medical use and potential for abuse/dependence. Schedule I drugs lack accepted medical use and have high abuse potential, while Schedules II-V have accepted medical uses with progressively decreasing abuse potential.",
+		"rationale": "The DEA scheduling system classifies drugs based on their accepted medical use and potential for abuse/dependence. Schedule I drugs lack accepted medical use and have high abuse potential, while Schedules II-V have accepted medical uses with progressively decreasing abuse potential.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32838,7 +32838,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e040aa13"],
-		"explanation": "Cocaine inhibits the reuptake of dopamine by binding to the dopamine transporter, leading to increased dopamine concentration in the synapse.",
+		"rationale": "Cocaine inhibits the reuptake of dopamine by binding to the dopamine transporter, leading to increased dopamine concentration in the synapse.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32868,7 +32868,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["badc6ca6", "cfd112db", "f5223143"],
-		"explanation": "Cocaine use is associated with mydriasis (pupil dilation), decreased corneal sensation, and conjunctival blanching (vasoconstriction). Keratitis can occur with smoking, not typically direct application.",
+		"rationale": "Cocaine use is associated with mydriasis (pupil dilation), decreased corneal sensation, and conjunctival blanching (vasoconstriction). Keratitis can occur with smoking, not typically direct application.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32898,7 +32898,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["90425f95"],
-		"explanation": "Opioid dependence, such as with heroin, is associated with pupillary miosis (constriction) and an exo posture. Withdrawal is associated with the opposite: mydriasis and eso posture.",
+		"rationale": "Opioid dependence, such as with heroin, is associated with pupillary miosis (constriction) and an exo posture. Withdrawal is associated with the opposite: mydriasis and eso posture.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32928,7 +32928,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7f960955"],
-		"explanation": "Methamphetamine increases dopamine and other catecholamine levels by stimulating their release and preventing their breakdown and reuptake.",
+		"rationale": "Methamphetamine increases dopamine and other catecholamine levels by stimulating their release and preventing their breakdown and reuptake.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32958,7 +32958,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e927ed5c", "4c7ca25f", "d67ce128"],
-		"explanation": "Methamphetamine can cause acute pupillary dilation, blurred vision from decreased accommodation, intra-retinal hemorrhage due to blood pressure spikes, and a non-ischemic optic neuropathy presentation potentially related to vascular issues or nutritional deficits.",
+		"rationale": "Methamphetamine can cause acute pupillary dilation, blurred vision from decreased accommodation, intra-retinal hemorrhage due to blood pressure spikes, and a non-ischemic optic neuropathy presentation potentially related to vascular issues or nutritional deficits.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -32988,7 +32988,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bbc5bfa2", "dcf6022d", "4369d355"],
-		"explanation": "Cannabis use can lead to decreased saccadic accuracy, reduced smooth pursuit function, and increased photophobia. While pupil size changes are noted, the effect is variable and not consistently dilation. IOP is reduced, not increased.",
+		"rationale": "Cannabis use can lead to decreased saccadic accuracy, reduced smooth pursuit function, and increased photophobia. While pupil size changes are noted, the effect is variable and not consistently dilation. IOP is reduced, not increased.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -33018,7 +33018,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aa9e218a"],
-		"explanation": "Although THC reduces IOP, its therapeutic utility is limited by its short duration of action, receptor desensitization over time, and significant behavioral side effects.",
+		"rationale": "Although THC reduces IOP, its therapeutic utility is limited by its short duration of action, receptor desensitization over time, and significant behavioral side effects.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -33048,7 +33048,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b0a83089"],
-		"explanation": "Cocaine causes mydriasis, heroin causes miosis (in dependence), and methamphetamine causes mydriasis. Marijuana's effect on pupil size is variable.",
+		"rationale": "Cocaine causes mydriasis, heroin causes miosis (in dependence), and methamphetamine causes mydriasis. Marijuana's effect on pupil size is variable.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -33078,7 +33078,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d4b67ce5"],
-		"explanation": "Cocaine drops can be used diagnostically to verify a Horner's pupil because cocaine blocks norepinephrine reuptake; a Horner's pupil (denervated) will fail to dilate significantly compared to the normal eye.",
+		"rationale": "Cocaine drops can be used diagnostically to verify a Horner's pupil because cocaine blocks norepinephrine reuptake; a Horner's pupil (denervated) will fail to dilate significantly compared to the normal eye.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -33108,7 +33108,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["19a18e94"],
-		"explanation": "The text mentions that optic neuropathy associated with methamphetamine use might be related to acute vascular events (vasospasm, hypertension) or nutritional deficiencies common in users, such as B vitamin deficiency.",
+		"rationale": "The text mentions that optic neuropathy associated with methamphetamine use might be related to acute vascular events (vasospasm, hypertension) or nutritional deficiencies common in users, such as B vitamin deficiency.",
 		"metadata": {},
 		"moduleId": "js77jqjkwhcaq484gcg6t76mds7m92xz",
 		"options": [
@@ -33138,7 +33138,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["13b2d1e4"],
-		"explanation": "Benzodiazepines exert their effect by enhancing the response to GABA, an inhibitory neurotransmitter, through their action on GABA-A receptors, leading to increased chloride channel opening and neuronal hyperpolarization.",
+		"rationale": "Benzodiazepines exert their effect by enhancing the response to GABA, an inhibitory neurotransmitter, through their action on GABA-A receptors, leading to increased chloride channel opening and neuronal hyperpolarization.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33168,7 +33168,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f3508b49"],
-		"explanation": "Short-acting benzodiazepines like temazepam are preferred for sleep-onset insomnia when hangover effects are undesirable, as they are metabolized more quickly than long-acting agents.",
+		"rationale": "Short-acting benzodiazepines like temazepam are preferred for sleep-onset insomnia when hangover effects are undesirable, as they are metabolized more quickly than long-acting agents.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33198,7 +33198,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fb773f1a"],
-		"explanation": "Midazolam is a short-acting benzodiazepine frequently used intravenously or intramuscularly for procedural sedation, including before cataract surgery, due to its rapid onset and short duration of action.",
+		"rationale": "Midazolam is a short-acting benzodiazepine frequently used intravenously or intramuscularly for procedural sedation, including before cataract surgery, due to its rapid onset and short duration of action.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33228,7 +33228,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["40fce37e", "70019402", "bf129556", "edb41f22"],
-		"explanation": "Common side effects of benzodiazepines include drowsiness, muscle weakness, dizziness, and potential for dependence with long-term use. They also carry risks of misuse, abuse, and withdrawal reactions.",
+		"rationale": "Common side effects of benzodiazepines include drowsiness, muscle weakness, dizziness, and potential for dependence with long-term use. They also carry risks of misuse, abuse, and withdrawal reactions.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33258,7 +33258,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["08b8371b"],
-		"explanation": "Zolpidem, zaleplon, and zopiclone (Z-drugs) are non-benzodiazepine hypnotics that bind to GABA-A receptors, albeit at a different site than benzodiazepines, to produce sedative effects.",
+		"rationale": "Zolpidem, zaleplon, and zopiclone (Z-drugs) are non-benzodiazepine hypnotics that bind to GABA-A receptors, albeit at a different site than benzodiazepines, to produce sedative effects.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33288,7 +33288,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3c69e1f8"],
-		"explanation": "The concurrent use of benzodiazepines and opioids poses a significant risk of severe respiratory depression, which can be fatal. Both drug classes depress central nervous system respiratory drive.",
+		"rationale": "The concurrent use of benzodiazepines and opioids poses a significant risk of severe respiratory depression, which can be fatal. Both drug classes depress central nervous system respiratory drive.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33318,7 +33318,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["697d7c80", "bd29d096", "cdfc8fd9"],
-		"explanation": "Benzodiazepines can affect ocular motor function, causing dysfunction of saccades, smooth pursuits, and nystagmus. Retinal toxicity, such as the 'white-dot-like' retinopathy linked to clonazepam, has also been reported.",
+		"rationale": "Benzodiazepines can affect ocular motor function, causing dysfunction of saccades, smooth pursuits, and nystagmus. Retinal toxicity, such as the 'white-dot-like' retinopathy linked to clonazepam, has also been reported.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33348,7 +33348,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e53d3632"],
-		"explanation": "Buspirone is an anxiolytic thought to exert its effects primarily through interactions with serotonin 5-HT1A receptors, distinguishing its mechanism from GABAergic agents like benzodiazepines.",
+		"rationale": "Buspirone is an anxiolytic thought to exert its effects primarily through interactions with serotonin 5-HT1A receptors, distinguishing its mechanism from GABAergic agents like benzodiazepines.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33378,7 +33378,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bfb64cf9"],
-		"explanation": "Elderly patients are more susceptible to the adverse effects of benzodiazepines, including memory impairment, decreased motor coordination, dizziness, and increased risk of falls. Therefore, these drugs should be used cautiously or avoided in this population.",
+		"rationale": "Elderly patients are more susceptible to the adverse effects of benzodiazepines, including memory impairment, decreased motor coordination, dizziness, and increased risk of falls. Therefore, these drugs should be used cautiously or avoided in this population.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33408,7 +33408,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["40183b48", "e7d69542", "abdc428a"],
-		"explanation": "Diazepam, alprazolam, and lorazepam are all benzodiazepines commonly used for their anxiolytic properties. Zolpidem is primarily used as a hypnotic.",
+		"rationale": "Diazepam, alprazolam, and lorazepam are all benzodiazepines commonly used for their anxiolytic properties. Zolpidem is primarily used as a hypnotic.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33438,7 +33438,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3c9554f5"],
-		"explanation": "Melatonin is recommended to be taken 1-2 hours before bedtime on an empty stomach to optimize absorption and minimize potential gastrointestinal upset.",
+		"rationale": "Melatonin is recommended to be taken 1-2 hours before bedtime on an empty stomach to optimize absorption and minimize potential gastrointestinal upset.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33468,7 +33468,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c7dc99b2", "4914f22a"],
-		"explanation": "Barbiturates are now infrequently used for anxiety primarily due to their significant potential for tolerance and physical dependence, and because safer alternatives like benzodiazepines have become available.",
+		"rationale": "Barbiturates are now infrequently used for anxiety primarily due to their significant potential for tolerance and physical dependence, and because safer alternatives like benzodiazepines have become available.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33502,7 +33502,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e0cdefe5"],
-		"explanation": "Thiopental sodium is specifically listed as a very short-acting barbiturate used in anesthesia.",
+		"rationale": "Thiopental sodium is specifically listed as a very short-acting barbiturate used in anesthesia.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33532,7 +33532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["db873f8d", "5e087be5"],
-		"explanation": "Significant weight gain and movement disorders, particularly tardive dyskinesia with long-term use, are notable side effects associated with antipsychotic medications.",
+		"rationale": "Significant weight gain and movement disorders, particularly tardive dyskinesia with long-term use, are notable side effects associated with antipsychotic medications.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33566,7 +33566,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fd20a3a8"],
-		"explanation": "Atypical (second-generation) antipsychotics have a greater propensity for causing metabolic side effects, including impaired glucose metabolism and induction or exacerbation of diabetes, compared to typical antipsychotics.",
+		"rationale": "Atypical (second-generation) antipsychotics have a greater propensity for causing metabolic side effects, including impaired glucose metabolism and induction or exacerbation of diabetes, compared to typical antipsychotics.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33596,7 +33596,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6a6e55f8", "b6b710d9", "07a60ce6"],
-		"explanation": "Chlorpromazine use is associated with numerous ocular side effects, including pigment deposition leading to corneal verticillata, anterior subcapsular cataracts, and phototoxicity due to its accumulation in pigmented uveal tissue.",
+		"rationale": "Chlorpromazine use is associated with numerous ocular side effects, including pigment deposition leading to corneal verticillata, anterior subcapsular cataracts, and phototoxicity due to its accumulation in pigmented uveal tissue.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33630,7 +33630,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a285fcf9"],
-		"explanation": "Phenobarbital, a long-acting barbiturate used for epilepsy, carries a notable risk of causing Stevens-Johnson syndrome (SJS) and is known for having an extensive list of potential drug interactions.",
+		"rationale": "Phenobarbital, a long-acting barbiturate used for epilepsy, carries a notable risk of causing Stevens-Johnson syndrome (SJS) and is known for having an extensive list of potential drug interactions.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33660,7 +33660,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["beb09239"],
-		"explanation": "Both typical and atypical antipsychotics block D2 dopamine receptors, but atypical antipsychotics also frequently act on serotonin receptors, distinguishing their mechanism from typical agents.",
+		"rationale": "Both typical and atypical antipsychotics block D2 dopamine receptors, but atypical antipsychotics also frequently act on serotonin receptors, distinguishing their mechanism from typical agents.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33690,7 +33690,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fdfb8b8d", "274b06c7"],
-		"explanation": "The text specifically mentions that Thioridazine, a typical antipsychotic used when others fail, is associated with cataracts and retinal pigmented epithelial (RPE) toxicity.",
+		"rationale": "The text specifically mentions that Thioridazine, a typical antipsychotic used when others fail, is associated with cataracts and retinal pigmented epithelial (RPE) toxicity.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33724,7 +33724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f54dea4d"],
-		"explanation": "Haloperidol, a typical antipsychotic, is noted for causing fewer sedative and antimuscarinic effects than chlorpromazine but is associated with a higher incidence of neuromuscular side effects like muscle spasms and restlessness (akathisia).",
+		"rationale": "Haloperidol, a typical antipsychotic, is noted for causing fewer sedative and antimuscarinic effects than chlorpromazine but is associated with a higher incidence of neuromuscular side effects like muscle spasms and restlessness (akathisia).",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33754,7 +33754,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["68c73b7f"],
-		"explanation": "Aripiprazole is noted for causing less weight gain compared to some other atypical antipsychotics, but commonly causes Parkinsonism and sialorrhea.",
+		"rationale": "Aripiprazole is noted for causing less weight gain compared to some other atypical antipsychotics, but commonly causes Parkinsonism and sialorrhea.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33784,7 +33784,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["882f05b7", "07a8fd8e"],
-		"explanation": "Risperidone and olanzapine are specifically contraindicated for treating behavioral problems in older dementia patients due to an increased risk of stroke.",
+		"rationale": "Risperidone and olanzapine are specifically contraindicated for treating behavioral problems in older dementia patients due to an increased risk of stroke.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33814,7 +33814,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6df958e3"],
-		"explanation": "Lithium is primarily classified as a mood stabilizer used for bipolar disorder and treatment-resistant major depressive disorder.",
+		"rationale": "Lithium is primarily classified as a mood stabilizer used for bipolar disorder and treatment-resistant major depressive disorder.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33844,7 +33844,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8a89c2c7"],
-		"explanation": "Olanzapine is noted for often causing very marked weight gain and metabolic syndrome, while aripiprazole causes less weight gain.",
+		"rationale": "Olanzapine is noted for often causing very marked weight gain and metabolic syndrome, while aripiprazole causes less weight gain.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33874,7 +33874,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0e6cfe6d", "4bf2e2ce", "92ca9576"],
-		"explanation": "Clozapine is associated with pigment deposits on the corneal endothelium and anterior lens capsule, severe dry eye due to anticholinergic effects (blocking muscarinic receptors), and potentially diabetic retinopathy. Eyelid myokymia is also associated with clozapine.",
+		"rationale": "Clozapine is associated with pigment deposits on the corneal endothelium and anterior lens capsule, severe dry eye due to anticholinergic effects (blocking muscarinic receptors), and potentially diabetic retinopathy. Eyelid myokymia is also associated with clozapine.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33904,7 +33904,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d5cb03be"],
-		"explanation": "Lithium use is correlated with downbeat nystagmus, which can be reversible upon discontinuation. It also causes dry eye due to altered tear osmolarity.",
+		"rationale": "Lithium use is correlated with downbeat nystagmus, which can be reversible upon discontinuation. It also causes dry eye due to altered tear osmolarity.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33934,7 +33934,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["32b99878"],
-		"explanation": "SSRIs are generally considered first-line treatment for depression because they are better tolerated and safer in overdose compared to TCAs and MAOIs.",
+		"rationale": "SSRIs are generally considered first-line treatment for depression because they are better tolerated and safer in overdose compared to TCAs and MAOIs.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33964,7 +33964,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e789b1c7", "8511d6bd", "18f48bae"],
-		"explanation": "All major classes of antidepressants (TCAs, SSRIs, SNRIs, MAOIs) can cause mydriasis (pupil dilation) and cycloplegia (impaired accommodation), potentially increasing intraocular pressure, especially in those with narrow angles. Dry eye is also a common side effect across classes.",
+		"rationale": "All major classes of antidepressants (TCAs, SSRIs, SNRIs, MAOIs) can cause mydriasis (pupil dilation) and cycloplegia (impaired accommodation), potentially increasing intraocular pressure, especially in those with narrow angles. Dry eye is also a common side effect across classes.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -33994,7 +33994,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["16e84225"],
-		"explanation": "While most antidepressants can increase IOP via mydriasis and subsequent angle narrowing, SSRIs and SNRIs have an additional mechanism involving serotonin receptors (5-HT7, 5-HT2A, 5-HT2C) in the iris-ciliary body complex, leading to increased aqueous humor production.",
+		"rationale": "While most antidepressants can increase IOP via mydriasis and subsequent angle narrowing, SSRIs and SNRIs have an additional mechanism involving serotonin receptors (5-HT7, 5-HT2A, 5-HT2C) in the iris-ciliary body complex, leading to increased aqueous humor production.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34024,7 +34024,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["46601dbc", "05212d68", "6909bf89"],
-		"explanation": "Due to lithium's effects on kidney function and sodium handling, NSAIDs and most hypertension drugs must be used cautiously. Tetracycline antibiotics and metronidazole can significantly increase lithium levels, raising toxicity risk.",
+		"rationale": "Due to lithium's effects on kidney function and sodium handling, NSAIDs and most hypertension drugs must be used cautiously. Tetracycline antibiotics and metronidazole can significantly increase lithium levels, raising toxicity risk.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34054,7 +34054,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fccdf4dd"],
-		"explanation": "Oculogyric crisis, characterized by spasmodic upward deviation of the eyes, is an ocular side effect associated with SSRI use.",
+		"rationale": "Oculogyric crisis, characterized by spasmodic upward deviation of the eyes, is an ocular side effect associated with SSRI use.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34084,7 +34084,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7e1f7353"],
-		"explanation": "SNRIs inhibit the reuptake of both serotonin and norepinephrine, whereas SSRIs primarily inhibit serotonin reuptake.",
+		"rationale": "SNRIs inhibit the reuptake of both serotonin and norepinephrine, whereas SSRIs primarily inhibit serotonin reuptake.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34114,7 +34114,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ef4166bb"],
-		"explanation": "Duloxetine, an SNRI, is specifically contraindicated in patients with uncontrolled narrow angle or angle-closure glaucoma.",
+		"rationale": "Duloxetine, an SNRI, is specifically contraindicated in patients with uncontrolled narrow angle or angle-closure glaucoma.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34144,7 +34144,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["92825584", "02e4cfd0", "512886fe"],
-		"explanation": "Dry mouth, constipation, and orthostatic hypotension are common side effects of Tricyclic Antidepressants (TCAs). Diarrhea is more commonly associated with SSRIs.",
+		"rationale": "Dry mouth, constipation, and orthostatic hypotension are common side effects of Tricyclic Antidepressants (TCAs). Diarrhea is more commonly associated with SSRIs.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34174,7 +34174,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a884d868"],
-		"explanation": "Amitriptyline, while not recommended for depression due to toxicity in overdose, is used off-label for neuropathic pain and migraine prophylaxis.",
+		"rationale": "Amitriptyline, while not recommended for depression due to toxicity in overdose, is used off-label for neuropathic pain and migraine prophylaxis.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34204,7 +34204,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7ac7da0b"],
-		"explanation": "Both SSRIs and SNRIs carry an increased risk of suicidal thinking and behavior, particularly in children and young adults under 25, especially when initiating therapy.",
+		"rationale": "Both SSRIs and SNRIs carry an increased risk of suicidal thinking and behavior, particularly in children and young adults under 25, especially when initiating therapy.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34234,7 +34234,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f86a4c66", "a4fb0eed", "662bd18a"],
-		"explanation": "Paroxetine (Paxil), Citalopram (Celexa), and Fluoxetine (Prozac) are all examples of Selective Serotonin Re-uptake Inhibitors (SSRIs). Venlafaxine is an SNRI.",
+		"rationale": "Paroxetine (Paxil), Citalopram (Celexa), and Fluoxetine (Prozac) are all examples of Selective Serotonin Re-uptake Inhibitors (SSRIs). Venlafaxine is an SNRI.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34264,7 +34264,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b7e06a9c"],
-		"explanation": "TCAs with more sedative properties, such as amitriptyline, doxepin, and trimipramine, are often preferred for agitated and anxious patients.",
+		"rationale": "TCAs with more sedative properties, such as amitriptyline, doxepin, and trimipramine, are often preferred for agitated and anxious patients.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34294,7 +34294,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dfed764d", "1b9b98e1", "7e4b5b0d"],
-		"explanation": "Due to their anticholinergic (muscarinic receptor blocking) effects, TCAs commonly cause dry eye, pupil dilation (mydriasis), and decreased accommodation (cycloplegia).",
+		"rationale": "Due to their anticholinergic (muscarinic receptor blocking) effects, TCAs commonly cause dry eye, pupil dilation (mydriasis), and decreased accommodation (cycloplegia).",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34324,7 +34324,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cdf2bacf", "f42564be", "615b56e5"],
-		"explanation": "Serotonin syndrome is a potentially serious side effect characterized by a triad of mental status changes, neuromuscular hyperactivity, and autonomic hyperactivity. Hypotension is not typically part of this syndrome; autonomic hyperactivity often manifests as hypertension and tachycardia.",
+		"rationale": "Serotonin syndrome is a potentially serious side effect characterized by a triad of mental status changes, neuromuscular hyperactivity, and autonomic hyperactivity. Hypotension is not typically part of this syndrome; autonomic hyperactivity often manifests as hypertension and tachycardia.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34354,7 +34354,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["97cb8f35"],
-		"explanation": "Monoamine oxidase inhibitors (MAOIs) work by blocking the enzyme monoamine oxidase, which is responsible for breaking down neurotransmitters like norepinephrine, serotonin, and dopamine.",
+		"rationale": "Monoamine oxidase inhibitors (MAOIs) work by blocking the enzyme monoamine oxidase, which is responsible for breaking down neurotransmitters like norepinephrine, serotonin, and dopamine.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34384,7 +34384,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4b87f5de"],
-		"explanation": "Consuming foods rich in tyramine (like aged cheese, cured meats, red wine) while taking MAOIs can lead to a hypertensive crisis due to the accumulation of norepinephrine.",
+		"rationale": "Consuming foods rich in tyramine (like aged cheese, cured meats, red wine) while taking MAOIs can lead to a hypertensive crisis due to the accumulation of norepinephrine.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34414,7 +34414,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["79220e99", "6c283ba2", "818fbbc1"],
-		"explanation": "The literature regarding topical phenylephrine use in patients on MAOIs is conflicting; some studies show significant cardiovascular response increases, while others show no effect. Phenylephrine is a direct-acting sympathomimetic, theoretically bypassing the tyramine-dependent mechanism affecting indirect agents. Reduced systemic absorption occurs with topical administration.",
+		"rationale": "The literature regarding topical phenylephrine use in patients on MAOIs is conflicting; some studies show significant cardiovascular response increases, while others show no effect. Phenylephrine is a direct-acting sympathomimetic, theoretically bypassing the tyramine-dependent mechanism affecting indirect agents. Reduced systemic absorption occurs with topical administration.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34444,7 +34444,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a11cace9"],
-		"explanation": "Bupropion (Wellbutrin) inhibits norepinephrine and dopamine reuptake and is indicated for depression, seasonal affective disorder, and as an aid for smoking cessation.",
+		"rationale": "Bupropion (Wellbutrin) inhibits norepinephrine and dopamine reuptake and is indicated for depression, seasonal affective disorder, and as an aid for smoking cessation.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34474,7 +34474,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["cb05f930"],
-		"explanation": "Trazodone is noted as being used for depressive illness, particularly when sedation is required, due to its serotonin receptor antagonism.",
+		"rationale": "Trazodone is noted as being used for depressive illness, particularly when sedation is required, due to its serotonin receptor antagonism.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34504,7 +34504,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e4ad57a6"],
-		"explanation": "Levodopa is extensively metabolized to dopamine in the periphery before reaching the brain. Peripheral DOPA decarboxylase inhibitors (DDCIs) like carbidopa prevent this peripheral conversion, allowing more levodopa to cross the blood-brain barrier and reducing peripheral side effects.",
+		"rationale": "Levodopa is extensively metabolized to dopamine in the periphery before reaching the brain. Peripheral DOPA decarboxylase inhibitors (DDCIs) like carbidopa prevent this peripheral conversion, allowing more levodopa to cross the blood-brain barrier and reducing peripheral side effects.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34534,7 +34534,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["19a1db26", "54ba7467", "0328bc71"],
-		"explanation": "Pramipexole, ropinirole, and rotigotine are listed as examples of dopamine-receptor agonists used in Parkinson's disease treatment. Benztropine is an anticholinergic agent.",
+		"rationale": "Pramipexole, ropinirole, and rotigotine are listed as examples of dopamine-receptor agonists used in Parkinson's disease treatment. Benztropine is an anticholinergic agent.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34564,7 +34564,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bb63b439"],
-		"explanation": "Tolcapone inhibits catechol-O-methyl transferase (COMT), an enzyme that metabolizes levodopa. By inhibiting COMT, tolcapone reduces the breakdown of levodopa, particularly peripherally, increasing its bioavailability and central effect.",
+		"rationale": "Tolcapone inhibits catechol-O-methyl transferase (COMT), an enzyme that metabolizes levodopa. By inhibiting COMT, tolcapone reduces the breakdown of levodopa, particularly peripherally, increasing its bioavailability and central effect.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34594,7 +34594,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3952d877", "f8b7c982", "417bdcdb"],
-		"explanation": "The text explicitly mentions mydriasis or miosis, blepharospasm, eyelid ptosis, prolonged latency of saccades, and visual hallucinations as potential ocular side effects of levodopa therapy. Dry eye is a common anticholinergic side effect but not specifically listed for levodopa here.",
+		"rationale": "The text explicitly mentions mydriasis or miosis, blepharospasm, eyelid ptosis, prolonged latency of saccades, and visual hallucinations as potential ocular side effects of levodopa therapy. Dry eye is a common anticholinergic side effect but not specifically listed for levodopa here.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34624,7 +34624,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fb3a0658"],
-		"explanation": "Rasagiline and selegiline are selective, irreversible inhibitors of MAO-B, primarily used for Parkinson's disease. Phenelzine and tranylcypromine are non-selective, irreversible MAOIs used mainly for depression.",
+		"rationale": "Rasagiline and selegiline are selective, irreversible inhibitors of MAO-B, primarily used for Parkinson's disease. Phenelzine and tranylcypromine are non-selective, irreversible MAOIs used mainly for depression.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34654,7 +34654,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ece3dd53", "c999be4a"],
-		"explanation": "The text states that the most useful mechanisms exploited therapeutically by anticonvulsants are those that enhance GABA action and inhibit sodium channel activity. Inhibition of calcium channels and glutamate receptors are also mentioned as mechanisms.",
+		"rationale": "The text states that the most useful mechanisms exploited therapeutically by anticonvulsants are those that enhance GABA action and inhibit sodium channel activity. Inhibition of calcium channels and glutamate receptors are also mentioned as mechanisms.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34684,7 +34684,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["375ec3fc"],
-		"explanation": "Carbamazepine is specifically noted as being commonly used to treat pain associated with trigeminal neuralgia, in addition to its use for partial epileptic seizures. While it has anticonvulsant properties, its specific analgesic indication mentioned is trigeminal neuralgia.",
+		"rationale": "Carbamazepine is specifically noted as being commonly used to treat pain associated with trigeminal neuralgia, in addition to its use for partial epileptic seizures. While it has anticonvulsant properties, its specific analgesic indication mentioned is trigeminal neuralgia.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34714,7 +34714,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d4f4c799", "e12476d7", "4213eca2"],
-		"explanation": "The text explicitly lists diplopia, oscillopsia, gaze-evoked nystagmus, gaze palsies, downbeat nystagmus, periodic alternating nystagmus, subclinical central/paracentral color vision decrease, oculogyric crisis, and reduced contrast sensitivity as ocular side effects associated with carbamazepine.",
+		"rationale": "The text explicitly lists diplopia, oscillopsia, gaze-evoked nystagmus, gaze palsies, downbeat nystagmus, periodic alternating nystagmus, subclinical central/paracentral color vision decrease, oculogyric crisis, and reduced contrast sensitivity as ocular side effects associated with carbamazepine.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34744,7 +34744,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8bd8e239"],
-		"explanation": "The text states that barbiturates act as positive allosteric modulators of GABA_A receptors and block excitatory AMPA and kainate glutamate receptors. They do not primarily block sodium channels (like dibenzoazepines or hydantoins) or calcium channels (like zonisamide).",
+		"rationale": "The text states that barbiturates act as positive allosteric modulators of GABA_A receptors and block excitatory AMPA and kainate glutamate receptors. They do not primarily block sodium channels (like dibenzoazepines or hydantoins) or calcium channels (like zonisamide).",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34774,7 +34774,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0bc8d46b", "7a4f1446", "1654137c"],
-		"explanation": "The text explicitly associates Carbamazepine, Phenobarbital, and Phenytoin with Stevens-Johnson syndrome. Topiramate is primarily associated with uveal effusion and angle closure.",
+		"rationale": "The text explicitly associates Carbamazepine, Phenobarbital, and Phenytoin with Stevens-Johnson syndrome. Topiramate is primarily associated with uveal effusion and angle closure.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34804,7 +34804,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2265b86d"],
-		"explanation": "Topiramate is noted to cause uveal effusion with secondary angle closure. This occurs because swelling of the ciliary body pushes the lens and iris anteriorly, shallowing the angle and raising IOP, often associated with a significant bilateral myopic shift, typically within the first month.",
+		"rationale": "Topiramate is noted to cause uveal effusion with secondary angle closure. This occurs because swelling of the ciliary body pushes the lens and iris anteriorly, shallowing the angle and raising IOP, often associated with a significant bilateral myopic shift, typically within the first month.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34834,7 +34834,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["15f6a826"],
-		"explanation": "The text describes the mechanism of topiramate-induced angle closure as resulting from uveal effusion causing the ciliary body to swell, which in turn pushes the lens and iris anteriorly, narrowing the anterior chamber angle.",
+		"rationale": "The text describes the mechanism of topiramate-induced angle closure as resulting from uveal effusion causing the ciliary body to swell, which in turn pushes the lens and iris anteriorly, narrowing the anterior chamber angle.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34864,7 +34864,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9672dc57"],
-		"explanation": "Hydantoin anticonvulsants, such as phenytoin, act by slowing synaptic transmission. They achieve this by blocking sodium channels from recovering from the inactivated state, thereby inhibiting repetitive neuronal firing.",
+		"rationale": "Hydantoin anticonvulsants, such as phenytoin, act by slowing synaptic transmission. They achieve this by blocking sodium channels from recovering from the inactivated state, thereby inhibiting repetitive neuronal firing.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34894,7 +34894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["250f8ed5", "b44cb7d3", "12528a00"],
-		"explanation": "The text lists nystagmus as a potential ocular side effect for carbamazepine, primidone, and phenytoin. Topiramate's main ocular concerns mentioned are angle closure and myokymia.",
+		"rationale": "The text lists nystagmus as a potential ocular side effect for carbamazepine, primidone, and phenytoin. Topiramate's main ocular concerns mentioned are angle closure and myokymia.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34924,7 +34924,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a63839ec"],
-		"explanation": "The text indicates that eslicarbazepine acetate inhibits voltage-gated sodium channels, especially in rapidly firing neurons, and has a much lower affinity for these channels in the resting state compared with carbamazepine and oxcarbazepine.",
+		"rationale": "The text indicates that eslicarbazepine acetate inhibits voltage-gated sodium channels, especially in rapidly firing neurons, and has a much lower affinity for these channels in the resting state compared with carbamazepine and oxcarbazepine.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34954,7 +34954,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1d073c3b"],
-		"explanation": "Vigabatrin inhibits GABA transaminase, which increases GABA levels, but is associated with potentially irreversible peripheral visual field loss, retinal atrophy, and optic nerve atrophy.",
+		"rationale": "Vigabatrin inhibits GABA transaminase, which increases GABA levels, but is associated with potentially irreversible peripheral visual field loss, retinal atrophy, and optic nerve atrophy.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -34984,7 +34984,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ccfad10d"],
-		"explanation": "Pregabalin, although structurally similar to GABA, does not bind to GABA receptors. Its primary mechanism involves binding to the alpha2-delta subunit of presynaptic voltage-gated calcium channels.",
+		"rationale": "Pregabalin, although structurally similar to GABA, does not bind to GABA receptors. Its primary mechanism involves binding to the alpha2-delta subunit of presynaptic voltage-gated calcium channels.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35014,7 +35014,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a6a2e6ec"],
-		"explanation": "Succinimide anticonvulsants, such as ethosuximide and methsuximide, are primarily used for absence seizures and are thought to inhibit T-type calcium channels.",
+		"rationale": "Succinimide anticonvulsants, such as ethosuximide and methsuximide, are primarily used for absence seizures and are thought to inhibit T-type calcium channels.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35044,7 +35044,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2b5f247c", "55d0dbf8"],
-		"explanation": "Both Gabapentin and Valproic acid list diplopia and tremor as common side effects according to the provided text.",
+		"rationale": "Both Gabapentin and Valproic acid list diplopia and tremor as common side effects according to the provided text.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35074,7 +35074,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7373dbe0"],
-		"explanation": "Vigabatrin functions by irreversibly inhibiting the enzyme gamma-aminobutyric acid transaminase (GABA-T), which prevents the breakdown of GABA and increases its concentration.",
+		"rationale": "Vigabatrin functions by irreversibly inhibiting the enzyme gamma-aminobutyric acid transaminase (GABA-T), which prevents the breakdown of GABA and increases its concentration.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35104,7 +35104,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aeaa4a81"],
-		"explanation": "Valproic acid and its derivatives are described as broad-spectrum anticonvulsants effective against most seizure types including absence, tonic-clonic, juvenile myoclonic, and complex partial seizures.",
+		"rationale": "Valproic acid and its derivatives are described as broad-spectrum anticonvulsants effective against most seizure types including absence, tonic-clonic, juvenile myoclonic, and complex partial seizures.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35134,7 +35134,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d910f62f"],
-		"explanation": "Lamotrigine, a triazine anticonvulsant, has a known association with Stevens-Johnson syndrome, a serious systemic hypersensitivity reaction.",
+		"rationale": "Lamotrigine, a triazine anticonvulsant, has a known association with Stevens-Johnson syndrome, a serious systemic hypersensitivity reaction.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35164,7 +35164,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b8bab181", "5363d254", "d62bf6dd"],
-		"explanation": "Gabapentin, Vigabatrin, and Felbamate are all explicitly mentioned as potentially causing both diplopia and nystagmus.",
+		"rationale": "Gabapentin, Vigabatrin, and Felbamate are all explicitly mentioned as potentially causing both diplopia and nystagmus.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35194,7 +35194,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7ff02fcc"],
-		"explanation": "Perampanel is noted as the first FDA-approved non-competitive AMPA (glutamate) receptor antagonist used as adjunctive therapy for focal seizures.",
+		"rationale": "Perampanel is noted as the first FDA-approved non-competitive AMPA (glutamate) receptor antagonist used as adjunctive therapy for focal seizures.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35224,7 +35224,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["67c3931b", "2d81ed69"],
-		"explanation": "Felbamate's use is significantly limited due to its propensity to cause severe side effects, specifically aplastic anemia and hepatitis/liver failure.",
+		"rationale": "Felbamate's use is significantly limited due to its propensity to cause severe side effects, specifically aplastic anemia and hepatitis/liver failure.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35254,7 +35254,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["89afc544"],
-		"explanation": "Magnesium sulfate is specifically indicated for the prevention of seizures in pre-eclampsia and the treatment and prevention of recurrent seizures in eclampsia, demonstrating superior efficacy compared to older agents like diazepam or phenytoin in this context.",
+		"rationale": "Magnesium sulfate is specifically indicated for the prevention of seizures in pre-eclampsia and the treatment and prevention of recurrent seizures in eclampsia, demonstrating superior efficacy compared to older agents like diazepam or phenytoin in this context.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35284,7 +35284,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7afbac93"],
-		"explanation": "While cannabidiol (CBD) possesses several therapeutic properties, studies have indicated it may cause an increase in intraocular pressure (IOP), contrasting with THC which tends to lower IOP.",
+		"rationale": "While cannabidiol (CBD) possesses several therapeutic properties, studies have indicated it may cause an increase in intraocular pressure (IOP), contrasting with THC which tends to lower IOP.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35314,7 +35314,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["756aef86", "88684d9f"],
-		"explanation": "Lacosamide is approved as adjunctive therapy for focal-onset seizures. Rufinamide is specifically indicated as adjunctive treatment for seizures associated with Lennox-Gastaut syndrome.",
+		"rationale": "Lacosamide is approved as adjunctive therapy for focal-onset seizures. Rufinamide is specifically indicated as adjunctive treatment for seizures associated with Lennox-Gastaut syndrome.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35344,7 +35344,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8a59e21d"],
-		"explanation": "Triptans exert their primary antimigraine effect by acting as agonists at serotonin 5-HT1B and 5-HT1D receptors, leading to vasoconstriction of dilated cranial blood vessels and inhibition of neurotransmitter release in the trigeminal system.",
+		"rationale": "Triptans exert their primary antimigraine effect by acting as agonists at serotonin 5-HT1B and 5-HT1D receptors, leading to vasoconstriction of dilated cranial blood vessels and inhibition of neurotransmitter release in the trigeminal system.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35374,7 +35374,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b037358e", "3d5e498d", "a603a452"],
-		"explanation": "Triptans can cause various ocular side effects. Mydriasis and changes in accommodation are relatively common. Due to their vasoconstrictive properties, rarer but serious ischemic events like ischemic optic neuropathy and retinal vascular occlusions can occur.",
+		"rationale": "Triptans can cause various ocular side effects. Mydriasis and changes in accommodation are relatively common. Due to their vasoconstrictive properties, rarer but serious ischemic events like ischemic optic neuropathy and retinal vascular occlusions can occur.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35404,7 +35404,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3e27b48a"],
-		"explanation": "Triptans cause vasoconstriction and are associated with increased blood pressure. They are contraindicated in patients with uncontrolled hypertension, ischemic heart disease, cerebrovascular disease, or peripheral vascular conditions due to the risk of exacerbating these conditions.",
+		"rationale": "Triptans cause vasoconstriction and are associated with increased blood pressure. They are contraindicated in patients with uncontrolled hypertension, ischemic heart disease, cerebrovascular disease, or peripheral vascular conditions due to the risk of exacerbating these conditions.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35434,7 +35434,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c71e9354"],
-		"explanation": "While both triptans and ergotamines are 5-HT1B/1D agonists, triptans are more selective and lack significant activity at adrenergic and 5-HT2A receptors, resulting in less pronounced peripheral vasoconstriction compared to ergotamines.",
+		"rationale": "While both triptans and ergotamines are 5-HT1B/1D agonists, triptans are more selective and lack significant activity at adrenergic and 5-HT2A receptors, resulting in less pronounced peripheral vasoconstriction compared to ergotamines.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35464,7 +35464,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8b6a694a"],
-		"explanation": "The binding of acetylcholine to nicotinic cholinergic receptors on the muscle fiber membrane opens ligand-gated ion channels, primarily allowing an influx of sodium ions (Na+) which causes depolarization of the motor end plate.",
+		"rationale": "The binding of acetylcholine to nicotinic cholinergic receptors on the muscle fiber membrane opens ligand-gated ion channels, primarily allowing an influx of sodium ions (Na+) which causes depolarization of the motor end plate.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35494,7 +35494,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9c7ace1b", "438c9496"],
-		"explanation": "Abrupt discontinuation of both baclofen (oral or intrathecal) and tizanidine can lead to significant withdrawal syndromes. Symptoms can include rebound spasticity, anxiety, tremors, tachycardia, and hypertension.",
+		"rationale": "Abrupt discontinuation of both baclofen (oral or intrathecal) and tizanidine can lead to significant withdrawal syndromes. Symptoms can include rebound spasticity, anxiety, tremors, tachycardia, and hypertension.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35524,7 +35524,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3504a91a"],
-		"explanation": "Baclofen, a GABAB receptor agonist, exerts its muscle relaxant effects centrally. It has also been used off-label for various conditions, including the suppression of periodic alternating nystagmus.",
+		"rationale": "Baclofen, a GABAB receptor agonist, exerts its muscle relaxant effects centrally. It has also been used off-label for various conditions, including the suppression of periodic alternating nystagmus.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35554,7 +35554,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4d8a4dea"],
-		"explanation": "Botulinum toxin works by preventing the release of acetylcholine from presynaptic nerve terminals at the neuromuscular junction, thereby inhibiting muscle contraction and causing localized paralysis, which is effective for conditions like blepharospasm.",
+		"rationale": "Botulinum toxin works by preventing the release of acetylcholine from presynaptic nerve terminals at the neuromuscular junction, thereby inhibiting muscle contraction and causing localized paralysis, which is effective for conditions like blepharospasm.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35584,7 +35584,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8ce5fcbf"],
-		"explanation": "Clinical studies and the provided material indicate that Botulinum Toxin type A (BTX-A) generally offers a longer duration of therapeutic effect compared to Botulinum Toxin type B (BTX-B) for indications like cervical dystonia.",
+		"rationale": "Clinical studies and the provided material indicate that Botulinum Toxin type A (BTX-A) generally offers a longer duration of therapeutic effect compared to Botulinum Toxin type B (BTX-B) for indications like cervical dystonia.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35614,7 +35614,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["48586a63"],
-		"explanation": "Dantrolene carries a black box warning regarding the risk of potentially fatal hepatotoxicity, particularly with high doses (>800 mg/day) and prolonged use (3-12 months), limiting its utility for chronic spasticity management.",
+		"rationale": "Dantrolene carries a black box warning regarding the risk of potentially fatal hepatotoxicity, particularly with high doses (>800 mg/day) and prolonged use (3-12 months), limiting its utility for chronic spasticity management.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35644,7 +35644,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4497279f", "ed92504d"],
-		"explanation": "Orphenadrine and Cyclobenzaprine possess significant anticholinergic properties. These actions commonly lead to side effects such as dry mouth, blurred vision (due to impaired accommodation, particularly affecting near vision), and constipation or urinary retention.",
+		"rationale": "Orphenadrine and Cyclobenzaprine possess significant anticholinergic properties. These actions commonly lead to side effects such as dry mouth, blurred vision (due to impaired accommodation, particularly affecting near vision), and constipation or urinary retention.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35674,7 +35674,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["67a57573"],
-		"explanation": "Methocarbamol is specifically associated with the potential ocular side effects of diplopia (double vision) and nystagmus (involuntary eye movements).",
+		"rationale": "Methocarbamol is specifically associated with the potential ocular side effects of diplopia (double vision) and nystagmus (involuntary eye movements).",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35704,7 +35704,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["108527ec"],
-		"explanation": "Cyclobenzaprine is structurally related to tricyclic antidepressants and can cause similar cardiovascular side effects, including tachycardia and cardiac conduction disturbances. This poses a significant risk for patients with pre-existing heart rhythm problems.",
+		"rationale": "Cyclobenzaprine is structurally related to tricyclic antidepressants and can cause similar cardiovascular side effects, including tachycardia and cardiac conduction disturbances. This poses a significant risk for patients with pre-existing heart rhythm problems.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35734,7 +35734,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a3734ec"],
-		"explanation": "Carisoprodol is metabolized to meprobamate, a substance with known potential for abuse and dependence. This risk leads to carisoprodol being classified as a DEA Schedule IV controlled substance and raises concerns about psychological dependence and withdrawal symptoms with prolonged use.",
+		"rationale": "Carisoprodol is metabolized to meprobamate, a substance with known potential for abuse and dependence. This risk leads to carisoprodol being classified as a DEA Schedule IV controlled substance and raises concerns about psychological dependence and withdrawal symptoms with prolonged use.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35764,7 +35764,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3091186a", "1d6be1a2"],
-		"explanation": "Methocarbamol can cause brown or green urine discoloration. Chlorzoxazone can cause orange, red, or purple urine discoloration. These are unique side effects associated with these specific agents.",
+		"rationale": "Methocarbamol can cause brown or green urine discoloration. Chlorzoxazone can cause orange, red, or purple urine discoloration. These are unique side effects associated with these specific agents.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35794,7 +35794,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aba2e331"],
-		"explanation": "Dantrolene acts peripherally by blocking ryanodine receptors on the sarcoplasmic reticulum, which inhibits the release of calcium ions necessary for muscle contraction. Other listed agents act centrally or at the neuromuscular junction.",
+		"rationale": "Dantrolene acts peripherally by blocking ryanodine receptors on the sarcoplasmic reticulum, which inhibits the release of calcium ions necessary for muscle contraction. Other listed agents act centrally or at the neuromuscular junction.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35824,7 +35824,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["55428252", "575281d4"],
-		"explanation": "Diplopia (double vision) is listed as a side effect for both Methocarbamol and Carisoprodol. Pupil dilation (mydriasis), often accompanied by decreased accommodation causing blurred near vision, is an anticholinergic effect associated with Cyclobenzaprine, Carisoprodol, and Orphenadrine.",
+		"rationale": "Diplopia (double vision) is listed as a side effect for both Methocarbamol and Carisoprodol. Pupil dilation (mydriasis), often accompanied by decreased accommodation causing blurred near vision, is an anticholinergic effect associated with Cyclobenzaprine, Carisoprodol, and Orphenadrine.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35854,7 +35854,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6fd42e92"],
-		"explanation": "The most likely cause of this patient’s symptoms is Thorazine (chlorpromazine), a first-generation antipsychotic known for its distinctive ocular side effects. Chlorpromazine can cause a star-shaped anterior subcapsular cataract, which is a classic finding described in the question. Additionally, it can lead to dry eye, abnormal blinking or tics, decreased accommodation (low NPA), and pigmentary retinopathy that may mimic diabetic retinopathy even in patients without diabetes. The combination of these specific ocular findings, especially the unique cataract type and retinopathy, points to chlorpromazine as the underlying cause, making Thorazine the correct answer.",
+		"rationale": "The most likely cause of this patient’s symptoms is Thorazine (chlorpromazine), a first-generation antipsychotic known for its distinctive ocular side effects. Chlorpromazine can cause a star-shaped anterior subcapsular cataract, which is a classic finding described in the question. Additionally, it can lead to dry eye, abnormal blinking or tics, decreased accommodation (low NPA), and pigmentary retinopathy that may mimic diabetic retinopathy even in patients without diabetes. The combination of these specific ocular findings, especially the unique cataract type and retinopathy, points to chlorpromazine as the underlying cause, making Thorazine the correct answer.",
 		"metadata": {},
 		"moduleId": "js79syadscz679z78t56eynkxh7m98wr",
 		"options": [
@@ -35884,7 +35884,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0dcdeab8"],
-		"explanation": "Beta-2 receptor activation stimulates the G protein, which in turn activates the enzyme adenylyl cyclase. Adenylyl cyclase increases the production of intracellular cyclic AMP (cAMP), leading to smooth muscle relaxation and bronchodilation.",
+		"rationale": "Beta-2 receptor activation stimulates the G protein, which in turn activates the enzyme adenylyl cyclase. Adenylyl cyclase increases the production of intracellular cyclic AMP (cAMP), leading to smooth muscle relaxation and bronchodilation.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -35914,7 +35914,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3830c60f"],
-		"explanation": "Selective beta-2 agonists primarily target beta-2 receptors on bronchial smooth muscle, minimizing the activation of beta-1 receptors located on cardiac muscle. This selectivity reduces the risk of cardiac side effects like tachycardia compared to non-selective agents.",
+		"rationale": "Selective beta-2 agonists primarily target beta-2 receptors on bronchial smooth muscle, minimizing the activation of beta-1 receptors located on cardiac muscle. This selectivity reduces the risk of cardiac side effects like tachycardia compared to non-selective agents.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -35944,7 +35944,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d36f3551"],
-		"explanation": "Tachyphylaxis, or diminishing response to a drug with chronic use, can occur with beta-2 agonists. A proposed mechanism is the down-regulation (decrease in number) of beta-2 adrenergic receptors on the cell surface following prolonged stimulation.",
+		"rationale": "Tachyphylaxis, or diminishing response to a drug with chronic use, can occur with beta-2 agonists. A proposed mechanism is the down-regulation (decrease in number) of beta-2 adrenergic receptors on the cell surface following prolonged stimulation.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -35974,7 +35974,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e8bcfb03", "afb6535b", "ffd7ede5"],
-		"explanation": "Beta-2 adrenergic agonists can cause several ocular side effects, including decreased accommodation (difficulty focusing), photophobia (light sensitivity), and mydriasis (pupil dilation). They are also associated with dry eye, not increased tearing. Miosis (pupil constriction) is the opposite effect.",
+		"rationale": "Beta-2 adrenergic agonists can cause several ocular side effects, including decreased accommodation (difficulty focusing), photophobia (light sensitivity), and mydriasis (pupil dilation). They are also associated with dry eye, not increased tearing. Miosis (pupil constriction) is the opposite effect.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36008,7 +36008,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b9a5b10c"],
-		"explanation": "The potential mydriatic (pupil-dilating) effect of beta-2 agonists can be problematic in patients with narrow anterior chamber angles, as dilation can obstruct aqueous outflow and potentially trigger an acute angle closure glaucoma attack. Caution is therefore advised in this group.",
+		"rationale": "The potential mydriatic (pupil-dilating) effect of beta-2 agonists can be problematic in patients with narrow anterior chamber angles, as dilation can obstruct aqueous outflow and potentially trigger an acute angle closure glaucoma attack. Caution is therefore advised in this group.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36038,7 +36038,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["846cfba2"],
-		"explanation": "Short-acting beta-2 agonists (SABAs) like albuterol have a rapid onset of action and are used 'as needed' for the immediate relief of acute asthma symptoms such as wheezing, shortness of breath, and chest tightness. They are often referred to as 'rescue' inhalers.",
+		"rationale": "Short-acting beta-2 agonists (SABAs) like albuterol have a rapid onset of action and are used 'as needed' for the immediate relief of acute asthma symptoms such as wheezing, shortness of breath, and chest tightness. They are often referred to as 'rescue' inhalers.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36068,7 +36068,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["67140ff3"],
-		"explanation": "Long-acting beta-2 agonists (LABAs) like salmeterol provide extended bronchodilation and are used for maintenance therapy, typically in combination with inhaled corticosteroids, for patients with moderate-to-severe persistent asthma whose symptoms are not adequately controlled by corticosteroids alone. LABAs are rarely used as monotherapy.",
+		"rationale": "Long-acting beta-2 agonists (LABAs) like salmeterol provide extended bronchodilation and are used for maintenance therapy, typically in combination with inhaled corticosteroids, for patients with moderate-to-severe persistent asthma whose symptoms are not adequately controlled by corticosteroids alone. LABAs are rarely used as monotherapy.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36098,7 +36098,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b727b7f0", "f16ee639"],
-		"explanation": "Albuterol and its enantiomer levalbuterol are classified as short-acting beta-2 agonists (SABAs), used for rapid symptom relief. Salmeterol and formoterol are long-acting beta-2 agonists (LABAs). Metaproterenol is a less selective beta agonist.",
+		"rationale": "Albuterol and its enantiomer levalbuterol are classified as short-acting beta-2 agonists (SABAs), used for rapid symptom relief. Salmeterol and formoterol are long-acting beta-2 agonists (LABAs). Metaproterenol is a less selective beta agonist.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36132,7 +36132,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["80438ae5", "8137aac9"],
-		"explanation": "Systemic side effects of beta-2 agonists can occur, particularly with higher doses or oral administration. Commonly reported effects include tremor, palpitations (feeling a rapid or irregular heartbeat), and tachycardia (increased heart rate). Bradycardia (slow heart rate) is the opposite effect. Hypoglycemia and constipation are not typically associated effects.",
+		"rationale": "Systemic side effects of beta-2 agonists can occur, particularly with higher doses or oral administration. Commonly reported effects include tremor, palpitations (feeling a rapid or irregular heartbeat), and tachycardia (increased heart rate). Bradycardia (slow heart rate) is the opposite effect. Hypoglycemia and constipation are not typically associated effects.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36166,7 +36166,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9abf97ab"],
-		"explanation": "The beta-2 receptor is coupled to a stimulatory G protein (Gs). Upon receptor activation by an agonist, the G protein activates adenylyl cyclase, the enzyme responsible for converting ATP to cyclic AMP (cAMP). Protein kinase A is activated downstream by cAMP.",
+		"rationale": "The beta-2 receptor is coupled to a stimulatory G protein (Gs). Upon receptor activation by an agonist, the G protein activates adenylyl cyclase, the enzyme responsible for converting ATP to cyclic AMP (cAMP). Protein kinase A is activated downstream by cAMP.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36196,7 +36196,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6225d7e1"],
-		"explanation": "Theophylline and dyphylline belong to the xanthine (or methylxanthine) class of drugs, primarily used as bronchodilators.",
+		"rationale": "Theophylline and dyphylline belong to the xanthine (or methylxanthine) class of drugs, primarily used as bronchodilators.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36226,7 +36226,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["692ead52"],
-		"explanation": "Leukotriene receptor antagonists work by blocking the action of leukotriene D4 (and related leukotrienes) on the CysLT1 receptor in the airways, reducing inflammatory bronchoconstriction.",
+		"rationale": "Leukotriene receptor antagonists work by blocking the action of leukotriene D4 (and related leukotrienes) on the CysLT1 receptor in the airways, reducing inflammatory bronchoconstriction.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36256,7 +36256,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fb9bb714"],
-		"explanation": "Zafirlukast and montelukast are indicated for the prophylaxis (prevention) of asthma but are explicitly stated as not suitable for treating acute asthma attacks.",
+		"rationale": "Zafirlukast and montelukast are indicated for the prophylaxis (prevention) of asthma but are explicitly stated as not suitable for treating acute asthma attacks.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36286,7 +36286,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e5243b8a", "0e6e459d", "51a6f22b"],
-		"explanation": "Montelukast and zafirlukast are leukotriene receptor antagonists, while zileuton inhibits leukotriene synthesis via 5-LOX inhibition. All three act on the leukotriene inflammatory pathway. Theophylline acts via adenosine antagonism and PDE inhibition.",
+		"rationale": "Montelukast and zafirlukast are leukotriene receptor antagonists, while zileuton inhibits leukotriene synthesis via 5-LOX inhibition. All three act on the leukotriene inflammatory pathway. Theophylline acts via adenosine antagonism and PDE inhibition.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36316,7 +36316,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a0decea1"],
-		"explanation": "Zileuton inhibits the 5-LOX (5-lipoxygenase) enzyme, which is crucial for the synthesis of leukotrienes from arachidonic acid.",
+		"rationale": "Zileuton inhibits the 5-LOX (5-lipoxygenase) enzyme, which is crucial for the synthesis of leukotrienes from arachidonic acid.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36346,7 +36346,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["98e269e2", "915ba7e3"],
-		"explanation": "Gastrointestinal disturbances and headache are listed as common side effects for zafirlukast, montelukast, and zileuton. Drowsiness is listed for montelukast, and respiratory infections for zafirlukast, but not all three.",
+		"rationale": "Gastrointestinal disturbances and headache are listed as common side effects for zafirlukast, montelukast, and zileuton. Drowsiness is listed for montelukast, and respiratory infections for zafirlukast, but not all three.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36376,7 +36376,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b69a6f24"],
-		"explanation": "Montelukast is specifically indicated for both asthma prophylaxis and symptomatic relief of seasonal allergic rhinitis in asthmatic patients.",
+		"rationale": "Montelukast is specifically indicated for both asthma prophylaxis and symptomatic relief of seasonal allergic rhinitis in asthmatic patients.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36406,7 +36406,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["15670dd3"],
-		"explanation": "Theophylline has fallen out of favor primarily due to its numerous side effects and extensive drug interactions stemming from non-selective PDE inhibition and CYP450 metabolism.",
+		"rationale": "Theophylline has fallen out of favor primarily due to its numerous side effects and extensive drug interactions stemming from non-selective PDE inhibition and CYP450 metabolism.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36436,7 +36436,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["aa88b518", "740d9857", "61d8370e"],
-		"explanation": "Cimetidine, ciprofloxacin (a fluoroquinolone), and erythromycin (a macrolide) are all listed as drugs that decrease theophylline clearance, potentially leading to toxicity. Zileuton is not listed as having this interaction.",
+		"rationale": "Cimetidine, ciprofloxacin (a fluoroquinolone), and erythromycin (a macrolide) are all listed as drugs that decrease theophylline clearance, potentially leading to toxicity. Zileuton is not listed as having this interaction.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36466,7 +36466,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["79bea4fd"],
-		"explanation": "Concomitant therapy with theophylline and beta2 agonists should be closely monitored due to the potential risk of causing significant hypokalemia (low potassium levels).",
+		"rationale": "Concomitant therapy with theophylline and beta2 agonists should be closely monitored due to the potential risk of causing significant hypokalemia (low potassium levels).",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36496,7 +36496,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8c8100ca"],
-		"explanation": "Both inhaled antimuscarinic bronchodilators and first-generation H1 antihistamines exhibit anticholinergic properties, which commonly include drying effects on mucous membranes, such as causing dry eye.",
+		"rationale": "Both inhaled antimuscarinic bronchodilators and first-generation H1 antihistamines exhibit anticholinergic properties, which commonly include drying effects on mucous membranes, such as causing dry eye.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36526,7 +36526,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f09b14cf"],
-		"explanation": "First-generation H1 antihistamines possess potent antimuscarinic (anticholinergic) properties, which can lead to mydriasis (pupil dilation). Mydriasis can precipitate angle closure in susceptible individuals, making these drugs contraindicated in angle-closure glaucoma.",
+		"rationale": "First-generation H1 antihistamines possess potent antimuscarinic (anticholinergic) properties, which can lead to mydriasis (pupil dilation). Mydriasis can precipitate angle closure in susceptible individuals, making these drugs contraindicated in angle-closure glaucoma.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36556,7 +36556,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b5615797"],
-		"explanation": "Loratadine is a second-generation H1 antihistamine. Second-generation agents have significantly fewer anticholinergic effects compared to first-generation agents (like Diphenhydramine and Chlorpheniramine) and are therefore not contraindicated in angle-closure glaucoma. Tiotropium is an antimuscarinic bronchodilator, not an antihistamine for rhinitis.",
+		"rationale": "Loratadine is a second-generation H1 antihistamine. Second-generation agents have significantly fewer anticholinergic effects compared to first-generation agents (like Diphenhydramine and Chlorpheniramine) and are therefore not contraindicated in angle-closure glaucoma. Tiotropium is an antimuscarinic bronchodilator, not an antihistamine for rhinitis.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36586,7 +36586,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a21bed6b", "27885dab"],
-		"explanation": "Diphenhydramine and Chlorpheniramine are listed in the text as first-generation H1 antihistamines. Cetirizine, Loratadine, and Fexofenadine are second-generation H1 antihistamines.",
+		"rationale": "Diphenhydramine and Chlorpheniramine are listed in the text as first-generation H1 antihistamines. Cetirizine, Loratadine, and Fexofenadine are second-generation H1 antihistamines.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36620,7 +36620,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["51fa2682"],
-		"explanation": "First-generation H1 antihistamines readily cross the blood-brain barrier (BBB), leading to central effects like sedation. Second-generation agents have much lower BBB penetration, resulting in significantly less sedation.",
+		"rationale": "First-generation H1 antihistamines readily cross the blood-brain barrier (BBB), leading to central effects like sedation. Second-generation agents have much lower BBB penetration, resulting in significantly less sedation.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36650,7 +36650,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["4ca3b5ef", "a7cd6a35", "0958e67e"],
-		"explanation": "Inhaled antimuscarinic bronchodilators block acetylcholine at muscarinic receptors, leading to predictable anticholinergic side effects including dry eye, increased heart rate, and constipation. Sedation is more characteristic of first-generation antihistamines, and bronchodilation is the therapeutic effect, not a side effect.",
+		"rationale": "Inhaled antimuscarinic bronchodilators block acetylcholine at muscarinic receptors, leading to predictable anticholinergic side effects including dry eye, increased heart rate, and constipation. Sedation is more characteristic of first-generation antihistamines, and bronchodilation is the therapeutic effect, not a side effect.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36684,7 +36684,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f6073476", "da88da37"],
-		"explanation": "Compared to first-generation H1 antihistamines, second-generation agents generally have a longer duration of action and exhibit markedly reduced anticholinergic side effects (except for dry eye/mucous membranes) due to less penetration of the blood-brain barrier, resulting in less sedation. First-generation drugs typically have a faster onset.",
+		"rationale": "Compared to first-generation H1 antihistamines, second-generation agents generally have a longer duration of action and exhibit markedly reduced anticholinergic side effects (except for dry eye/mucous membranes) due to less penetration of the blood-brain barrier, resulting in less sedation. First-generation drugs typically have a faster onset.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36718,7 +36718,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["393d8d6f"],
-		"explanation": "Antimuscarinic bronchodilators work by blocking muscarinic acetylcholine receptors. Blockade of these receptors in the eye can interfere with accommodation (focusing) and potentially cause pupil dilation, leading to blurred vision.",
+		"rationale": "Antimuscarinic bronchodilators work by blocking muscarinic acetylcholine receptors. Blockade of these receptors in the eye can interfere with accommodation (focusing) and potentially cause pupil dilation, leading to blurred vision.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36748,7 +36748,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["76811c26"],
-		"explanation": "The text specifically notes that cetirizine and its isomer levocetirizine have a faster onset of action compared to other second-generation H1 antihistamines, but they also tend to cause more sedation than others in their class.",
+		"rationale": "The text specifically notes that cetirizine and its isomer levocetirizine have a faster onset of action compared to other second-generation H1 antihistamines, but they also tend to cause more sedation than others in their class.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36778,7 +36778,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["10083179", "12e23df1"],
-		"explanation": "The potent muscarinic receptor antagonism of first-generation H1 antihistamines causes anticholinergic effects. Ocular effects include dry eye (dry mucous membranes) and dilated pupils (mydriasis). Miosis (constriction) and bradycardia (slow heart rate) are cholinergic effects, and diarrhea is not a typical anticholinergic effect (constipation is).",
+		"rationale": "The potent muscarinic receptor antagonism of first-generation H1 antihistamines causes anticholinergic effects. Ocular effects include dry eye (dry mucous membranes) and dilated pupils (mydriasis). Miosis (constriction) and bradycardia (slow heart rate) are cholinergic effects, and diarrhea is not a typical anticholinergic effect (constipation is).",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36812,7 +36812,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7ea28f21"],
-		"explanation": "Traditional mast cell stabilizers limit calcium influx into mast cells, which prevents the degranulation process and the subsequent release of histamine and other vasoactive mediators.",
+		"rationale": "Traditional mast cell stabilizers limit calcium influx into mast cells, which prevents the degranulation process and the subsequent release of histamine and other vasoactive mediators.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36842,7 +36842,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6927b025"],
-		"explanation": "Mast cell stabilizers have a delayed onset of action (2-5 days) and reach maximum benefit around 15 days. To be effective for preventing seasonal allergies, therapy should begin about 2 weeks before the anticipated start of the allergy season.",
+		"rationale": "Mast cell stabilizers have a delayed onset of action (2-5 days) and reach maximum benefit around 15 days. To be effective for preventing seasonal allergies, therapy should begin about 2 weeks before the anticipated start of the allergy season.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36872,7 +36872,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0b30cca5"],
-		"explanation": "Mast cell stabilizers work by preventing the release of histamine and other mediators from mast cells. They do not block already released histamine, making them more suitable for prophylaxis (prevention) rather than treating acute symptoms where mediators are already present.",
+		"rationale": "Mast cell stabilizers work by preventing the release of histamine and other mediators from mast cells. They do not block already released histamine, making them more suitable for prophylaxis (prevention) rather than treating acute symptoms where mediators are already present.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36902,7 +36902,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7c5c8dab", "2aa9233b", "74adf277", "c111f49c"],
-		"explanation": "The provided text explicitly mentions sodium cromoglycate (sodium cromolyn), lodoxamide tromethamine (Alomide), pemirolast potassium (Alamast), and nedocromil sodium (Alocril) as mast cell stabilizers available in ophthalmic formulations.",
+		"rationale": "The provided text explicitly mentions sodium cromoglycate (sodium cromolyn), lodoxamide tromethamine (Alomide), pemirolast potassium (Alamast), and nedocromil sodium (Alocril) as mast cell stabilizers available in ophthalmic formulations.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36932,7 +36932,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["90bd9150"],
-		"explanation": "The text states that acetylcysteine may be compounded into an ophthalmic solution for conditions like filamentary keratitis, which are characterized by mucous plaques on the cornea and conjunctiva, leveraging its mucolytic properties.",
+		"rationale": "The text states that acetylcysteine may be compounded into an ophthalmic solution for conditions like filamentary keratitis, which are characterized by mucous plaques on the cornea and conjunctiva, leveraging its mucolytic properties.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36962,7 +36962,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e9ebaff1"],
-		"explanation": "Acetylcysteine contains a free sulfhydryl group which breaks the disulfide bonds within the mucus matrix, thereby reducing mucus viscosity and facilitating its clearance.",
+		"rationale": "Acetylcysteine contains a free sulfhydryl group which breaks the disulfide bonds within the mucus matrix, thereby reducing mucus viscosity and facilitating its clearance.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -36992,7 +36992,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["219de842"],
-		"explanation": "Guaifenesin, an expectorant, can cause side effects like dry mouth and constipation. The text advises that drinking plenty of water can help alleviate these effects.",
+		"rationale": "Guaifenesin, an expectorant, can cause side effects like dry mouth and constipation. The text advises that drinking plenty of water can help alleviate these effects.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -37022,7 +37022,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6747e5a3", "f3734b33", "3ded0da5"],
-		"explanation": "Guaifenesin is an expectorant that liquefies lower respiratory secretions. Acetylcysteine acts as a mucolytic by breaking disulfide bonds and can be compounded for ophthalmic use in filamentary keratitis. Mast cell stabilizers prevent histamine release, they do not block histamine receptors.",
+		"rationale": "Guaifenesin is an expectorant that liquefies lower respiratory secretions. Acetylcysteine acts as a mucolytic by breaking disulfide bonds and can be compounded for ophthalmic use in filamentary keratitis. Mast cell stabilizers prevent histamine release, they do not block histamine receptors.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -37052,7 +37052,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["db79ef54", "c40c4c1d", "e76072b6"],
-		"explanation": "The text specifically mentions the need for a compounding pharmacist, stinging upon instillation, and an associated odor as limitations or challenges associated with the clinical use of compounded ophthalmic acetylcysteine.",
+		"rationale": "The text specifically mentions the need for a compounding pharmacist, stinging upon instillation, and an associated odor as limitations or challenges associated with the clinical use of compounded ophthalmic acetylcysteine.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -37082,7 +37082,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["152e19d5"],
-		"explanation": "Mast cell stabilizers like lodoxamide prevent the release of histamine rather than blocking receptors. Their effects are not immediate and may take 2 to 5 days to become noticeable, with maximum benefit achieved after about 15 days.",
+		"rationale": "Mast cell stabilizers like lodoxamide prevent the release of histamine rather than blocking receptors. Their effects are not immediate and may take 2 to 5 days to become noticeable, with maximum benefit achieved after about 15 days.",
 		"metadata": {},
 		"moduleId": "js72xyeeg9q3td7d9derkk94g97m8qj5",
 		"options": [
@@ -37112,7 +37112,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7c2ecfb8", "db316ca0"],
-		"explanation": "The material states that calcium salts (like calcium carbonate) and aluminum salts can cause constipation, while magnesium salts tend to cause diarrhea.",
+		"rationale": "The material states that calcium salts (like calcium carbonate) and aluminum salts can cause constipation, while magnesium salts tend to cause diarrhea.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37142,7 +37142,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ac04583f"],
-		"explanation": "H2 blockers act as competitive antagonists by reversibly binding to histamine H2 receptors on gastric parietal cells, preventing histamine from stimulating acid secretion.",
+		"rationale": "H2 blockers act as competitive antagonists by reversibly binding to histamine H2 receptors on gastric parietal cells, preventing histamine from stimulating acid secretion.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37172,7 +37172,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["2c9bd801"],
-		"explanation": "Magnesium salts should be used with caution in patients with poor renal function due to the risk of magnesium toxicity.",
+		"rationale": "Magnesium salts should be used with caution in patients with poor renal function due to the risk of magnesium toxicity.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37202,7 +37202,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["716be2ab"],
-		"explanation": "Famotidine is identified as the most potent H2 blocker among the listed options.",
+		"rationale": "Famotidine is identified as the most potent H2 blocker among the listed options.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37232,7 +37232,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9a43affb"],
-		"explanation": "Cimetidine is a potent inhibitor of the cytochrome P450 (CYP450) enzyme system, leading to potential interactions with drugs metabolized by these enzymes, such as warfarin.",
+		"rationale": "Cimetidine is a potent inhibitor of the cytochrome P450 (CYP450) enzyme system, leading to potential interactions with drugs metabolized by these enzymes, such as warfarin.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37262,7 +37262,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["32cee22e"],
-		"explanation": "Sodium bicarbonate reacts with stomach acid to produce carbon dioxide gas, leading to burping. It also carries a sodium load, requiring caution in CHF.",
+		"rationale": "Sodium bicarbonate reacts with stomach acid to produce carbon dioxide gas, leading to burping. It also carries a sodium load, requiring caution in CHF.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37292,7 +37292,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5d6faf33", "e0ebfd5c"],
-		"explanation": "H2 blockers and PPIs are commonly prescribed concurrently with high-dose oral steroids to provide gastric protection against potential ulcer formation.",
+		"rationale": "H2 blockers and PPIs are commonly prescribed concurrently with high-dose oral steroids to provide gastric protection against potential ulcer formation.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37322,7 +37322,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ace78c49", "1c5a130e", "e1ec8d2f"],
-		"explanation": "The material notes that CNS side effects like confusion or delirium with H2 blockers have been correlated with use in patients with renal impairment, hepatic impairment, or those over 50 years of age.",
+		"rationale": "The material notes that CNS side effects like confusion or delirium with H2 blockers have been correlated with use in patients with renal impairment, hepatic impairment, or those over 50 years of age.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37352,7 +37352,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["441bc45c"],
-		"explanation": "By blocking the H2 receptor, H2 blockers prevent the histamine-induced signaling cascade (via cAMP and PKA) that leads to the phosphorylation and movement of H+/K+ ATPase transporters (proton pumps) to the parietal cell membrane, thus reducing acid secretion.",
+		"rationale": "By blocking the H2 receptor, H2 blockers prevent the histamine-induced signaling cascade (via cAMP and PKA) that leads to the phosphorylation and movement of H+/K+ ATPase transporters (proton pumps) to the parietal cell membrane, thus reducing acid secretion.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37382,7 +37382,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["c106340d"],
-		"explanation": "Common combination antacids like Maalox and Mylanta contain both magnesium salts (hydroxide or carbonate) and aluminum salts (hydroxide).",
+		"rationale": "Common combination antacids like Maalox and Mylanta contain both magnesium salts (hydroxide or carbonate) and aluminum salts (hydroxide).",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37412,7 +37412,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["d9a05cf1"],
-		"explanation": "Proton pump inhibitors (PPIs) like omeprazole irreversibly inhibit the H+, K+-ATPase enzyme (proton pump) by forming a covalent disulfide bond with cysteine residues on the enzyme's alpha subunit.",
+		"rationale": "Proton pump inhibitors (PPIs) like omeprazole irreversibly inhibit the H+, K+-ATPase enzyme (proton pump) by forming a covalent disulfide bond with cysteine residues on the enzyme's alpha subunit.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37442,7 +37442,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9dadb1f0"],
-		"explanation": "PPIs are weak bases that accumulate and require conversion to their active sulfonamide form within the highly acidic environment of the parietal cell secretory canaliculi.",
+		"rationale": "PPIs are weak bases that accumulate and require conversion to their active sulfonamide form within the highly acidic environment of the parietal cell secretory canaliculi.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37472,7 +37472,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["682face7"],
-		"explanation": "Despite short plasma half-lives, PPIs have a long duration of action because they irreversibly inhibit existing proton pumps. Acid secretion recovery requires the synthesis of new H+, K+-ATPase molecules, which takes 36-72 hours.",
+		"rationale": "Despite short plasma half-lives, PPIs have a long duration of action because they irreversibly inhibit existing proton pumps. Acid secretion recovery requires the synthesis of new H+, K+-ATPase molecules, which takes 36-72 hours.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37502,7 +37502,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["db581bb1"],
-		"explanation": "The most frequently reported common side effects of PPI therapy include headache, diarrhea, nausea, and vomiting. While more serious effects can occur with long-term use, these are the most common.",
+		"rationale": "The most frequently reported common side effects of PPI therapy include headache, diarrhea, nausea, and vomiting. While more serious effects can occur with long-term use, these are the most common.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37532,7 +37532,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["959f7f22", "7031f548", "3854b938"],
-		"explanation": "Rare but reported ocular adverse effects associated with PPI use include optic atrophy, anterior ischemic optic neuropathy (AION), optic neuritis, dry eye syndrome, and diplopia. Glaucoma and cataracts are not typically listed as associated adverse effects.",
+		"rationale": "Rare but reported ocular adverse effects associated with PPI use include optic atrophy, anterior ischemic optic neuropathy (AION), optic neuritis, dry eye syndrome, and diplopia. Glaucoma and cataracts are not typically listed as associated adverse effects.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37566,7 +37566,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["177a99e9"],
-		"explanation": "PPIs inhibit CYP2C19, the enzyme required to convert the prodrug clopidogrel into its active form. This interaction reduces the antiplatelet effect of clopidogrel, potentially increasing the risk of cardiovascular events.",
+		"rationale": "PPIs inhibit CYP2C19, the enzyme required to convert the prodrug clopidogrel into its active form. This interaction reduces the antiplatelet effect of clopidogrel, potentially increasing the risk of cardiovascular events.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37596,7 +37596,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0e21fb54", "e100ff25", "f310d2dd"],
-		"explanation": "PPIs can inhibit the metabolism or secretion of several drugs, potentially leading to increased levels and risk of toxicity. These include warfarin, benzodiazepines, citalopram, and phenytoin. They also increase the risk of digoxin toxicity. PPIs decrease the activation (and thus efficacy) of clopidogrel.",
+		"rationale": "PPIs can inhibit the metabolism or secretion of several drugs, potentially leading to increased levels and risk of toxicity. These include warfarin, benzodiazepines, citalopram, and phenytoin. They also increase the risk of digoxin toxicity. PPIs decrease the activation (and thus efficacy) of clopidogrel.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37630,7 +37630,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["fa57d59f"],
-		"explanation": "PPIs are frequently prescribed concurrently with medications known to cause gastric irritation or ulceration, such as high-dose oral steroids or NSAIDs, to provide gastric protection during the course of therapy.",
+		"rationale": "PPIs are frequently prescribed concurrently with medications known to cause gastric irritation or ulceration, such as high-dose oral steroids or NSAIDs, to provide gastric protection during the course of therapy.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37660,7 +37660,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1263b71f"],
-		"explanation": "Sucralfate requires an acidic environment to polymerize and form a protective paste. Therefore, its administration should be spaced apart from agents that reduce stomach acid, such as antacids, H2 blockers, and PPIs, to ensure efficacy.",
+		"rationale": "Sucralfate requires an acidic environment to polymerize and form a protective paste. Therefore, its administration should be spaced apart from agents that reduce stomach acid, such as antacids, H2 blockers, and PPIs, to ensure efficacy.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37690,7 +37690,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f94c6612", "48ff4746"],
-		"explanation": "Bismuth subcitrate has multiple beneficial actions: it increases mucus and bicarbonate secretion, forms a barrier, accumulates epidermal growth factor, exerts cytoprotective effects via prostaglandins, and has bactericidal effects against H. pylori. It does not directly inhibit the proton pump or CYP enzymes.",
+		"rationale": "Bismuth subcitrate has multiple beneficial actions: it increases mucus and bicarbonate secretion, forms a barrier, accumulates epidermal growth factor, exerts cytoprotective effects via prostaglandins, and has bactericidal effects against H. pylori. It does not directly inhibit the proton pump or CYP enzymes.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37724,7 +37724,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8682eb94"],
-		"explanation": "Misoprostol is a synthetic prostaglandin E1 analog that reduces gastric acid secretion by acting on parietal cell prostaglandin receptors, increases mucus and bicarbonate secretion, and thickens the mucosal layer.",
+		"rationale": "Misoprostol is a synthetic prostaglandin E1 analog that reduces gastric acid secretion by acting on parietal cell prostaglandin receptors, increases mucus and bicarbonate secretion, and thickens the mucosal layer.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37754,7 +37754,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["46c3af99"],
-		"explanation": "Misoprostol is classified as pregnancy category X because it can induce uterine contractions and miscarriage.",
+		"rationale": "Misoprostol is classified as pregnancy category X because it can induce uterine contractions and miscarriage.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37784,7 +37784,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["7dbac0f2", "3e053e3d"],
-		"explanation": "Metoclopramide, a dopamine antagonist, can cause extraocular muscle spasm and oculogyric crisis as potential ocular side effects.",
+		"rationale": "Metoclopramide, a dopamine antagonist, can cause extraocular muscle spasm and oculogyric crisis as potential ocular side effects.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37818,7 +37818,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["52b6abbb"],
-		"explanation": "Metoclopramide primarily acts by inhibiting dopamine D2 and serotonin 5-HT3 receptors in the chemoreceptor trigger zone, which enhances acetylcholine release and increases gastrointestinal motility.",
+		"rationale": "Metoclopramide primarily acts by inhibiting dopamine D2 and serotonin 5-HT3 receptors in the chemoreceptor trigger zone, which enhances acetylcholine release and increases gastrointestinal motility.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37848,7 +37848,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["801ec303", "2253ccfd"],
-		"explanation": "Metoclopramide, as a dopamine antagonist, carries a risk of tardive dyskinesia with chronic use and, rarely, neuroleptic malignant syndrome (NMS).",
+		"rationale": "Metoclopramide, as a dopamine antagonist, carries a risk of tardive dyskinesia with chronic use and, rarely, neuroleptic malignant syndrome (NMS).",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37882,7 +37882,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["26b40e91"],
-		"explanation": "Hyoscyamine belongs to the belladonna alkaloid class and is the levo-isomer of atropine, acting as a muscarinic receptor antagonist.",
+		"rationale": "Hyoscyamine belongs to the belladonna alkaloid class and is the levo-isomer of atropine, acting as a muscarinic receptor antagonist.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37912,7 +37912,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["375406f4", "67996012", "57f4f9a4", "525748f6", "8d37e235"],
-		"explanation": "Hyoscyamine, as an anticholinergic (muscarinic antagonist), causes mydriasis, cycloplegia, decreased salivation (dry mouth), decreased sweating, and reduced gastrointestinal motility.",
+		"rationale": "Hyoscyamine, as an anticholinergic (muscarinic antagonist), causes mydriasis, cycloplegia, decreased salivation (dry mouth), decreased sweating, and reduced gastrointestinal motility.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37946,7 +37946,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["03bdf4a4"],
-		"explanation": "Dicyclomine functions as an antagonist at muscarinic M1 and M2 receptors and also non-competitively inhibits histamine and bradykinin.",
+		"rationale": "Dicyclomine functions as an antagonist at muscarinic M1 and M2 receptors and also non-competitively inhibits histamine and bradykinin.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -37976,7 +37976,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["03f8433d", "6f249c8d", "53ce206e"],
-		"explanation": "Dicyclomine is an anticholinergic drug, and its common side effects include blurred vision, dry eye, and dry mouth, all relevant concerns in optometric practice.",
+		"rationale": "Dicyclomine is an anticholinergic drug, and its common side effects include blurred vision, dry eye, and dry mouth, all relevant concerns in optometric practice.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38010,7 +38010,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a688089e"],
-		"explanation": "Metoclopramide enhances GI motility by antagonizing dopamine, while hyoscyamine and dicyclomine decrease motility by antagonizing muscarinic receptors (anticholinergic effect).",
+		"rationale": "Metoclopramide enhances GI motility by antagonizing dopamine, while hyoscyamine and dicyclomine decrease motility by antagonizing muscarinic receptors (anticholinergic effect).",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38040,7 +38040,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f8a920a0"],
-		"explanation": "Meclizine is identified as a histamine H1 antagonist that targets H1 receptors on the vestibular nuclei and nucleus of the solitary tract, involved in motion sickness and nausea stimuli processing.",
+		"rationale": "Meclizine is identified as a histamine H1 antagonist that targets H1 receptors on the vestibular nuclei and nucleus of the solitary tract, involved in motion sickness and nausea stimuli processing.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38070,7 +38070,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["097f11a7"],
-		"explanation": "Promethazine is mentioned as potentially useful in eye care for patients with traumatic hyphema because preventing vomiting can avoid increases in intracranial pressure that might worsen the hyphema.",
+		"rationale": "Promethazine is mentioned as potentially useful in eye care for patients with traumatic hyphema because preventing vomiting can avoid increases in intracranial pressure that might worsen the hyphema.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38100,7 +38100,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f14fe922", "c9fc48de", "1f28d440"],
-		"explanation": "The text lists drowsiness, dry mouth, dry eye, and respiratory depression as side effects of promethazine. Headache is listed as a side effect of ondansetron.",
+		"rationale": "The text lists drowsiness, dry mouth, dry eye, and respiratory depression as side effects of promethazine. Headache is listed as a side effect of ondansetron.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38130,7 +38130,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["61a873fe"],
-		"explanation": "Ondansetron is described as a competitive serotonin type 3 receptor (5-HT3) antagonist.",
+		"rationale": "Ondansetron is described as a competitive serotonin type 3 receptor (5-HT3) antagonist.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38160,7 +38160,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f9d18822", "29f2670e", "1d8f8b7e"],
-		"explanation": "Dronabinol and nabilone are synthetic THC derivatives (A), approved for chemotherapy-induced nausea/vomiting, act via CB1 agonism (suppressing vomiting), and commonly cause sedation (C) and euphoria (E). CB2's role is mentioned but CB1 is the primary target for suppression. Motion sickness is not their primary indication.",
+		"rationale": "Dronabinol and nabilone are synthetic THC derivatives (A), approved for chemotherapy-induced nausea/vomiting, act via CB1 agonism (suppressing vomiting), and commonly cause sedation (C) and euphoria (E). CB2's role is mentioned but CB1 is the primary target for suppression. Motion sickness is not their primary indication.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38194,7 +38194,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["220b7290"],
-		"explanation": "Psyllium, polycarbophil, and methylcellulose are explicitly listed as examples of bulk-forming laxatives.",
+		"rationale": "Psyllium, polycarbophil, and methylcellulose are explicitly listed as examples of bulk-forming laxatives.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38224,7 +38224,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a47e991"],
-		"explanation": "Emollient laxatives, like docusate, work by lowering the surface tension at the oil-water interface of feces, allowing water and lipids to penetrate and soften the stool.",
+		"rationale": "Emollient laxatives, like docusate, work by lowering the surface tension at the oil-water interface of feces, allowing water and lipids to penetrate and soften the stool.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38254,7 +38254,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["5284d909"],
-		"explanation": "Castor oil is described as extremely quick acting, with an onset of 1+ hour. Bisacodyl takes about 6 hours, sennosides up to 12 hours, and saline cathartics around 3 hours.",
+		"rationale": "Castor oil is described as extremely quick acting, with an onset of 1+ hour. Bisacodyl takes about 6 hours, sennosides up to 12 hours, and saline cathartics around 3 hours.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38284,7 +38284,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["709f915e", "7359c081"],
-		"explanation": "Castor oil stimulates small intestine smooth muscle contraction via ricinoleic acid. Bisacodyl acts directly on the colon, acted on by enzymes to form a peristalsis-inducing compound. Docusate is an emollient, and psyllium is bulk-forming.",
+		"rationale": "Castor oil stimulates small intestine smooth muscle contraction via ricinoleic acid. Bisacodyl acts directly on the colon, acted on by enzymes to form a peristalsis-inducing compound. Docusate is an emollient, and psyllium is bulk-forming.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38314,7 +38314,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3ac57e3f"],
-		"explanation": "The text explicitly mentions blurred vision and transient vision loss as possible side effects of ondansetron.",
+		"rationale": "The text explicitly mentions blurred vision and transient vision loss as possible side effects of ondansetron.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38344,7 +38344,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b6dcccb3", "d54d471c"],
-		"explanation": "Bismuth subsalicylate decreases fluid/electrolyte flow into the bowel and reduces intestinal inflammation.",
+		"rationale": "Bismuth subsalicylate decreases fluid/electrolyte flow into the bowel and reduces intestinal inflammation.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38378,7 +38378,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3c06404c"],
-		"explanation": "Loperamide binds to opiate receptors in the gut wall, inhibiting acetylcholine and prostaglandin release, which slows peristalsis.",
+		"rationale": "Loperamide binds to opiate receptors in the gut wall, inhibiting acetylcholine and prostaglandin release, which slows peristalsis.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38412,7 +38412,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6b16009f", "6c3cae8b"],
-		"explanation": "Diphenoxylate and Paregoric are centrally active opioids used for diarrhea, unlike loperamide which acts peripherally. Constipation is a common side effect, especially with opioids.",
+		"rationale": "Diphenoxylate and Paregoric are centrally active opioids used for diarrhea, unlike loperamide which acts peripherally. Constipation is a common side effect, especially with opioids.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38446,7 +38446,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ed7c62ad"],
-		"explanation": "While constipation can occur with any anti-diarrheal, it is most likely following the use of opioid agents like diphenoxylate and paregoric.",
+		"rationale": "While constipation can occur with any anti-diarrheal, it is most likely following the use of opioid agents like diphenoxylate and paregoric.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38480,7 +38480,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ffc02d87"],
-		"explanation": "Diphenoxylate is combined with atropine.",
+		"rationale": "Diphenoxylate is combined with atropine.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38514,7 +38514,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["34995511", "32fdc7d5", "effc9c4f", "5999719b"],
-		"explanation": "Sulfasalazine, mesalazine, balsalazide, and olsalazine are all aminosalicylates containing 5-ASA used to treat inflammatory bowel disease.",
+		"rationale": "Sulfasalazine, mesalazine, balsalazide, and olsalazine are all aminosalicylates containing 5-ASA used to treat inflammatory bowel disease.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38548,7 +38548,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["bc81be1f"],
-		"explanation": "Kaolin is believed to work by adsorbing bacteria or germs causing diarrhea.",
+		"rationale": "Kaolin is believed to work by adsorbing bacteria or germs causing diarrhea.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38582,7 +38582,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["8b6cf6e2"],
-		"explanation": "Aminosalicylates contain 5-ASA and are used to reduce inflammation in the intestinal lining for conditions like Crohn's disease and ulcerative colitis.",
+		"rationale": "Aminosalicylates contain 5-ASA and are used to reduce inflammation in the intestinal lining for conditions like Crohn's disease and ulcerative colitis.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38616,7 +38616,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["b7570e80", "c705cab5"],
-		"explanation": "Ursodiol is a bile acid that reduces cholesterol secretion by the liver and its reabsorption by the intestines, aiding in gallstone dissolution.",
+		"rationale": "Ursodiol is a bile acid that reduces cholesterol secretion by the liver and its reabsorption by the intestines, aiding in gallstone dissolution.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38650,7 +38650,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["401c3abc"],
-		"explanation": "Ursodiol is used for gallstone dissolution, and the initial response may take 3-6 months.",
+		"rationale": "Ursodiol is used for gallstone dissolution, and the initial response may take 3-6 months.",
 		"metadata": {},
 		"moduleId": "js797s4mvnx2deqyffgr09bhhn7m9dh8",
 		"options": [
@@ -38684,7 +38684,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["9cd372ac"],
-		"explanation": "Bisphosphonates, such as alendronate, attach to hydroxyapatite binding sites on bone surfaces undergoing active resorption. They impair osteoclast function by hindering ruffled border formation, adherence to bone, and proton production, thereby inhibiting bone resorption.",
+		"rationale": "Bisphosphonates, such as alendronate, attach to hydroxyapatite binding sites on bone surfaces undergoing active resorption. They impair osteoclast function by hindering ruffled border formation, adherence to bone, and proton production, thereby inhibiting bone resorption.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38714,7 +38714,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["34688a1f"],
-		"explanation": "The material explicitly lists anterior uveitis as the primary ocular side effect of bisphosphonates, alongside conjunctivitis and scleritis.",
+		"rationale": "The material explicitly lists anterior uveitis as the primary ocular side effect of bisphosphonates, alongside conjunctivitis and scleritis.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38744,7 +38744,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["afab4cbe", "1ef73e13", "e656225d"],
-		"explanation": "Bisphosphonates are indicated for treating osteoporosis, Paget disease of the bone, and hypercalcemia associated with malignancy. Interstitial cystitis is treated with pentosan polysulfate sodium.",
+		"rationale": "Bisphosphonates are indicated for treating osteoporosis, Paget disease of the bone, and hypercalcemia associated with malignancy. Interstitial cystitis is treated with pentosan polysulfate sodium.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38774,7 +38774,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ba7ed1db"],
-		"explanation": "Isotretinoin's mechanism, although not fully elucidated, involves the inhibition of sebaceous gland function (reducing size and sebum production) and keratinization.",
+		"rationale": "Isotretinoin's mechanism, although not fully elucidated, involves the inhibition of sebaceous gland function (reducing size and sebum production) and keratinization.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38804,7 +38804,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["183c1381", "7bbc09bd"],
-		"explanation": "Isotretinoin commonly causes decreased meibomian gland function leading to dry eye, and less commonly, can cause nyctalopia (decreased night vision) and intracranial hypertension.",
+		"rationale": "Isotretinoin commonly causes decreased meibomian gland function leading to dry eye, and less commonly, can cause nyctalopia (decreased night vision) and intracranial hypertension.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38834,7 +38834,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["1bfa3609", "a22de504"],
-		"explanation": "Isotretinoin is Pregnancy Category X due to its severe teratogenicity, making its use contraindicated during pregnancy or planned conception. It is also a contraindication for corneal refractive surgery due to its effects on ocular surface healing and dryness.",
+		"rationale": "Isotretinoin is Pregnancy Category X due to its severe teratogenicity, making its use contraindicated during pregnancy or planned conception. It is also a contraindication for corneal refractive surgery due to its effects on ocular surface healing and dryness.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38864,7 +38864,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["f99e7c51"],
-		"explanation": "Pentosan polysulfate sodium is used to treat interstitial cystitis, a condition causing bladder pain and pressure.",
+		"rationale": "Pentosan polysulfate sodium is used to treat interstitial cystitis, a condition causing bladder pain and pressure.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38894,7 +38894,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["54e9a35d"],
-		"explanation": "Long-term use and high cumulative doses (≥ 500 grams) of pentosan polysulfate sodium are specifically linked to the development of a toxic maculopathy.",
+		"rationale": "Long-term use and high cumulative doses (≥ 500 grams) of pentosan polysulfate sodium are specifically linked to the development of a toxic maculopathy.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38924,7 +38924,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["88e6e093"],
-		"explanation": "Due to the risk of toxic maculopathy, patients on long-term pentosan polysulfate sodium require monitoring similar to those on hydroxychloroquine, which includes Optical Coherence Tomography (OCT) to assess macular structure.",
+		"rationale": "Due to the risk of toxic maculopathy, patients on long-term pentosan polysulfate sodium require monitoring similar to those on hydroxychloroquine, which includes Optical Coherence Tomography (OCT) to assess macular structure.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38954,7 +38954,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ecb95078"],
-		"explanation": "Both bisphosphonates and isotretinoin list bone, joint, and/or muscle pain as potential side effects. Anterior uveitis is primarily associated with bisphosphonates, while dry eye and photosensitivity are key side effects of isotretinoin.",
+		"rationale": "Both bisphosphonates and isotretinoin list bone, joint, and/or muscle pain as potential side effects. Anterior uveitis is primarily associated with bisphosphonates, while dry eye and photosensitivity are key side effects of isotretinoin.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -38984,7 +38984,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["e912dac1"],
-		"explanation": "Amiodarone is listed as a cause of vortex/whorl keratopathy in the provided table.",
+		"rationale": "Amiodarone is listed as a cause of vortex/whorl keratopathy in the provided table.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39014,7 +39014,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["0f71d619"],
-		"explanation": "Alpha-1 blockers are associated with Intraoperative Floppy Iris Syndrome (IFIS), a complication during cataract surgery.",
+		"rationale": "Alpha-1 blockers are associated with Intraoperative Floppy Iris Syndrome (IFIS), a complication during cataract surgery.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39044,7 +39044,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["ba23bab1"],
-		"explanation": "Long-term use of glucocorticoids is a well-known risk factor for the development of posterior subcapsular cataracts.",
+		"rationale": "Long-term use of glucocorticoids is a well-known risk factor for the development of posterior subcapsular cataracts.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39074,7 +39074,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6503ce86"],
-		"explanation": "PDE5 inhibitors, used for erectile dysfunction, are known to cause changes in color perception, often described as blue-tinged vision (cyanopsia).",
+		"rationale": "PDE5 inhibitors, used for erectile dysfunction, are known to cause changes in color perception, often described as blue-tinged vision (cyanopsia).",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39104,7 +39104,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["96abcaa5", "2071f789", "ed5fdc79"],
-		"explanation": "Amiodarone, Ethambutol, and Isoniazid are all listed in the table as causes of optic neuropathy or optic atrophy. Vigabatrin also causes optic neuropathy but is not an option. Phenytoin causes oculomotor dysfunction.",
+		"rationale": "Amiodarone, Ethambutol, and Isoniazid are all listed in the table as causes of optic neuropathy or optic atrophy. Vigabatrin also causes optic neuropathy but is not an option. Phenytoin causes oculomotor dysfunction.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39134,7 +39134,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["3a14dd3f", "4808b637", "8d365749"],
-		"explanation": "The table lists Amiodarone (vortex keratopathy), Gold salts (crystalline keratopathy), and Phenothiazines (pigmented keratopathy) as causes of keratopathy involving deposits or visible patterns. Alendronate is associated with scleritis and uveitis.",
+		"rationale": "The table lists Amiodarone (vortex keratopathy), Gold salts (crystalline keratopathy), and Phenothiazines (pigmented keratopathy) as causes of keratopathy involving deposits or visible patterns. Alendronate is associated with scleritis and uveitis.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39164,7 +39164,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["58269977", "65a86c17"],
-		"explanation": "Isoniazid and Ethambutol are common anti-tuberculosis medications listed as causing optic neuritis and/or optic neuropathy/atrophy, which are pathologies of the optic nerve. Tamoxifen affects multiple structures but not primarily the optic nerve in this context. Amantadine causes corneal edema.",
+		"rationale": "Isoniazid and Ethambutol are common anti-tuberculosis medications listed as causing optic neuritis and/or optic neuropathy/atrophy, which are pathologies of the optic nerve. Tamoxifen affects multiple structures but not primarily the optic nerve in this context. Amantadine causes corneal edema.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39194,7 +39194,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["a52c76d4"],
-		"explanation": "Alendronate, a bisphosphonate used for osteoporosis, is listed as a cause of both scleritis and uveitis.",
+		"rationale": "Alendronate, a bisphosphonate used for osteoporosis, is listed as a cause of both scleritis and uveitis.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39224,7 +39224,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["6c80d28e"],
-		"explanation": "Tamoxifen is listed in the table as causing vortex keratopathy (Cornea), intraretinal deposits (Retina), macular edema (Macula), and optic nerve edema (Optic Nerve).",
+		"rationale": "Tamoxifen is listed in the table as causing vortex keratopathy (Cornea), intraretinal deposits (Retina), macular edema (Macula), and optic nerve edema (Optic Nerve).",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [
@@ -39254,7 +39254,7 @@
 	{
 		"aiGenerated": true,
 		"correctAnswers": ["dff8fdaf"],
-		"explanation": "Tamoxifen is listed in the table as a cause of both macular edema and intraretinal deposits.",
+		"rationale": "Tamoxifen is listed in the table as a cause of both macular edema and intraretinal deposits.",
 		"metadata": {},
 		"moduleId": "js7ez0vytvxtkq9z2dbt0prbmn7m84kp",
 		"options": [

--- a/src/convex/customQuiz.ts
+++ b/src/convex/customQuiz.ts
@@ -2,6 +2,7 @@ import { query, mutation } from './_generated/server';
 import type { MutationCtx, QueryCtx } from './_generated/server';
 import { v } from 'convex/values';
 import type { Doc, Id } from './_generated/dataModel';
+import { getRationale } from '../lib/utils/rationale';
 
 type SourceFilter = 'all' | 'flagged' | 'incomplete';
 type AttemptStatus = 'in_progress' | 'submitted' | 'timed_out' | 'abandoned';
@@ -57,12 +58,16 @@ async function requireAttemptOwner(
 	return attempt;
 }
 
-function hasInteraction(record: Pick<Doc<'userProgress'>, 'selectedOptions' | 'eliminatedOptions'>) {
+function hasInteraction(
+	record: Pick<Doc<'userProgress'>, 'selectedOptions' | 'eliminatedOptions'>
+) {
 	return record.selectedOptions.length > 0 || record.eliminatedOptions.length > 0;
 }
 
 function normalizeQuestionType(type: string): string {
-	return String(type || '').trim().toLowerCase();
+	return String(type || '')
+		.trim()
+		.toLowerCase();
 }
 
 function seededHash(input: string): number {
@@ -107,7 +112,9 @@ function exactSetMatch(correctAnswers: string[], userAnswers: string[]) {
 }
 
 function matchingRoleFromOptionText(text: string): 'prompt' | 'answer' | null {
-	const normalized = String(text ?? '').trimStart().toLowerCase();
+	const normalized = String(text ?? '')
+		.trimStart()
+		.toLowerCase();
 	if (normalized.startsWith('prompt:')) return 'prompt';
 	if (normalized.startsWith('answer:')) return 'answer';
 	return null;
@@ -175,14 +182,14 @@ function normalizeMatchingCorrectPairs(
 				answerToken: string;
 			} => Boolean(pair)
 		)
-			.map((pair) => ({
-				promptId: resolveMatchingOptionTokenToId(pair.promptId, options) ?? '',
-				answerId:
-					splitMatchingAnswerToken(pair.answerToken)
-						.map((token) => resolveMatchingOptionTokenToId(token, options))
-						.filter((id): id is string => Boolean(id))
-						.find((id) => answerIdSet.has(id)) ?? ''
-			}))
+		.map((pair) => ({
+			promptId: resolveMatchingOptionTokenToId(pair.promptId, options) ?? '',
+			answerId:
+				splitMatchingAnswerToken(pair.answerToken)
+					.map((token) => resolveMatchingOptionTokenToId(token, options))
+					.filter((id): id is string => Boolean(id))
+					.find((id) => answerIdSet.has(id)) ?? ''
+		}))
 		.filter((pair) => promptIdSet.has(pair.promptId) && answerIdSet.has(pair.answerId));
 	if (pairValues.length > 0) {
 		return Array.from(new Set(pairValues.map((pair) => `${pair.promptId}::${pair.answerId}`)));
@@ -219,7 +226,9 @@ function matchingCorrectByPrompt(
 	const answerOptions = options.filter((o) => matchingRoleFromOptionText(o.text) === 'answer');
 	const promptIdSet = new Set(promptOptions.map((o) => o.id));
 	const answerIdSet = new Set(answerOptions.map((o) => o.id));
-	const answerKeyById = new Map(answerOptions.map((o) => [o.id, normalizeMatchingAnswerText(o.text)]));
+	const answerKeyById = new Map(
+		answerOptions.map((o) => [o.id, normalizeMatchingAnswerText(o.text)])
+	);
 	const answerIdsByKey = new Map<string, Set<string>>();
 	for (const [id, key] of answerKeyById.entries()) {
 		if (!answerIdsByKey.has(key)) answerIdsByKey.set(key, new Set());
@@ -282,14 +291,10 @@ function normalizeMatchingUserPairs(
 ): string[] {
 	const options = questionSnapshot.options || [];
 	const promptIdSet = new Set(
-		options
-			.filter((o) => matchingRoleFromOptionText(o.text) === 'prompt')
-			.map((o) => o.id)
+		options.filter((o) => matchingRoleFromOptionText(o.text) === 'prompt').map((o) => o.id)
 	);
 	const answerIdSet = new Set(
-		options
-			.filter((o) => matchingRoleFromOptionText(o.text) === 'answer')
-			.map((o) => o.id)
+		options.filter((o) => matchingRoleFromOptionText(o.text) === 'answer').map((o) => o.id)
 	);
 
 	return Array.from(
@@ -365,11 +370,17 @@ function normalizeForFlags(
 function looksUnsafeRegexPattern(pattern: string): boolean {
 	if (pattern.length > 200) return true;
 	// Heuristic for catastrophic backtracking patterns like (.+)+ or (a*){2,}
-	if (/\((?:[^()\\]|\\.)*(?:\+|\*|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)\s*(?:\+|\*|\{\d+(?:,\d*)?\})/.test(pattern)) {
+	if (
+		/\((?:[^()\\]|\\.)*(?:\+|\*|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)\s*(?:\+|\*|\{\d+(?:,\d*)?\})/.test(
+			pattern
+		)
+	) {
 		return true;
 	}
 	// Heuristic for repeated wildcard groups such as (.*.*)+
-	if (/\((?:[^()\\]|\\.)*(?:\.\*|\.\+)(?:[^()\\]|\\.)*(?:\.\*|\.\+)(?:[^()\\]|\\.)*\)/.test(pattern)) {
+	if (
+		/\((?:[^()\\]|\\.)*(?:\.\*|\.\+)(?:[^()\\]|\\.)*(?:\.\*|\.\+)(?:[^()\\]|\\.)*\)/.test(pattern)
+	) {
 		return true;
 	}
 	return false;
@@ -458,7 +469,10 @@ function scoreAttemptItem(item: Doc<'quizAttemptItems'>) {
 			item.response.selectedOptions || []
 		);
 	} else {
-		isCorrect = exactSetMatch(item.questionSnapshot.correctAnswers || [], item.response.selectedOptions || []);
+		isCorrect = exactSetMatch(
+			item.questionSnapshot.correctAnswers || [],
+			item.response.selectedOptions || []
+		);
 	}
 
 	return {
@@ -481,7 +495,10 @@ function computeAttemptCounters(items: Doc<'quizAttemptItems'>[]) {
 	return { visitedCount, answeredCount, flaggedCount };
 }
 
-async function getClassPublishedModules(ctx: ConvexCtx, classId: Id<'class'>): Promise<Doc<'module'>[]> {
+async function getClassPublishedModules(
+	ctx: ConvexCtx,
+	classId: Id<'class'>
+): Promise<Doc<'module'>[]> {
 	const modules = (await ctx.db
 		.query('module')
 		.withIndex('by_classId', (q) => q.eq('classId', classId))
@@ -527,7 +544,10 @@ async function getModuleTagsForClass(
 		.filter((link) => !link.deletedAt && moduleIdSet.has(link.moduleId))
 		.filter((link) => tagById.has(link.tagId));
 
-	const tagsByModuleId = new Map<Id<'module'>, Array<{ _id: Id<'tags'>; name: string; color?: string }>>();
+	const tagsByModuleId = new Map<
+		Id<'module'>,
+		Array<{ _id: Id<'tags'>; name: string; color?: string }>
+	>();
 	const moduleIdsByTagId = new Map<Id<'tags'>, Set<Id<'module'>>>();
 
 	for (const link of filteredLinks) {
@@ -565,13 +585,16 @@ async function getModuleTagsForClass(
 	return { tagsByModuleId, tagCollections };
 }
 
-async function getEligibleQuestionsForAttempt(ctx: ConvexCtx, params: {
-	userId: Id<'users'>;
-	classId: Id<'class'>;
-	moduleIds: Id<'module'>[];
-	sourceFilter: SourceFilter;
-	questionTypes?: string[];
-}): Promise<{
+async function getEligibleQuestionsForAttempt(
+	ctx: ConvexCtx,
+	params: {
+		userId: Id<'users'>;
+		classId: Id<'class'>;
+		moduleIds: Id<'module'>[];
+		sourceFilter: SourceFilter;
+		questionTypes?: string[];
+	}
+): Promise<{
 	questions: Doc<'question'>[];
 	modulesById: Map<Id<'module'>, Doc<'module'>>;
 }> {
@@ -594,11 +617,11 @@ async function getEligibleQuestionsForAttempt(ctx: ConvexCtx, params: {
 
 	const questionLists = await Promise.all(
 		params.moduleIds.map(async (moduleId) => {
-				const q = await ctx.db
-					.query('question')
-					.withIndex('by_moduleId_order', (indexQ) => indexQ.eq('moduleId', moduleId))
-					.filter((qb) => qb.eq(qb.field('status'), 'published'))
-					.collect();
+			const q = await ctx.db
+				.query('question')
+				.withIndex('by_moduleId_order', (indexQ) => indexQ.eq('moduleId', moduleId))
+				.filter((qb) => qb.eq(qb.field('status'), 'published'))
+				.collect();
 			return q as Doc<'question'>[];
 		})
 	);
@@ -614,9 +637,7 @@ async function getEligibleQuestionsForAttempt(ctx: ConvexCtx, params: {
 
 	const progress = (await ctx.db
 		.query('userProgress')
-		.withIndex('by_user_class', (q) =>
-			q.eq('userId', params.userId).eq('classId', params.classId)
-		)
+		.withIndex('by_user_class', (q) => q.eq('userId', params.userId).eq('classId', params.classId))
 		.collect()) as Doc<'userProgress'>[];
 
 	const progressByQuestionId = new Map<Id<'question'>, Doc<'userProgress'>>(
@@ -624,7 +645,9 @@ async function getEligibleQuestionsForAttempt(ctx: ConvexCtx, params: {
 	);
 
 	if (params.sourceFilter === 'flagged') {
-		questions = questions.filter((question) => progressByQuestionId.get(question._id)?.isFlagged === true);
+		questions = questions.filter(
+			(question) => progressByQuestionId.get(question._id)?.isFlagged === true
+		);
 	} else if (params.sourceFilter === 'incomplete') {
 		questions = questions.filter((question) => {
 			const record = progressByQuestionId.get(question._id);
@@ -712,19 +735,19 @@ export const getClassQuizBuilderData = query({
 				code: classDoc.code,
 				description: classDoc.description
 			},
-				modules: modules.map((m: Doc<'module'>) => ({
-					_id: m._id,
-					title: m.title,
-					emoji: m.emoji,
-					order: m.order,
-					description: m.description,
-					questionCount: m.questionCount ?? 0,
-					tags: tagsByModuleId.get(m._id) ?? []
-				})),
-				tagCollections: tagCollectionsWithCounts,
-				limits: {
-					maxQuestionsPerAttempt: MAX_QUESTIONS_PER_ATTEMPT
-				}
+			modules: modules.map((m: Doc<'module'>) => ({
+				_id: m._id,
+				title: m.title,
+				emoji: m.emoji,
+				order: m.order,
+				description: m.description,
+				questionCount: m.questionCount ?? 0,
+				tags: tagsByModuleId.get(m._id) ?? []
+			})),
+			tagCollections: tagCollectionsWithCounts,
+			limits: {
+				maxQuestionsPerAttempt: MAX_QUESTIONS_PER_ATTEMPT
+			}
 		};
 	}
 });
@@ -771,7 +794,9 @@ export const getEligibleQuestionPoolSummary = query({
 
 		return {
 			totalEligible: questions.length,
-			byModule: Array.from(byModule.values()).sort((a, b) => a.moduleTitle.localeCompare(b.moduleTitle)),
+			byModule: Array.from(byModule.values()).sort((a, b) =>
+				a.moduleTitle.localeCompare(b.moduleTitle)
+			),
 			byType: Array.from(byType.entries())
 				.map(([questionType, count]) => ({ questionType, count }))
 				.sort((a, b) => a.questionType.localeCompare(b.questionType))
@@ -816,7 +841,9 @@ export const createCustomQuizAttempt = mutation({
 		const seed = `${nowTs()}_${Math.random().toString(36).slice(2)}`;
 		const shuffledPool = shuffledWithSeed(questions, `pool:${seed}`);
 		const selected = shuffledPool.slice(0, actualCount);
-		const orderedQuestions = args.shuffleQuestions ? selected : [...selected].sort((a, b) => a.order - b.order);
+		const orderedQuestions = args.shuffleQuestions
+			? selected
+			: [...selected].sort((a, b) => a.order - b.order);
 		const now = nowTs();
 
 		const attemptId = await ctx.db.insert('quizAttempts', {
@@ -830,7 +857,8 @@ export const createCustomQuizAttempt = mutation({
 				questionCountRequested: requestedCount,
 				questionCountActual: actualCount,
 				sourceFilter: args.sourceFilter,
-				questionTypes: args.questionTypes && args.questionTypes.length > 0 ? args.questionTypes : undefined,
+				questionTypes:
+					args.questionTypes && args.questionTypes.length > 0 ? args.questionTypes : undefined,
 				shuffleQuestions: args.shuffleQuestions,
 				shuffleOptions: args.shuffleOptions,
 				timeLimitSec,
@@ -871,7 +899,7 @@ export const createCustomQuizAttempt = mutation({
 					stem: question.stem,
 					options: question.options || [],
 					correctAnswers: question.correctAnswers || [],
-					explanation: question.explanation,
+					rationale: getRationale(question),
 					questionUpdatedAt: question.updatedAt
 				},
 				response: {
@@ -903,7 +931,7 @@ export const getAttemptRunnerBundle = query({
 			.withIndex('by_attempt_order', (q) => q.eq('attemptId', args.attemptId))
 			.collect()) as Doc<'quizAttemptItems'>[];
 
-			const classDoc = (await ctx.db.get(attempt.classId)) as Doc<'class'> | null;
+		const classDoc = (await ctx.db.get(attempt.classId)) as Doc<'class'> | null;
 		const modules = await Promise.all(
 			Array.from(new Set(items.map((item) => item.moduleId))).map(async (moduleId) => {
 				const module = await ctx.db.get(moduleId);
@@ -915,7 +943,7 @@ export const getAttemptRunnerBundle = query({
 			attempt: {
 				_id: attempt._id,
 				classId: attempt.classId,
-					className: isClassDoc(classDoc) ? classDoc.name : 'Class',
+				className: isClassDoc(classDoc) ? classDoc.name : 'Class',
 				status: attempt.status as AttemptStatus,
 				startedAt: attempt.startedAt,
 				lastActivityAt: attempt.lastActivityAt,
@@ -960,7 +988,9 @@ export const patchAttemptResponses = mutation({
 
 		const now = nowTs();
 		const elapsedMsArg =
-			args.elapsedMs !== undefined ? Math.max(0, clampInt(args.elapsedMs, 0, 7 * 24 * 60 * 60 * 1000)) : undefined;
+			args.elapsedMs !== undefined
+				? Math.max(0, clampInt(args.elapsedMs, 0, 7 * 24 * 60 * 60 * 1000))
+				: undefined;
 
 		for (const change of args.changes) {
 			const item = (await ctx.db.get(change.itemId)) as Doc<'quizAttemptItems'> | null;
@@ -993,7 +1023,8 @@ export const patchAttemptResponses = mutation({
 			}
 
 			const answerPresent = fitb
-				? String(nextResponse.textResponse ?? nextResponse.selectedOptions[0] ?? '').trim().length > 0
+				? String(nextResponse.textResponse ?? nextResponse.selectedOptions[0] ?? '').trim().length >
+					0
 				: (nextResponse.selectedOptions || []).length > 0;
 
 			if (answerPresent && nextResponse.answeredAt === undefined) {
@@ -1021,7 +1052,9 @@ export const patchAttemptResponses = mutation({
 			progressCounters: counters,
 			lastActivityAt: now,
 			elapsedMs:
-				elapsedMsArg !== undefined ? Math.max(attempt.elapsedMs ?? 0, elapsedMsArg) : attempt.elapsedMs,
+				elapsedMsArg !== undefined
+					? Math.max(attempt.elapsedMs ?? 0, elapsedMsArg)
+					: attempt.elapsedMs,
 			updatedAt: now
 		});
 
@@ -1044,7 +1077,10 @@ export const heartbeatAttempt = mutation({
 		const now = nowTs();
 		await ctx.db.patch(attempt._id, {
 			lastActivityAt: now,
-			elapsedMs: Math.max(attempt.elapsedMs ?? 0, Math.max(0, clampInt(args.elapsedMs, 0, 7 * 24 * 60 * 60 * 1000))),
+			elapsedMs: Math.max(
+				attempt.elapsedMs ?? 0,
+				Math.max(0, clampInt(args.elapsedMs, 0, 7 * 24 * 60 * 60 * 1000))
+			),
 			updatedAt: now
 		});
 		return { ok: true };
@@ -1068,13 +1104,17 @@ export const submitAttempt = mutation({
 
 		const now = nowTs();
 		const elapsedMsSubmitted =
-			args.elapsedMs !== undefined ? Math.max(0, clampInt(args.elapsedMs, 0, 7 * 24 * 60 * 60 * 1000)) : undefined;
+			args.elapsedMs !== undefined
+				? Math.max(0, clampInt(args.elapsedMs, 0, 7 * 24 * 60 * 60 * 1000))
+				: undefined;
 		const effectiveElapsedMs = Math.max(
 			attempt.elapsedMs ?? 0,
 			elapsedMsSubmitted ?? 0,
 			now - attempt.startedAt
 		);
-		const expiryAt = attempt.timeLimitSec ? attempt.startedAt + attempt.timeLimitSec * 1000 : undefined;
+		const expiryAt = attempt.timeLimitSec
+			? attempt.startedAt + attempt.timeLimitSec * 1000
+			: undefined;
 		const timedOut = expiryAt !== undefined && now >= expiryAt;
 
 		const items = (await ctx.db
@@ -1090,11 +1130,23 @@ export const submitAttempt = mutation({
 
 		const byType = new Map<
 			string,
-			{ questionType: string; total: number; correct: number; incorrect: number; unanswered: number }
+			{
+				questionType: string;
+				total: number;
+				correct: number;
+				incorrect: number;
+				unanswered: number;
+			}
 		>();
 		const byModule = new Map<
 			Id<'module'>,
-			{ moduleId: Id<'module'>; total: number; correct: number; incorrect: number; unanswered: number }
+			{
+				moduleId: Id<'module'>;
+				total: number;
+				correct: number;
+				incorrect: number;
+				unanswered: number;
+			}
 		>();
 
 		for (const item of items) {
@@ -1106,23 +1158,26 @@ export const submitAttempt = mutation({
 			else incorrectCount += 1;
 
 			const typeKey = normalizeQuestionType(item.questionSnapshot.type);
-			const typeAcc =
-				byType.get(typeKey) ??
-				{ questionType: typeKey, total: 0, correct: 0, incorrect: 0, unanswered: 0 };
+			const typeAcc = byType.get(typeKey) ?? {
+				questionType: typeKey,
+				total: 0,
+				correct: 0,
+				incorrect: 0,
+				unanswered: 0
+			};
 			typeAcc.total += 1;
 			if (score.unanswered) typeAcc.unanswered += 1;
 			else if (score.isCorrect) typeAcc.correct += 1;
 			else typeAcc.incorrect += 1;
 			byType.set(typeKey, typeAcc);
 
-			const moduleAcc =
-				byModule.get(item.moduleId) ?? {
-					moduleId: item.moduleId,
-					total: 0,
-					correct: 0,
-					incorrect: 0,
-					unanswered: 0
-				};
+			const moduleAcc = byModule.get(item.moduleId) ?? {
+				moduleId: item.moduleId,
+				total: 0,
+				correct: 0,
+				incorrect: 0,
+				unanswered: 0
+			};
 			moduleAcc.total += 1;
 			if (score.unanswered) moduleAcc.unanswered += 1;
 			else if (score.isCorrect) moduleAcc.correct += 1;
@@ -1144,9 +1199,7 @@ export const submitAttempt = mutation({
 		const passThresholdPct = clampInt(attempt.configSnapshot.passThresholdPct, 0, 100);
 		const moduleIds = Array.from(byModule.keys());
 		const moduleDocs = await Promise.all(moduleIds.map((moduleId) => ctx.db.get(moduleId)));
-		const moduleTitleMap = new Map(
-			moduleDocs.filter(isModuleDoc).map((m) => [m._id, m.title])
-		);
+		const moduleTitleMap = new Map(moduleDocs.filter(isModuleDoc).map((m) => [m._id, m.title]));
 
 		const byModuleSummary = Array.from(byModule.values()).map((row) => ({
 			moduleId: row.moduleId,
@@ -1225,7 +1278,7 @@ export const getAttemptResults = query({
 			attempt: {
 				_id: attempt._id,
 				classId: attempt.classId,
-					className: isClassDoc(classDoc) ? classDoc.name : 'Class',
+				className: isClassDoc(classDoc) ? classDoc.name : 'Class',
 				status: attempt.status,
 				startedAt: attempt.startedAt,
 				submittedAt: attempt.submittedAt,
@@ -1254,7 +1307,7 @@ export const getAttemptResults = query({
 						type: item.questionSnapshot.type,
 						stem: item.questionSnapshot.stem,
 						options: orderedOptions,
-						explanation: item.questionSnapshot.explanation ?? ''
+						rationale: getRationale(item.questionSnapshot)
 					},
 					response: item.response,
 					score: item.score,
@@ -1273,9 +1326,7 @@ export const getUserAttemptsForClass = query({
 
 		const attempts = (await ctx.db
 			.query('quizAttempts')
-			.withIndex('by_user_class', (q) =>
-				q.eq('userId', user._id).eq('classId', args.classId)
-			)
+			.withIndex('by_user_class', (q) => q.eq('userId', user._id).eq('classId', args.classId))
 			.collect()) as Doc<'quizAttempts'>[];
 
 		return attempts

--- a/src/convex/migrations.ts
+++ b/src/convex/migrations.ts
@@ -2,6 +2,7 @@ import { internalMutation, mutation, query } from './_generated/server';
 import { v } from 'convex/values';
 import type { Id } from './_generated/dataModel';
 import { authAdminMutation } from './authQueries';
+import { getRationale } from '../lib/utils/rationale';
 
 /**
  * Get stats about questions and userProgress for migration planning (paginated).
@@ -22,9 +23,7 @@ export const getStats = query({
 				.paginate({ cursor: args.cursor ?? null, numItems: batchSize });
 
 			const withFlagCount = page.filter((q) => q.flagCount !== undefined && q.flagCount !== null);
-			const needingBackfill = page.filter(
-				(q) => q.flagCount === undefined || q.flagCount === null
-			);
+			const needingBackfill = page.filter((q) => q.flagCount === undefined || q.flagCount === null);
 
 			return {
 				type: 'questions',
@@ -70,9 +69,7 @@ export const findClassByName = query({
 			}));
 		}
 		const searchLower = args.search!.toLowerCase();
-		const matches = classes.filter(
-			(c) => c.name && c.name.toLowerCase().includes(searchLower)
-		);
+		const matches = classes.filter((c) => c.name && c.name.toLowerCase().includes(searchLower));
 		return matches.map((c) => ({
 			id: c._id,
 			name: c.name
@@ -208,6 +205,47 @@ export const resetFlagCounts = mutation({
 			totalQuestions: questions.length,
 			reset: updated,
 			message: `Reset ${updated} questions to flagCount=0`
+		};
+	}
+});
+
+/**
+ * Backfill legacy explanation fields into rationale for quiz attempt snapshots.
+ * Run via CLI: bunx convex run migrations:backfillAttemptItemRationales
+ */
+export const backfillAttemptItemRationales = mutation({
+	args: {
+		batchSize: v.optional(v.number()),
+		cursor: v.optional(v.string())
+	},
+	handler: async (ctx, args) => {
+		const {
+			page: items,
+			isDone,
+			continueCursor
+		} = await ctx.db
+			.query('quizAttemptItems')
+			.paginate({ cursor: args.cursor ?? null, numItems: args.batchSize ?? 200 });
+
+		let updated = 0;
+		for (const item of items) {
+			const rationale = getRationale(item.questionSnapshot).trim();
+			if (!rationale || item.questionSnapshot.rationale === rationale) continue;
+
+			await ctx.db.patch(item._id, {
+				questionSnapshot: {
+					...item.questionSnapshot,
+					rationale
+				},
+				updatedAt: Date.now()
+			});
+			updated += 1;
+		}
+
+		return {
+			updated,
+			done: isDone,
+			cursor: continueCursor
 		};
 	}
 });
@@ -360,8 +398,7 @@ export const backfillCohortStats = mutation({
 				if (student.progressStats) {
 					const pct =
 						student.progressStats.totalQuestions > 0
-							? (student.progressStats.questionsInteracted /
-									student.progressStats.totalQuestions) *
+							? (student.progressStats.questionsInteracted / student.progressStats.totalQuestions) *
 								100
 							: 0;
 					totalProgressSum += pct;
@@ -385,8 +422,7 @@ export const backfillCohortStats = mutation({
 			}
 		}
 
-		const averageCompletion =
-			totalStudents > 0 ? Math.round(totalProgressSum / totalStudents) : 0;
+		const averageCompletion = totalStudents > 0 ? Math.round(totalProgressSum / totalStudents) : 0;
 
 		// Update cohort with stats
 		await ctx.db.patch(args.cohortId, {
@@ -572,8 +608,7 @@ export const getAllCohortsStatus = query({
 					totalStudents: students.length,
 					studentsWithProgressStats: studentsWithStats.length,
 					totalClasses: classes.length,
-					needsBackfill:
-						!cohort.stats || studentsWithStats.length < students.length
+					needsBackfill: !cohort.stats || studentsWithStats.length < students.length
 				};
 			})
 		);
@@ -788,9 +823,7 @@ export const clearPlanField = mutation({
 			page: users,
 			isDone,
 			continueCursor
-		} = await ctx.db
-			.query('users')
-			.paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+		} = await ctx.db.query('users').paginate({ cursor: args.cursor ?? null, numItems: batchSize });
 
 		let processed = 0;
 		let cleared = 0;

--- a/src/convex/question.ts
+++ b/src/convex/question.ts
@@ -6,6 +6,7 @@ import { internal, components } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import type { MutationCtx } from './_generated/server';
 import { applyQuestionCreationDeltaAndEvaluateBadges } from './badgeEngine';
+import { getRationale } from '../lib/utils/rationale';
 
 const MAX_QUESTIONS_PER_MODULE = 150;
 const LIMIT_FREE = 15;
@@ -130,7 +131,9 @@ function generateOptionId(used: Set<string>): string {
 }
 
 function matchingRoleFromText(text: string): 'prompt' | 'answer' | null {
-	const normalized = String(text ?? '').trimStart().toLowerCase();
+	const normalized = String(text ?? '')
+		.trimStart()
+		.toLowerCase();
 	if (normalized.startsWith('prompt:')) return 'prompt';
 	if (normalized.startsWith('answer:')) return 'answer';
 	return null;
@@ -154,7 +157,9 @@ function matchingOptionKey(text: string): string {
 	return `${role}:${normalizeWhitespaceLower(withoutPrefix)}`;
 }
 
-function parseMatchingPairToken(value: string): { promptToken: string; answerToken: string } | null {
+function parseMatchingPairToken(
+	value: string
+): { promptToken: string; answerToken: string } | null {
 	const raw = String(value ?? '').trim();
 	const sep = raw.indexOf('::');
 	if (sep <= 0) return null;
@@ -282,9 +287,10 @@ function assignMatchingOptionIds(
 	return { optionsWithIds, legacyIdMap };
 }
 
-function assignFreshOptionIds(
-	inputOptions: Array<{ text: string; id?: string }>
-): { optionsWithIds: Array<{ id: string; text: string }>; legacyIdMap: Map<string, string> } {
+function assignFreshOptionIds(inputOptions: Array<{ text: string; id?: string }>): {
+	optionsWithIds: Array<{ id: string; text: string }>;
+	legacyIdMap: Map<string, string>;
+} {
 	const used = new Set<string>();
 	const optionsWithIds: Array<{ id: string; text: string }> = [];
 	const legacyIdMap = new Map<string, string>();
@@ -389,6 +395,7 @@ function convertQuestionType(type: string): string {
 
 function computeSearchText(input: {
 	stem: string;
+	rationale?: string | null;
 	explanation?: string | null;
 	type: string;
 	status: string;
@@ -399,7 +406,8 @@ function computeSearchText(input: {
 }): string {
 	const parts: Array<string> = [];
 	parts.push(input.stem || '');
-	if (input.explanation) parts.push(input.explanation);
+	const rationale = getRationale(input);
+	if (rationale) parts.push(rationale);
 	parts.push(convertQuestionType(input.type));
 	parts.push((input.status || '').toLowerCase());
 	parts.push(input.aiGenerated ? 'ai' : 'user');
@@ -413,6 +421,13 @@ function computeSearchText(input: {
 		if (g.customPromptUsed) parts.push('custom');
 	}
 	return parts.join(' ').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function normalizeIncomingRationale(input: {
+	rationale?: string | null;
+	explanation?: string | null;
+}): string {
+	return getRationale(input).trim();
 }
 
 export const getQuestionsByModule = authQuery({
@@ -461,7 +476,8 @@ export const insertQuestion = authCuratorMutation({
 		stem: v.string(),
 		options: v.array(v.object({ text: v.string() })),
 		correctAnswers: v.array(v.string()),
-		explanation: v.string(),
+		rationale: v.optional(v.string()),
+		explanation: v.optional(v.string()),
 		aiGenerated: v.boolean(),
 		status: v.string(),
 		order: v.number(),
@@ -484,6 +500,10 @@ export const insertQuestion = authCuratorMutation({
 	},
 	handler: async (ctx, args) => {
 		await checkModuleCapacity(ctx, args.moduleId, 1);
+		const rationale = normalizeIncomingRationale(args);
+		if (!rationale) {
+			throw new Error('Question rationale is required');
+		}
 
 		const { optionsWithIds } = assignOptionIds(args.options);
 
@@ -502,7 +522,7 @@ export const insertQuestion = authCuratorMutation({
 
 		const searchText = computeSearchText({
 			stem: args.stem,
-			explanation: args.explanation,
+			rationale,
 			type: args.type,
 			status: args.status,
 			aiGenerated: args.aiGenerated,
@@ -513,6 +533,7 @@ export const insertQuestion = authCuratorMutation({
 
 		const id = await ctx.db.insert('question', {
 			...args,
+			rationale,
 			type: convertQuestionType(args.type),
 			status: args.status.toLowerCase(),
 			options: optionsWithIds,
@@ -591,13 +612,18 @@ export const updateQuestion = authCuratorMutation({
 		stem: v.string(),
 		options: v.array(v.object({ text: v.string(), id: v.optional(v.string()) })),
 		correctAnswers: v.array(v.string()),
-		explanation: v.string(),
+		rationale: v.optional(v.string()),
+		explanation: v.optional(v.string()),
 		status: v.string()
 	},
 	handler: async (ctx, args) => {
 		const questionToUpdate = await ctx.db.get(args.questionId);
 		if (!questionToUpdate || questionToUpdate.moduleId !== args.moduleId) {
 			throw new Error('Question not found or access denied');
+		}
+		const rationale = normalizeIncomingRationale(args);
+		if (!rationale) {
+			throw new Error('Question rationale is required');
 		}
 
 		const isMatching = convertQuestionType(args.type) === 'matching';
@@ -636,7 +662,7 @@ export const updateQuestion = authCuratorMutation({
 
 		const searchText = computeSearchText({
 			stem: args.stem,
-			explanation: args.explanation,
+			rationale,
 			type: args.type,
 			status: args.status,
 			aiGenerated: questionToUpdate.aiGenerated,
@@ -650,7 +676,7 @@ export const updateQuestion = authCuratorMutation({
 			stem: args.stem,
 			options: optionsWithIds,
 			correctAnswers: correctAnswerIds,
-			explanation: args.explanation,
+			rationale,
 			status: args.status.toLowerCase(),
 			updatedAt: Date.now(),
 			searchText
@@ -667,7 +693,8 @@ export const createQuestion = authCuratorMutation({
 		stem: v.string(),
 		options: v.array(v.object({ id: v.string(), text: v.string() })),
 		correctAnswers: v.array(v.string()),
-		explanation: v.string(),
+		rationale: v.optional(v.string()),
+		explanation: v.optional(v.string()),
 		aiGenerated: v.boolean(),
 		status: v.string(),
 		order: v.number(),
@@ -684,6 +711,10 @@ export const createQuestion = authCuratorMutation({
 	},
 	handler: async (ctx, args) => {
 		await checkModuleCapacity(ctx, args.moduleId, 1);
+		const rationale = normalizeIncomingRationale(args);
+		if (!rationale) {
+			throw new Error('Question rationale is required');
+		}
 
 		const identity = await ctx.auth.getUserIdentity();
 		const createdBy =
@@ -709,7 +740,7 @@ export const createQuestion = authCuratorMutation({
 
 		const searchText = computeSearchText({
 			stem: args.stem,
-			explanation: args.explanation,
+			rationale,
 			type: args.type,
 			status: args.status,
 			aiGenerated: args.aiGenerated,
@@ -719,6 +750,7 @@ export const createQuestion = authCuratorMutation({
 		});
 		const id = await ctx.db.insert('question', {
 			...args,
+			rationale,
 			options: optionsWithIds,
 			correctAnswers: normalizedCorrectAnswers,
 			searchText,
@@ -739,7 +771,8 @@ export const bulkInsertQuestions = authCuratorMutation({
 				stem: v.string(),
 				options: v.array(v.object({ text: v.string() })),
 				correctAnswers: v.array(v.string()),
-				explanation: v.string(),
+				rationale: v.optional(v.string()),
+				explanation: v.optional(v.string()),
 				aiGenerated: v.boolean(),
 				status: v.string(),
 				order: v.number(),
@@ -762,6 +795,10 @@ export const bulkInsertQuestions = authCuratorMutation({
 		const insertedIds: string[] = [];
 
 		for (const q of questions) {
+			const rationale = normalizeIncomingRationale(q);
+			if (!rationale) {
+				throw new Error('Each imported question must include a rationale');
+			}
 			const isMatching = convertQuestionType(q.type) === 'matching';
 			if (isMatching) {
 				const hasPairs = (q.correctAnswers || []).every((s) => String(s).includes('::'));
@@ -782,7 +819,7 @@ export const bulkInsertQuestions = authCuratorMutation({
 				stem: q.stem,
 				options: optionsWithIds,
 				correctAnswers: correctAnswerIds,
-				explanation: q.explanation,
+				rationale,
 				aiGenerated: q.aiGenerated,
 				status: q.status.toLowerCase(),
 				order: q.order,
@@ -790,7 +827,7 @@ export const bulkInsertQuestions = authCuratorMutation({
 				updatedAt: q.updatedAt,
 				searchText: computeSearchText({
 					stem: q.stem,
-					explanation: q.explanation,
+					rationale,
 					type: q.type,
 					status: q.status,
 					aiGenerated: q.aiGenerated,
@@ -930,8 +967,16 @@ export const duplicateQuestion = authCuratorMutation({
 		const { optionsWithIds, legacyIdMap } = assignFreshOptionIds(original.options || []);
 		const normalizedCorrectAnswers =
 			convertQuestionType(original.type) === 'matching'
-				? normalizeMatchingCorrectAnswers(original.correctAnswers || [], optionsWithIds, legacyIdMap)
-				: normalizeStandardCorrectAnswers(original.correctAnswers || [], optionsWithIds, legacyIdMap);
+				? normalizeMatchingCorrectAnswers(
+						original.correctAnswers || [],
+						optionsWithIds,
+						legacyIdMap
+					)
+				: normalizeStandardCorrectAnswers(
+						original.correctAnswers || [],
+						optionsWithIds,
+						legacyIdMap
+					);
 
 		const id = await ctx.db.insert('question', {
 			moduleId: original.moduleId,
@@ -939,7 +984,7 @@ export const duplicateQuestion = authCuratorMutation({
 			stem: original.stem,
 			options: optionsWithIds,
 			correctAnswers: normalizedCorrectAnswers,
-			explanation: original.explanation,
+			rationale: getRationale(original),
 			aiGenerated: original.aiGenerated,
 			status: original.status,
 			order: nextOrder,
@@ -947,7 +992,7 @@ export const duplicateQuestion = authCuratorMutation({
 			updatedAt: Date.now(),
 			searchText: computeSearchText({
 				stem: original.stem,
-				explanation: original.explanation,
+				rationale: getRationale(original),
 				type: original.type,
 				status: original.status,
 				aiGenerated: original.aiGenerated,
@@ -986,8 +1031,16 @@ export const duplicateQuestionMany = authCuratorMutation({
 			const { optionsWithIds, legacyIdMap } = assignFreshOptionIds(original.options || []);
 			const normalizedCorrectAnswers =
 				convertQuestionType(original.type) === 'matching'
-					? normalizeMatchingCorrectAnswers(original.correctAnswers || [], optionsWithIds, legacyIdMap)
-					: normalizeStandardCorrectAnswers(original.correctAnswers || [], optionsWithIds, legacyIdMap);
+					? normalizeMatchingCorrectAnswers(
+							original.correctAnswers || [],
+							optionsWithIds,
+							legacyIdMap
+						)
+					: normalizeStandardCorrectAnswers(
+							original.correctAnswers || [],
+							optionsWithIds,
+							legacyIdMap
+						);
 
 			const id = await ctx.db.insert('question', {
 				moduleId: original.moduleId,
@@ -995,7 +1048,7 @@ export const duplicateQuestionMany = authCuratorMutation({
 				stem: original.stem,
 				options: optionsWithIds,
 				correctAnswers: normalizedCorrectAnswers,
-				explanation: original.explanation,
+				rationale: getRationale(original),
 				aiGenerated: original.aiGenerated,
 				status: original.status,
 				order: nextOrder + i,
@@ -1003,7 +1056,7 @@ export const duplicateQuestionMany = authCuratorMutation({
 				updatedAt: Date.now(),
 				searchText: computeSearchText({
 					stem: original.stem,
-					explanation: original.explanation,
+					rationale: getRationale(original),
 					type: original.type,
 					status: original.status,
 					aiGenerated: original.aiGenerated,
@@ -1082,7 +1135,7 @@ export const backfillQuestionSearchTextForModule = mutation({
 		for (const q of items) {
 			const searchText = computeSearchText({
 				stem: q.stem,
-				explanation: q.explanation ?? '',
+				rationale: getRationale(q),
 				type: q.type,
 				status: q.status,
 				aiGenerated: q.aiGenerated,
@@ -1112,7 +1165,7 @@ export const backfillSearchTextForAllModules = mutation({
 			for (const q of items) {
 				const searchText = computeSearchText({
 					stem: q.stem,
-					explanation: q.explanation ?? '',
+					rationale: getRationale(q),
 					type: q.type,
 					status: q.status,
 					aiGenerated: q.aiGenerated,
@@ -1127,6 +1180,49 @@ export const backfillSearchTextForAllModules = mutation({
 			}
 		}
 		return { updated: totalUpdated };
+	}
+});
+
+export const backfillQuestionRationales = mutation({
+	args: {
+		batchSize: v.optional(v.number()),
+		cursor: v.optional(v.string())
+	},
+	handler: async (ctx, args) => {
+		const {
+			page: questions,
+			isDone,
+			continueCursor
+		} = await ctx.db
+			.query('question')
+			.paginate({ cursor: args.cursor ?? null, numItems: args.batchSize ?? 200 });
+
+		let updated = 0;
+		for (const question of questions) {
+			const rationale = getRationale(question).trim();
+			if (!rationale || question.rationale === rationale) continue;
+			await ctx.db.patch(question._id, {
+				rationale,
+				searchText: computeSearchText({
+					stem: question.stem,
+					rationale,
+					type: question.type,
+					status: question.status,
+					aiGenerated: question.aiGenerated,
+					options: question.options,
+					correctAnswers: question.correctAnswers,
+					metadata: question.metadata
+				}),
+				updatedAt: Date.now()
+			});
+			updated += 1;
+		}
+
+		return {
+			updated,
+			done: isDone,
+			cursor: continueCursor
+		};
 	}
 });
 
@@ -1156,7 +1252,7 @@ export const repairMatchingPairsForModule = authCuratorMutation({
 
 			const searchText = computeSearchText({
 				stem: q.stem,
-				explanation: q.explanation ?? '',
+				rationale: getRationale(q),
 				type: q.type,
 				status: q.status,
 				aiGenerated: q.aiGenerated,
@@ -1222,9 +1318,9 @@ Instructions:
 - When generating questions with multiple correct answers, never indicate to select all that apply. Do not use ("Select 3, Select all that apply, etc").
 ${domainHint}
 - Do NOT include any references to the material or meta-instructions.
-- Stems and explanations must be self-contained and must not mention or quote the source material.
-- Do not use phrases like: "the material", "the text", "the passage", "the document", "the slides", "the notes", "according to", "as stated", "as mentioned" in either the question, the options or the explanations.
-- Explanations must justify the correct answer and why distractors are incorrect without referencing the source.
+- Stems and rationales must be self-contained and must not mention or quote the source material.
+- Do not use phrases like: "the material", "the text", "the passage", "the document", "the slides", "the notes", "according to", "as stated", "as mentioned" in either the question, the options or the rationales.
+- Rationales must justify the correct answer and why distractors are incorrect without referencing the source.
 - Options must be plain strings with NO leading letters, numbers, or punctuation (no prefixes like "A.", "1)", or "-").
 ${extra ? `\nAdditional guidance:\n${extra}\n` : ''}
 
@@ -1247,10 +1343,10 @@ ${material}`;
 							stem: { type: Type.STRING },
 							options: { type: Type.ARRAY, minItems: 3, maxItems: 6, items: { type: Type.STRING } },
 							correctAnswerIndexes: { type: Type.ARRAY, minItems: 1, items: { type: Type.NUMBER } },
-							explanation: { type: Type.STRING }
+							rationale: { type: Type.STRING }
 						},
-						required: ['stem', 'options', 'correctAnswerIndexes', 'explanation'],
-						propertyOrdering: ['stem', 'options', 'correctAnswerIndexes', 'explanation']
+						required: ['stem', 'options', 'correctAnswerIndexes', 'rationale'],
+						propertyOrdering: ['stem', 'options', 'correctAnswerIndexes', 'rationale']
 					}
 				}
 				// Using default HIGH thinking level for better question quality
@@ -1267,7 +1363,8 @@ ${material}`;
 			stem: string;
 			options: string[];
 			correctAnswerIndexes: number[];
-			explanation: string;
+			rationale?: string;
+			explanation?: string;
 		}>;
 		try {
 			parsed = JSON.parse(responseText.trim());
@@ -1297,8 +1394,8 @@ ${material}`;
 			if (!Array.isArray(q.correctAnswerIndexes) || q.correctAnswerIndexes.length === 0) {
 				throw new Error(`Question ${i + 1} missing correct answer indexes`);
 			}
-			if (!q.explanation || typeof q.explanation !== 'string') {
-				throw new Error(`Question ${i + 1} missing or invalid explanation`);
+			if (!getRationale(q)) {
+				throw new Error(`Question ${i + 1} missing or invalid rationale`);
 			}
 		}
 
@@ -1313,7 +1410,7 @@ ${material}`;
 				stem: q.stem.trim(),
 				options,
 				correctAnswers: validIndexes,
-				explanation: typeof q.explanation === 'string' ? q.explanation.trim() : '',
+				rationale: getRationale(q).trim(),
 				aiGenerated: true,
 				status: 'published',
 				order: i,
@@ -1327,17 +1424,17 @@ ${material}`;
 });
 
 /**
- * Generate plausible distractor options and explanation from a stem and correct answer(s).
+ * Generate plausible distractor options and rationale from a stem and correct answer(s).
  * This helps educators who write their own questions but need assistance with distractors.
  */
-export const generateDistractorsAndExplanation = action({
+export const generateDistractorsAndRationale = action({
 	args: {
 		stem: v.string(),
 		correctAnswers: v.array(v.string()),
 		existingOptions: v.optional(v.array(v.string())),
 		focus: v.string(),
 		numDistractors: v.optional(v.number()),
-		existingExplanation: v.optional(v.string()),
+		existingRationale: v.optional(v.string()),
 		model: v.optional(v.string())
 	},
 	handler: async (
@@ -1348,7 +1445,7 @@ export const generateDistractorsAndExplanation = action({
 			existingOptions = [],
 			focus,
 			numDistractors = 3,
-			existingExplanation = '',
+			existingRationale = '',
 			model = 'gemini-3-flash-preview'
 		}
 	) => {
@@ -1384,15 +1481,15 @@ export const generateDistractorsAndExplanation = action({
 				? `\nExisting wrong options (match style, do not repeat): ${existingDistractors.join('; ')}`
 				: '';
 
-		const contextHint = existingExplanation.trim() ? `\nNotes: ${existingExplanation.trim()}` : '';
+		const contextHint = existingRationale.trim() ? `\nNotes: ${existingRationale.trim()}` : '';
 
-		const prompt = `${numDistractors} wrong options + explanation.${domainHint}
+		const prompt = `${numDistractors} wrong options + rationale.${domainHint}
 
 Q: ${stem}
 A: ${correctAnswers.join('; ')}${existingSection}${contextHint}
 
 Wrong options: plausible, unique, no prefixes. Match style and length of existing options and answer.
-Explanation: 2-3 sentences explaining the underlying concept. Use notes if provided. Do not reference options or say "this question".`;
+Rationale: 2-3 sentences explaining the underlying concept. Use notes if provided. Do not reference options or say "this question".`;
 
 		const result = await ai.models.generateContent({
 			model,
@@ -1411,9 +1508,9 @@ Explanation: 2-3 sentences explaining the underlying concept. Use notes if provi
 							minItems: numDistractors,
 							maxItems: numDistractors
 						},
-						explanation: { type: Type.STRING }
+						rationale: { type: Type.STRING }
 					},
-					required: ['distractors', 'explanation']
+					required: ['distractors', 'rationale']
 				}
 			}
 		});
@@ -1425,16 +1522,17 @@ Explanation: 2-3 sentences explaining the underlying concept. Use notes if provi
 
 		let parsed: {
 			distractors: string[];
-			explanation: string;
+			rationale?: string;
+			explanation?: string;
 		};
 		try {
 			parsed = JSON.parse(responseText.trim());
-			if (!Array.isArray(parsed.distractors) || typeof parsed.explanation !== 'string') {
+			if (!Array.isArray(parsed.distractors) || !getRationale(parsed)) {
 				throw new Error('Invalid response structure');
 			}
 		} catch (err) {
 			console.error('Failed to parse AI response:', err);
-			throw new Error('Failed to parse AI-generated distractors and explanation');
+			throw new Error('Failed to parse AI-generated distractors and rationale');
 		}
 
 		// Validate, clean up, and deduplicate against existing options
@@ -1450,23 +1548,26 @@ Explanation: 2-3 sentences explaining the underlying concept. Use notes if provi
 
 		return {
 			distractors: cleanedDistractors,
-			explanation: parsed.explanation.trim()
+			rationale: getRationale(parsed).trim()
 		};
 	}
 });
 
 /**
- * Generate an explanation only (for FITB questions).
+ * Generate a rationale only (for FITB questions).
  */
-export const generateExplanation = action({
+export const generateRationale = action({
 	args: {
 		stem: v.string(),
 		answer: v.string(),
 		focus: v.string(),
-		existingExplanation: v.optional(v.string()),
+		existingRationale: v.optional(v.string()),
 		model: v.optional(v.string())
 	},
-	handler: async (ctx, { stem, answer, focus, existingExplanation = '', model = 'gemini-3-flash-preview' }) => {
+	handler: async (
+		ctx,
+		{ stem, answer, focus, existingRationale = '', model = 'gemini-3-flash-preview' }
+	) => {
 		const identity = await ctx.auth.getUserIdentity();
 		if (!identity) throw new Error('Unauthenticated');
 
@@ -1490,9 +1591,9 @@ export const generateExplanation = action({
 					? ' (pharmacy context)'
 					: '';
 
-		const contextHint = existingExplanation.trim() ? `\nNotes: ${existingExplanation.trim()}` : '';
+		const contextHint = existingRationale.trim() ? `\nNotes: ${existingRationale.trim()}` : '';
 
-		const prompt = `2-3 sentence explanation of the concept.${domainHint} Use notes if provided. Do not say "this question".
+		const prompt = `2-3 sentence rationale of the concept.${domainHint} Use notes if provided. Do not say "this question".
 
 Q: ${stem}
 A: ${answer}${contextHint}`;
@@ -1508,9 +1609,9 @@ A: ${answer}${contextHint}`;
 				responseSchema: {
 					type: Type.OBJECT,
 					properties: {
-						explanation: { type: Type.STRING }
+						rationale: { type: Type.STRING }
 					},
-					required: ['explanation']
+					required: ['rationale']
 				}
 			}
 		});
@@ -1520,19 +1621,19 @@ A: ${answer}${contextHint}`;
 			throw new Error('AI response text is empty or invalid');
 		}
 
-		let parsed: { explanation: string };
+		let parsed: { rationale?: string; explanation?: string };
 		try {
 			parsed = JSON.parse(responseText.trim());
-			if (typeof parsed.explanation !== 'string') {
+			if (!getRationale(parsed)) {
 				throw new Error('Invalid response structure');
 			}
 		} catch (err) {
 			console.error('Failed to parse AI response:', err);
-			throw new Error('Failed to parse AI-generated explanation');
+			throw new Error('Failed to parse AI-generated rationale');
 		}
 
 		return {
-			explanation: parsed.explanation.trim()
+			rationale: getRationale(parsed).trim()
 		};
 	}
 });

--- a/src/convex/question.ts
+++ b/src/convex/question.ts
@@ -427,7 +427,7 @@ function normalizeIncomingRationale(input: {
 	rationale?: string | null;
 	explanation?: string | null;
 }): string {
-	return getRationale(input).trim();
+	return getRationale(input);
 }
 
 export const getQuestionsByModule = authQuery({
@@ -1199,7 +1199,7 @@ export const backfillQuestionRationales = mutation({
 
 		let updated = 0;
 		for (const question of questions) {
-			const rationale = getRationale(question).trim();
+			const rationale = getRationale(question);
 			if (!rationale || question.rationale === rationale) continue;
 			await ctx.db.patch(question._id, {
 				rationale,
@@ -1410,7 +1410,7 @@ ${material}`;
 				stem: q.stem.trim(),
 				options,
 				correctAnswers: validIndexes,
-				rationale: getRationale(q).trim(),
+				rationale: getRationale(q),
 				aiGenerated: true,
 				status: 'published',
 				order: i,
@@ -1548,7 +1548,7 @@ Rationale: 2-3 sentences explaining the underlying concept. Use notes if provide
 
 		return {
 			distractors: cleanedDistractors,
-			rationale: getRationale(parsed).trim()
+			rationale: getRationale(parsed)
 		};
 	}
 });
@@ -1633,7 +1633,7 @@ A: ${answer}${contextHint}`;
 		}
 
 		return {
-			rationale: getRationale(parsed).trim()
+			rationale: getRationale(parsed)
 		};
 	}
 });

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -172,6 +172,8 @@ export default defineSchema({
 		stem: v.string(),
 		options: v.array(v.object({ id: v.string(), text: v.string() })),
 		correctAnswers: v.array(v.string()),
+		rationale: v.optional(v.string()),
+		// DEPRECATED: retained temporarily for legacy question records
 		explanation: v.optional(v.string()),
 		aiGenerated: v.boolean(),
 		createdBy: v.optional(
@@ -353,11 +355,7 @@ export default defineSchema({
 			moduleIds: v.array(v.id('module')),
 			questionCountRequested: v.number(),
 			questionCountActual: v.number(),
-			sourceFilter: v.union(
-				v.literal('all'),
-				v.literal('flagged'),
-				v.literal('incomplete')
-			),
+			sourceFilter: v.union(v.literal('all'), v.literal('flagged'), v.literal('incomplete')),
 			questionTypes: v.optional(v.array(v.string())),
 			shuffleQuestions: v.boolean(),
 			shuffleOptions: v.boolean(),
@@ -431,6 +429,8 @@ export default defineSchema({
 			stem: v.string(),
 			options: v.array(v.object({ id: v.string(), text: v.string() })),
 			correctAnswers: v.array(v.string()),
+			rationale: v.optional(v.string()),
+			// DEPRECATED: retained temporarily for legacy attempt snapshots
 			explanation: v.optional(v.string()),
 			questionUpdatedAt: v.number()
 		}),

--- a/src/lib/admin/EditDocumentChunks.svelte
+++ b/src/lib/admin/EditDocumentChunks.svelte
@@ -8,6 +8,7 @@
 	import DeleteConfirmationModal from './DeleteConfirmationModal.svelte';
 	import { createUploader } from '$lib/utils/uploadthing';
 	import { UploadDropzone } from '@uploadthing/svelte';
+	import { replaceState } from '$app/navigation';
 
 	const client = useConvexClient();
 
@@ -24,9 +25,7 @@
 	const isProcessing = $derived(
 		getJob.data?.status === 'pending' || getJob.data?.status === 'processing'
 	);
-	const processingError = $derived(
-		getJob.data?.status === 'failed' ? getJob.data.error : ''
-	);
+	const processingError = $derived(getJob.data?.status === 'failed' ? getJob.data.error : '');
 	const processingStatus = $derived(getJob.data?.progress?.currentStep ?? '');
 	const chunksReceived = $derived(getJob.data?.progress?.chunksProcessed ?? 0);
 	const totalChunks = $derived(getJob.data?.progress?.totalChunks ?? 0);
@@ -163,17 +162,20 @@
 		const fileKey = params.get('fileKey');
 
 		if (shouldProcess && pdfUrl && !getJob.data) {
-			client.mutation(api.pdfJobs.createJob, {
-				documentId: currentDocView as Id<'contentLib'>,
-				pdfUrl,
-				fileKey: fileKey || undefined
-			}).then(() => {
-				params.delete('processing');
-				params.delete('pdfUrl');
-				params.delete('fileKey');
-				const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-				history.replaceState({}, '', newUrl);
-			}).catch(console.error);
+			client
+				.mutation(api.pdfJobs.createJob, {
+					documentId: currentDocView as Id<'contentLib'>,
+					pdfUrl,
+					fileKey: fileKey || undefined
+				})
+				.then(() => {
+					params.delete('processing');
+					params.delete('pdfUrl');
+					params.delete('fileKey');
+					const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+					replaceState(newUrl, {});
+				})
+				.catch(console.error);
 		}
 	});
 </script>
@@ -225,11 +227,7 @@
 		<div class="mt-6 mb-4" in:fade={{ duration: 150 }}>
 			<div class="alert alert-error">
 				<span>{processingError}</span>
-				<button
-					class="btn btn-sm btn-ghost gap-2"
-					onclick={retryFailedJob}
-					disabled={isRetrying}
-				>
+				<button class="btn btn-sm btn-ghost gap-2" onclick={retryFailedJob} disabled={isRetrying}>
 					{#if isRetrying}
 						<span class="loading loading-spinner loading-xs"></span>
 					{:else}
@@ -534,8 +532,14 @@
 
 		<div class="modal-action mt-8">
 			<form method="dialog" class="flex gap-3">
-				<button class="btn btn-ghost rounded-full" onclick={closeEdit} disabled={isSubmitting}>Cancel</button>
-				<button class="btn btn-primary rounded-full gap-2" onclick={saveEdit} disabled={isSubmitting}>
+				<button class="btn btn-ghost rounded-full" onclick={closeEdit} disabled={isSubmitting}
+					>Cancel</button
+				>
+				<button
+					class="btn btn-primary rounded-full gap-2"
+					onclick={saveEdit}
+					disabled={isSubmitting}
+				>
 					{#if isSubmitting}
 						<span class="loading loading-spinner loading-sm"></span>
 						<span>Saving...</span>

--- a/src/lib/admin/EditDocumentChunks.svelte
+++ b/src/lib/admin/EditDocumentChunks.svelte
@@ -9,6 +9,7 @@
 	import { createUploader } from '$lib/utils/uploadthing';
 	import { UploadDropzone } from '@uploadthing/svelte';
 	import { replaceState } from '$app/navigation';
+	import { resolve } from '$app/paths';
 
 	const client = useConvexClient();
 
@@ -172,7 +173,7 @@
 					params.delete('processing');
 					params.delete('pdfUrl');
 					params.delete('fileKey');
-					const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+					const newUrl = `${resolve('/admin/library')}${params.toString() ? `?${params.toString()}` : ''}`;
 					replaceState(newUrl, {});
 				})
 				.catch(console.error);

--- a/src/lib/admin/QuestionDetailView.svelte
+++ b/src/lib/admin/QuestionDetailView.svelte
@@ -11,6 +11,7 @@
 	} from 'lucide-svelte';
 	import { convertToDisplayFormat } from '$lib/utils/questionType.js';
 	import { getRationale, hasRationale } from '$lib/utils/rationale';
+	import { sanitizeHtml } from '$lib/utils/sanitizeHtml';
 	import type { Doc } from '../../convex/_generated/dataModel';
 
 	type QuestionItem = Doc<'question'>;
@@ -56,7 +57,7 @@
 	const isFillInTheBlank = $derived(question.type === 'fill_in_the_blank');
 	const isMatching = $derived(question.type === 'matching');
 	const isMultipleChoice = $derived(!isFillInTheBlank && !isMatching);
-	const questionRationale = $derived(getRationale(question));
+	const questionRationale = $derived(sanitizeHtml(getRationale(question)));
 
 	// FITB helpers
 	function decodeFitbAnswer(text: string): string {

--- a/src/lib/admin/QuestionDetailView.svelte
+++ b/src/lib/admin/QuestionDetailView.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
-	import { Pencil, Trash2, Copy, CopyPlus, ArrowRightLeft, Paperclip, Check, MoreVertical } from 'lucide-svelte';
+	import {
+		Pencil,
+		Trash2,
+		Copy,
+		CopyPlus,
+		ArrowRightLeft,
+		Paperclip,
+		Check,
+		MoreVertical
+	} from 'lucide-svelte';
 	import { convertToDisplayFormat } from '$lib/utils/questionType.js';
+	import { getRationale, hasRationale } from '$lib/utils/rationale';
 	import type { Doc } from '../../convex/_generated/dataModel';
 
 	type QuestionItem = Doc<'question'>;
@@ -46,6 +56,7 @@
 	const isFillInTheBlank = $derived(question.type === 'fill_in_the_blank');
 	const isMatching = $derived(question.type === 'matching');
 	const isMultipleChoice = $derived(!isFillInTheBlank && !isMatching);
+	const questionRationale = $derived(getRationale(question));
 
 	// FITB helpers
 	function decodeFitbAnswer(text: string): string {
@@ -64,10 +75,12 @@
 		if (!isFillInTheBlank) return [];
 		const answers = (question.correctAnswers || []) as string[];
 		const opts = (question.options || []) as Option[];
-		return answers.map((a) => {
-			const fromOption = opts.find((o) => o.id === a)?.text;
-			return decodeFitbAnswer(String(fromOption ?? a ?? ''));
-		}).filter((t) => t.length > 0);
+		return answers
+			.map((a) => {
+				const fromOption = opts.find((o) => o.id === a)?.text;
+				return decodeFitbAnswer(String(fromOption ?? a ?? ''));
+			})
+			.filter((t) => t.length > 0);
 	});
 
 	// Matching helpers
@@ -131,7 +144,11 @@
 
 <div class="h-full flex flex-col overflow-hidden">
 	<!-- Header -->
-	<div class="flex items-center justify-between p-4 border-b border-base-300 {isMobile ? 'sticky top-0 z-10 bg-base-100' : ''}">
+	<div
+		class="flex items-center justify-between p-4 border-b border-base-300 {isMobile
+			? 'sticky top-0 z-10 bg-base-100'
+			: ''}"
+	>
 		<div class="flex items-center {isMobile ? 'gap-2' : 'gap-3'}">
 			{#if questionIndex >= 0}
 				<span class="text-sm font-medium whitespace-nowrap">Question #{questionIndex + 1}</span>
@@ -139,8 +156,16 @@
 				<span class="text-sm font-medium whitespace-nowrap">Question #—</span>
 			{/if}
 			<div class="flex flex-wrap items-center gap-1">
-				<span class="badge badge-xs badge-ghost text-xs">{convertToDisplayFormat(question.type)}</span>
-				<span class="badge badge-xs {question.status === 'published' ? 'badge-success' : question.status === 'draft' ? 'badge-warning' : 'badge-neutral'}">{question.status}</span>
+				<span class="badge badge-xs badge-ghost text-xs"
+					>{convertToDisplayFormat(question.type)}</span
+				>
+				<span
+					class="badge badge-xs {question.status === 'published'
+						? 'badge-success'
+						: question.status === 'draft'
+							? 'badge-warning'
+							: 'badge-neutral'}">{question.status}</span
+				>
 			</div>
 		</div>
 		{#if canEdit}
@@ -167,10 +192,18 @@
 						<div class="dropdown dropdown-end">
 							<button tabindex="0" class="btn btn-sm btn-ghost btn-circle">
 								<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M19 9l-7 7-7-7"
+									></path>
 								</svg>
 							</button>
-							<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-2xl z-20 w-44 p-1 shadow-lg border border-base-300">
+							<ul
+								tabindex="0"
+								class="dropdown-content menu bg-base-100 rounded-2xl z-20 w-44 p-1 shadow-lg border border-base-300"
+							>
 								<li>
 									<button class="text-sm gap-2 rounded-xl" onclick={onDuplicateMany}>
 										<CopyPlus size={14} />
@@ -194,13 +227,25 @@
 	<div class="flex-1 overflow-y-auto {isMobile ? 'p-4' : 'p-6 pb-12'} min-h-0">
 		<!-- Question Stem -->
 		<div class={isMobile ? 'mb-6' : 'mb-8'}>
-			<div class="{isMobile ? 'text-base' : 'text-lg'} font-medium text-base-content leading-relaxed tiptap-content">{@html question.stem}</div>
+			<div
+				class="{isMobile
+					? 'text-base'
+					: 'text-lg'} font-medium text-base-content leading-relaxed tiptap-content"
+			>
+				{@html question.stem}
+			</div>
 		</div>
 
 		<!-- Fill in the Blank -->
 		{#if isFillInTheBlank}
 			<div class={isMobile ? 'mb-4' : 'mb-6'}>
-				<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 {isMobile ? 'mb-2' : 'mb-3'}">Accepted Answers</div>
+				<div
+					class="text-xs font-semibold uppercase tracking-wide text-base-content/60 {isMobile
+						? 'mb-2'
+						: 'mb-3'}"
+				>
+					Accepted Answers
+				</div>
 				<div class="card bg-base-100 border border-base-300 shadow-sm rounded-3xl">
 					<div class="card-body {isMobile ? 'p-3' : 'p-4'}">
 						{#if fitbAnswers.length > 0}
@@ -209,7 +254,9 @@
 									<Check size={12} />
 									Primary
 								</div>
-								<span class="{isMobile ? 'text-base' : 'text-lg'} font-semibold">{fitbAnswers[0]}</span>
+								<span class="{isMobile ? 'text-base' : 'text-lg'} font-semibold"
+									>{fitbAnswers[0]}</span
+								>
 							</div>
 							{#if fitbAnswers.length > 1}
 								<div class="mt-3 pt-3 border-t border-base-200">
@@ -231,36 +278,70 @@
 				</div>
 			</div>
 
-		<!-- Matching -->
+			<!-- Matching -->
 		{:else if isMatching}
 			<div class={isMobile ? 'mb-4' : 'mb-6'}>
-				<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 {isMobile ? 'mb-2' : 'mb-3'}">Matching Pairs</div>
+				<div
+					class="text-xs font-semibold uppercase tracking-wide text-base-content/60 {isMobile
+						? 'mb-2'
+						: 'mb-3'}"
+				>
+					Matching Pairs
+				</div>
 				<div class={isMobile ? 'space-y-2' : 'space-y-3'}>
 					{#each matchingPrompts as prompt (prompt.id)}
 						{@const correctAnswer = getCorrectAnswerForPrompt(prompt.id)}
 						<div class="flex items-center {isMobile ? 'gap-2' : 'gap-3'}">
 							<!-- Prompt -->
 							<div class="flex-1">
-								<div class="rounded-3xl border-2 border-base-300 bg-base-200 {isMobile ? 'px-4 py-2' : 'px-5 py-3'}">
-									<span class="font-semibold {isMobile ? 'text-xs' : 'text-sm'} tiptap-content">{@html getPromptLabel(prompt.text)}</span>
+								<div
+									class="rounded-3xl border-2 border-base-300 bg-base-200 {isMobile
+										? 'px-4 py-2'
+										: 'px-5 py-3'}"
+								>
+									<span class="font-semibold {isMobile ? 'text-xs' : 'text-sm'} tiptap-content"
+										>{@html getPromptLabel(prompt.text)}</span
+									>
 								</div>
 							</div>
 							<!-- Arrow -->
 							<div class="text-base-content/40 flex-shrink-0">
-								<svg class={isMobile ? 'w-4 h-4' : 'w-5 h-5'} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+								<svg
+									class={isMobile ? 'w-4 h-4' : 'w-5 h-5'}
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M13 7l5 5m0 0l-5 5m5-5H6"
+									/>
 								</svg>
 							</div>
 							<!-- Answer -->
 							<div class="flex-1">
 								{#if correctAnswer}
-									<div class="rounded-3xl border-2 border-success bg-success/10 {isMobile ? 'px-4 py-2' : 'px-5 py-3'} flex items-center gap-2">
+									<div
+										class="rounded-3xl border-2 border-success bg-success/10 {isMobile
+											? 'px-4 py-2'
+											: 'px-5 py-3'} flex items-center gap-2"
+									>
 										<Check size={isMobile ? 14 : 16} class="text-success flex-shrink-0" />
-										<span class="{isMobile ? 'text-xs' : 'text-sm'} tiptap-content">{@html correctAnswer}</span>
+										<span class="{isMobile ? 'text-xs' : 'text-sm'} tiptap-content"
+											>{@html correctAnswer}</span
+										>
 									</div>
 								{:else}
-									<div class="rounded-3xl border-2 border-dashed border-base-300 bg-base-100 {isMobile ? 'px-4 py-2' : 'px-5 py-3'}">
-										<span class="{isMobile ? 'text-xs' : 'text-sm'} text-base-content/40 italic">No match defined</span>
+									<div
+										class="rounded-3xl border-2 border-dashed border-base-300 bg-base-100 {isMobile
+											? 'px-4 py-2'
+											: 'px-5 py-3'}"
+									>
+										<span class="{isMobile ? 'text-xs' : 'text-sm'} text-base-content/40 italic"
+											>No match defined</span
+										>
 									</div>
 								{/if}
 							</div>
@@ -270,7 +351,9 @@
 
 				{#if matchingAnswers.length > matchingPrompts.length}
 					<div class="mt-4 pt-4 border-t border-base-200">
-						<p class="text-xs text-base-content/50 mb-2">Available answers ({matchingAnswers.length}):</p>
+						<p class="text-xs text-base-content/50 mb-2">
+							Available answers ({matchingAnswers.length}):
+						</p>
 						<div class="flex flex-wrap gap-2">
 							{#each matchingAnswers as answer (answer.id)}
 								<span class="badge badge-outline badge-sm">{getAnswerLabel(answer.text)}</span>
@@ -280,25 +363,49 @@
 				{/if}
 			</div>
 
-		<!-- Multiple Choice / Multiple Select -->
+			<!-- Multiple Choice / Multiple Select -->
 		{:else if isMultipleChoice && question.options?.length}
 			<div class={isMobile ? 'mb-4' : 'mb-6'}>
-				<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 {isMobile ? 'mb-2' : 'mb-3'}">Options</div>
+				<div
+					class="text-xs font-semibold uppercase tracking-wide text-base-content/60 {isMobile
+						? 'mb-2'
+						: 'mb-3'}"
+				>
+					Options
+				</div>
 				<div class={isMobile ? 'space-y-2' : 'space-y-3'}>
 					{#each question.options as option, optIndex (option.id)}
-						<label class="label cursor-pointer rounded-full flex items-center {isMobile ? 'border p-1.5' : 'border-2 p-2'} transition-colors {question.correctAnswers.includes(option.id) ? 'border-success bg-success/5' : 'border-base-300 bg-base-200'}">
+						<label
+							class="label cursor-pointer rounded-full flex items-center {isMobile
+								? 'border p-1.5'
+								: 'border-2 p-2'} transition-colors {question.correctAnswers.includes(option.id)
+								? 'border-success bg-success/5'
+								: 'border-base-300 bg-base-200'}"
+						>
 							<input
 								type="checkbox"
-								class="checkbox checkbox-primary {isMobile ? 'checkbox-xs ms-2' : 'checkbox-sm ms-3'}"
+								class="checkbox checkbox-primary {isMobile
+									? 'checkbox-xs ms-2'
+									: 'checkbox-sm ms-3'}"
 								checked={question.correctAnswers.includes(option.id)}
 								disabled
 							/>
-							<span class="flex-grow text-wrap break-words {isMobile ? 'ml-2 text-xs' : 'ml-4 text-sm'} my-2">
-								<span class="font-semibold mr-2 select-none">{String.fromCharCode(65 + optIndex)}.</span>
+							<span
+								class="flex-grow text-wrap break-words {isMobile
+									? 'ml-2 text-xs'
+									: 'ml-4 text-sm'} my-2"
+							>
+								<span class="font-semibold mr-2 select-none"
+									>{String.fromCharCode(65 + optIndex)}.</span
+								>
 								<span class="tiptap-content">{@html option.text}</span>
 							</span>
 							{#if question.correctAnswers.includes(option.id)}
-								<span class="text-success text-xs font-medium {isMobile ? 'mr-3' : 'mr-4'} flex-shrink-0">{isMobile ? '✓' : '✓ Correct'}</span>
+								<span
+									class="text-success text-xs font-medium {isMobile
+										? 'mr-3'
+										: 'mr-4'} flex-shrink-0">{isMobile ? '✓' : '✓ Correct'}</span
+								>
 							{/if}
 						</label>
 					{/each}
@@ -306,20 +413,32 @@
 			</div>
 		{/if}
 
-		<!-- Explanation -->
-			{#if question.explanation}
-				<div class={isMobile ? 'mb-4' : 'mb-6'}>
-					<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60" class:mb-2={isMobile} class:mb-3={!isMobile}>Explanation</div>
-					<div class="rounded-2xl border border-base-300 bg-base-200/30" class:p-3={isMobile} class:p-4={!isMobile}>
-						<div class="text-sm text-base-content/80 tiptap-content">{@html question.explanation}</div>
-					</div>
+		<!-- Rationale -->
+		{#if hasRationale(question)}
+			<div class={isMobile ? 'mb-4' : 'mb-6'}>
+				<div
+					class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+					class:mb-2={isMobile}
+					class:mb-3={!isMobile}
+				>
+					Rationale
 				</div>
+				<div
+					class="rounded-2xl border border-base-300 bg-base-200/30"
+					class:p-3={isMobile}
+					class:p-4={!isMobile}
+				>
+					<div class="text-sm text-base-content/80 tiptap-content">{@html questionRationale}</div>
+				</div>
+			</div>
 		{/if}
 
 		<!-- Attachments (desktop only) -->
 		{#if !isMobile && media && media.length > 0}
 			<div class="mb-6">
-				<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-3 flex items-center gap-2">
+				<div
+					class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-3 flex items-center gap-2"
+				>
 					<Paperclip size={14} />
 					Attachments ({media.length})
 				</div>
@@ -336,9 +455,13 @@
 									alt={attachment.altText}
 									class="w-full h-28 object-cover group-hover:brightness-110 group-hover:scale-105 transition-all duration-200"
 								/>
-								<div class="absolute inset-0 bg-primary/0 group-hover:bg-primary/10 transition-colors duration-200"></div>
+								<div
+									class="absolute inset-0 bg-primary/0 group-hover:bg-primary/10 transition-colors duration-200"
+								></div>
 								{#if attachment.caption}
-									<div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-2">
+									<div
+										class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-2"
+									>
 										<p class="text-white text-xs truncate">{attachment.caption}</p>
 									</div>
 								{/if}
@@ -355,23 +478,39 @@
 				{#if question.createdBy}
 					<span class="flex items-center gap-1.5">
 						<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+							/>
 						</svg>
-						{question.createdBy.firstName} {question.createdBy.lastName}
+						{question.createdBy.firstName}
+						{question.createdBy.lastName}
 					</span>
 				{:else if question.aiGenerated}
 					<span>AI generated</span>
 				{/if}
 				{#if question._creationTime}
 					<span class="flex items-center gap-1">
-						{#if question.createdBy || question.aiGenerated}<span class="text-base-content/25">&middot;</span>{/if}
-						Created {new Date(question._creationTime).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+						{#if question.createdBy || question.aiGenerated}<span class="text-base-content/25"
+								>&middot;</span
+							>{/if}
+						Created {new Date(question._creationTime).toLocaleDateString('en-US', {
+							month: 'short',
+							day: 'numeric',
+							year: 'numeric'
+						})}
 					</span>
 				{/if}
 				{#if question.updatedAt && question._creationTime && question.updatedAt - question._creationTime > 60_000}
 					<span class="flex items-center gap-1">
 						<span class="text-base-content/25">&middot;</span>
-						Updated {new Date(question.updatedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+						Updated {new Date(question.updatedAt).toLocaleDateString('en-US', {
+							month: 'short',
+							day: 'numeric',
+							year: 'numeric'
+						})}
 					</span>
 				{/if}
 			</div>

--- a/src/lib/admin/QuestionEditorInline.svelte
+++ b/src/lib/admin/QuestionEditorInline.svelte
@@ -352,8 +352,18 @@
 		caption: string,
 		showOnSolution?: boolean
 	) {
-		updateExistingMediaMeta(id, altText, caption, showOnSolution);
-		onChange();
+		return updateExistingMediaMeta(id, altText, caption, showOnSolution).then(() => {
+			onChange();
+		});
+	}
+
+	async function commitExistingMediaChange(
+		id: string,
+		altText: string,
+		caption: string,
+		showOnSolution?: boolean
+	) {
+		await handleExistingMediaChange(id, altText, caption, showOnSolution);
 	}
 
 	function mediaTypeFromMime(mime: string | undefined): string {
@@ -1427,8 +1437,8 @@
 												class="input input-bordered input-sm w-full"
 												placeholder="Alt text"
 												bind:value={m.altText}
-												oninput={() =>
-													handleExistingMediaChange(
+												onblur={() =>
+													commitExistingMediaChange(
 														m._id,
 														m.altText,
 														m.caption || '',
@@ -1439,8 +1449,8 @@
 												class="input input-bordered input-sm w-full"
 												placeholder="Caption (optional)"
 												bind:value={m.caption}
-												oninput={() =>
-													handleExistingMediaChange(
+												onblur={() =>
+													commitExistingMediaChange(
 														m._id,
 														m.altText,
 														m.caption || '',
@@ -1453,7 +1463,7 @@
 													class="checkbox checkbox-xs"
 													bind:checked={m.showOnSolution}
 													onchange={() =>
-														handleExistingMediaChange(
+														commitExistingMediaChange(
 															m._id,
 															m.altText,
 															m.caption || '',

--- a/src/lib/admin/QuestionEditorInline.svelte
+++ b/src/lib/admin/QuestionEditorInline.svelte
@@ -42,6 +42,7 @@
 	import { useClerkContext } from 'svelte-clerk';
 	import type { Focus } from '$lib/config/generation';
 	import { Loader2 } from 'lucide-svelte';
+	import { getRationale } from '$lib/utils/rationale';
 
 	type QuestionItem = Doc<'question'>;
 
@@ -64,7 +65,7 @@
 	} = $props();
 
 	let editor = $state() as Readable<Editor>;
-	let explanationEditor = $state() as Readable<Editor>;
+	let rationaleEditor = $state() as Readable<Editor>;
 
 	function handleKeyboardSave(e: KeyboardEvent) {
 		if ((e.metaKey || e.ctrlKey) && e.key === 's') {
@@ -84,12 +85,13 @@
 			}
 		});
 
-		explanationEditor = createEditor({
+		rationaleEditor = createEditor({
 			extensions: getEditorExtensions(),
-			content: editingQuestion?.explanation || '',
+			content: getRationale(editingQuestion),
 			editorProps: {
 				attributes: {
-					class: 'prose prose-sm max-w-none focus:outline-none min-h-[3rem] p-3 tiptap-content text-sm'
+					class:
+						'prose prose-sm max-w-none focus:outline-none min-h-[3rem] p-3 tiptap-content text-sm'
 				}
 			}
 		});
@@ -117,25 +119,75 @@
 	const menuItems = $derived([
 		{ name: 'bold', command: toggleBold, icon: Bold, active: () => isActive('bold') },
 		{ name: 'italic', command: toggleItalic, icon: Italic, active: () => isActive('italic') },
-		{ name: 'underline', command: toggleUnderline, icon: UnderlineIcon, active: () => isActive('underline') },
-		{ name: 'strike', command: toggleStrike, icon: StrikethroughIcon, active: () => isActive('strike') },
+		{
+			name: 'underline',
+			command: toggleUnderline,
+			icon: UnderlineIcon,
+			active: () => isActive('underline')
+		},
+		{
+			name: 'strike',
+			command: toggleStrike,
+			icon: StrikethroughIcon,
+			active: () => isActive('strike')
+		},
 		{ name: 'code', command: toggleCode, icon: CodeIcon, active: () => isActive('code') },
-		{ name: 'highlight', command: toggleHighlight, icon: HighlighterIcon, active: () => isActive('highlight') },
-		{ name: 'link', command: isActive('link') ? unsetLink : setLink, icon: LinkIcon, active: () => isActive('link') },
-		{ name: 'blockquote', command: toggleBlockquote, icon: QuoteIcon, active: () => isActive('blockquote') },
-		{ name: 'bullet-list', command: toggleBulletList, icon: ListIcon, active: () => isActive('bulletList') },
-		{ name: 'ordered-list', command: toggleOrderedList, icon: ListOrderedIcon, active: () => isActive('orderedList') }
+		{
+			name: 'highlight',
+			command: toggleHighlight,
+			icon: HighlighterIcon,
+			active: () => isActive('highlight')
+		},
+		{
+			name: 'link',
+			command: isActive('link') ? unsetLink : setLink,
+			icon: LinkIcon,
+			active: () => isActive('link')
+		},
+		{
+			name: 'blockquote',
+			command: toggleBlockquote,
+			icon: QuoteIcon,
+			active: () => isActive('blockquote')
+		},
+		{
+			name: 'bullet-list',
+			command: toggleBulletList,
+			icon: ListIcon,
+			active: () => isActive('bulletList')
+		},
+		{
+			name: 'ordered-list',
+			command: toggleOrderedList,
+			icon: ListOrderedIcon,
+			active: () => isActive('orderedList')
+		}
 	]);
 
-	const toggleExpBold = () => $explanationEditor.chain().focus().toggleBold().run();
-	const toggleExpItalic = () => $explanationEditor.chain().focus().toggleItalic().run();
-	const toggleExpUnderline = () => $explanationEditor.chain().focus().toggleUnderline().run();
-	const isExpActive = (name: string) => $explanationEditor?.isActive(name) ?? false;
+	const toggleRationaleBold = () => $rationaleEditor.chain().focus().toggleBold().run();
+	const toggleRationaleItalic = () => $rationaleEditor.chain().focus().toggleItalic().run();
+	const toggleRationaleUnderline = () => $rationaleEditor.chain().focus().toggleUnderline().run();
+	const isRationaleActive = (name: string) => $rationaleEditor?.isActive(name) ?? false;
 
-	const expMenuItems = $derived([
-		{ name: 'bold', command: toggleExpBold, icon: Bold, active: () => isExpActive('bold') },
-		{ name: 'italic', command: toggleExpItalic, icon: Italic, active: () => isExpActive('italic') },
-		{ name: 'underline', command: toggleExpUnderline, icon: UnderlineIcon, active: () => isExpActive('underline') }
+	const rationaleMenuItems = $derived([
+		{
+			name: 'bold',
+			command: toggleRationaleBold,
+			icon: Bold,
+			active: () => isRationaleActive('bold')
+		},
+		{
+			name: 'italic',
+			command: toggleRationaleItalic,
+			icon: Italic,
+			active: () => isRationaleActive('italic')
+		},
+		{
+			name: 'underline',
+			command: toggleRationaleUnderline,
+			icon: UnderlineIcon,
+			active: () => isRationaleActive('underline')
+		}
 	]);
 
 	const questionTypeOptions = [
@@ -146,7 +198,12 @@
 	];
 
 	const statusOptions = [
-		{ value: 'published', label: 'Published', icon: CheckCircle, colorClass: 'btn-success btn-soft' },
+		{
+			value: 'published',
+			label: 'Published',
+			icon: CheckCircle,
+			colorClass: 'btn-success btn-soft'
+		},
 		{ value: 'draft', label: 'Draft', icon: FileText, colorClass: 'btn-info btn-soft' },
 		{ value: 'archived', label: 'Archived', icon: Archive, colorClass: 'btn-error btn-soft' }
 	];
@@ -163,13 +220,13 @@
 	});
 
 	$effect(() => {
-		if ($explanationEditor) {
-			const updateExp = () => {
-				questionExplanation = $explanationEditor.getHTML();
+		if ($rationaleEditor) {
+			const updateRationale = () => {
+				questionRationale = $rationaleEditor.getHTML();
 				onChange();
 			};
-			$explanationEditor.on('update', updateExp);
-			return () => $explanationEditor.off('update', updateExp);
+			$rationaleEditor.on('update', updateRationale);
+			return () => $rationaleEditor.off('update', updateRationale);
 		}
 	});
 
@@ -178,13 +235,15 @@
 	const clerkUser = $derived(clerk.user);
 
 	let questionStem: string = $state(editingQuestion?.stem || '');
-	let questionExplanation: string = $state(editingQuestion?.explanation || '');
+	let questionRationale: string = $state(getRationale(editingQuestion));
 	let questionStatus: string = $state(editingQuestion?.status || defaultStatus);
 	let questionType: string = $state(editingQuestion?.type || 'multiple_choice');
 	let options: Array<{ id?: string; text: string }> = $state(
-		editingQuestion?.options?.length ? [...editingQuestion.options] : [{ text: '' }, { text: '' }, { text: '' }, { text: '' }]
+		editingQuestion?.options?.length
+			? [...editingQuestion.options]
+			: [{ text: '' }, { text: '' }, { text: '' }, { text: '' }]
 	);
-	
+
 	// Convert option IDs to indices for correct answers
 	let correctAnswers: string[] = $state(
 		editingQuestion?.correctAnswers && editingQuestion?.options
@@ -268,7 +327,12 @@
 	}
 
 	// Update existing media metadata
-	async function updateExistingMediaMeta(id: string, altText: string, caption: string, showOnSolution?: boolean) {
+	async function updateExistingMediaMeta(
+		id: string,
+		altText: string,
+		caption: string,
+		showOnSolution?: boolean
+	) {
 		try {
 			await client.mutation((api as any).questionMedia.update, {
 				mediaId: id,
@@ -282,7 +346,12 @@
 		}
 	}
 
-	function handleExistingMediaChange(id: string, altText: string, caption: string, showOnSolution?: boolean) {
+	function handleExistingMediaChange(
+		id: string,
+		altText: string,
+		caption: string,
+		showOnSolution?: boolean
+	) {
 		updateExistingMediaMeta(id, altText, caption, showOnSolution);
 		onChange();
 	}
@@ -541,7 +610,12 @@
 	);
 
 	function addOption() {
-		if (questionType === QUESTION_TYPES.TRUE_FALSE || questionType === QUESTION_TYPES.FILL_IN_THE_BLANK || questionType === QUESTION_TYPES.MATCHING) return;
+		if (
+			questionType === QUESTION_TYPES.TRUE_FALSE ||
+			questionType === QUESTION_TYPES.FILL_IN_THE_BLANK ||
+			questionType === QUESTION_TYPES.MATCHING
+		)
+			return;
 		options = [...options, { text: '' }];
 		onChange();
 	}
@@ -590,22 +664,22 @@
 					.filter((t) => t.length > 0)
 					.join('; ');
 
-				const result = await client.action(api.question.generateExplanation, {
+				const result = await client.action(api.question.generateRationale, {
 					stem: questionStem,
 					answer,
 					focus: userFocus,
-					existingExplanation: questionExplanation.trim() || undefined
+					existingRationale: questionRationale.trim() || undefined
 				});
 
-				if (result.explanation) {
-					questionExplanation = result.explanation;
-					if ($explanationEditor) {
-						$explanationEditor.commands.setContent(result.explanation);
+				if (result.rationale) {
+					questionRationale = result.rationale;
+					if ($rationaleEditor) {
+						$rationaleEditor.commands.setContent(result.rationale);
 					}
 				}
 
 				onChange();
-				toastStore.success('Explanation generated');
+				toastStore.success('Rationale generated');
 			} else {
 				const correctTexts = correctAnswers
 					.map((idx) => options[parseInt(idx)]?.text || '')
@@ -616,13 +690,13 @@
 				const emptyCount = options.filter((o) => o.text.trim().length === 0).length;
 				const numDistractors = Math.max(1, emptyCount);
 
-				const result = await client.action(api.question.generateDistractorsAndExplanation, {
+				const result = await client.action(api.question.generateDistractorsAndRationale, {
 					stem: questionStem,
 					correctAnswers: correctTexts,
 					existingOptions: existingTexts,
 					focus: userFocus,
 					numDistractors,
-					existingExplanation: questionExplanation.trim() || undefined
+					existingRationale: questionRationale.trim() || undefined
 				});
 
 				// Fill empty slots with generated distractors
@@ -634,10 +708,10 @@
 					return o;
 				});
 
-				if (result.explanation) {
-					questionExplanation = result.explanation;
-					if ($explanationEditor) {
-						$explanationEditor.commands.setContent(result.explanation);
+				if (result.rationale) {
+					questionRationale = result.rationale;
+					if ($rationaleEditor) {
+						$rationaleEditor.commands.setContent(result.rationale);
 					}
 				}
 
@@ -657,7 +731,12 @@
 	}
 
 	function removeOption(index: number) {
-		if (questionType === QUESTION_TYPES.TRUE_FALSE || questionType === QUESTION_TYPES.FILL_IN_THE_BLANK || questionType === QUESTION_TYPES.MATCHING) return;
+		if (
+			questionType === QUESTION_TYPES.TRUE_FALSE ||
+			questionType === QUESTION_TYPES.FILL_IN_THE_BLANK ||
+			questionType === QUESTION_TYPES.MATCHING
+		)
+			return;
 		if (options.length <= 2) return;
 		options = options.filter((_, i) => i !== index);
 		correctAnswers = correctAnswers
@@ -671,7 +750,11 @@
 
 	function toggleCorrectAnswer(index: number) {
 		const indexStr = index.toString();
-		if (questionType === QUESTION_TYPES.FILL_IN_THE_BLANK || questionType === QUESTION_TYPES.MATCHING) return;
+		if (
+			questionType === QUESTION_TYPES.FILL_IN_THE_BLANK ||
+			questionType === QUESTION_TYPES.MATCHING
+		)
+			return;
 		if (questionType === QUESTION_TYPES.TRUE_FALSE) {
 			correctAnswers = correctAnswers.includes(indexStr) ? [] : [indexStr];
 		} else if (correctAnswers.includes(indexStr)) {
@@ -789,7 +872,7 @@
 					stem: questionStem,
 					options: cleanOptions,
 					correctAnswers,
-					explanation: questionExplanation || '',
+					rationale: questionRationale || '',
 					status: questionStatus.toLowerCase()
 				});
 				questionId = editingQuestion._id as Id<'question'>;
@@ -812,7 +895,7 @@
 					stem: questionStem,
 					options: cleanOptions.map((opt) => ({ text: opt.text })),
 					correctAnswers,
-					explanation: questionExplanation || '',
+					rationale: questionRationale || '',
 					aiGenerated: false,
 					status: questionStatus.toLowerCase(),
 					order: nextOrder,
@@ -857,10 +940,14 @@
 
 <div class="h-full flex flex-col overflow-hidden bg-base-100">
 	<!-- Top Bar: Title & Actions -->
-	<div class="flex items-center justify-between px-4 py-3 border-b border-base-300 bg-base-100 flex-shrink-0">
+	<div
+		class="flex items-center justify-between px-4 py-3 border-b border-base-300 bg-base-100 flex-shrink-0"
+	>
 		<h3 class="text-base font-semibold">{mode === 'edit' ? 'Edit Question' : 'New Question'}</h3>
 		<div class="flex items-center gap-2">
-			<button class="btn btn-sm btn-ghost rounded-full" onclick={onCancel} disabled={isSubmitting}>Cancel</button>
+			<button class="btn btn-sm btn-ghost rounded-full" onclick={onCancel} disabled={isSubmitting}
+				>Cancel</button
+			>
 			<button
 				class="btn btn-sm btn-primary rounded-full gap-2"
 				onclick={handleSubmit}
@@ -877,14 +964,20 @@
 	</div>
 
 	<!-- Toolbar: Type & Status -->
-	<div class="flex flex-wrap items-center gap-8 px-6 py-4 border-b border-base-300 bg-base-200/30 flex-shrink-0">
+	<div
+		class="flex flex-wrap items-center gap-8 px-6 py-4 border-b border-base-300 bg-base-200/30 flex-shrink-0"
+	>
 		<!-- Type Selector -->
 		<div class="flex flex-col gap-2">
-			<span class="text-[10px] font-bold text-base-content/40 uppercase tracking-wider ml-1">Type</span>
+			<span class="text-[10px] font-bold text-base-content/40 uppercase tracking-wider ml-1"
+				>Type</span
+			>
 			<div class="flex shadow-sm bg-base-100 rounded-full border border-base-300 p-1 gap-0.5">
 				{#each questionTypeOptions as option (option.value)}
 					<button
-						class="btn btn-xs sm:btn-sm rounded-full border-0 {questionType === option.value ? 'btn-active font-medium' : 'btn-ghost opacity-60 hover:opacity-100 font-normal'}"
+						class="btn btn-xs sm:btn-sm rounded-full border-0 {questionType === option.value
+							? 'btn-active font-medium'
+							: 'btn-ghost opacity-60 hover:opacity-100 font-normal'}"
 						onclick={() => {
 							questionType = option.value;
 							handleTypeChange();
@@ -903,11 +996,15 @@
 
 		<!-- Status Selector -->
 		<div class="flex flex-col gap-2">
-			<span class="text-[10px] font-bold text-base-content/40 uppercase tracking-wider ml-1">Status</span>
+			<span class="text-[10px] font-bold text-base-content/40 uppercase tracking-wider ml-1"
+				>Status</span
+			>
 			<div class="flex shadow-sm bg-base-100 rounded-full border border-base-300 p-1 gap-0.5">
 				{#each statusOptions as option (option.value)}
 					<button
-						class="btn btn-xs sm:btn-sm rounded-full border-0 {questionStatus === option.value ? option.colorClass + ' btn-active font-medium' : 'btn-ghost opacity-60 hover:opacity-100 font-normal'}"
+						class="btn btn-xs sm:btn-sm rounded-full border-0 {questionStatus === option.value
+							? option.colorClass + ' btn-active font-medium'
+							: 'btn-ghost opacity-60 hover:opacity-100 font-normal'}"
 						onclick={() => {
 							questionStatus = option.value;
 							onChange();
@@ -925,22 +1022,31 @@
 	<!-- Main Scrollable Content -->
 	<div class="flex-1 overflow-y-auto min-h-0 p-4 pb-40 sm:p-6 sm:pb-40" onpaste={handlePaste}>
 		<div class="w-full max-w-none space-y-8">
-			
 			<!-- Question Stem -->
 			<div class="space-y-2">
 				<div class="flex items-center justify-between">
-					<label class="text-xs font-semibold uppercase tracking-wide text-base-content/60 flex items-center gap-2">
+					<label
+						class="text-xs font-semibold uppercase tracking-wide text-base-content/60 flex items-center gap-2"
+					>
 						<MessageSquare size={14} /> Question
 					</label>
-					<span class="text-[10px] text-base-content/40 font-medium hidden sm:inline">Ctrl + S to save</span>
+					<span class="text-[10px] text-base-content/40 font-medium hidden sm:inline"
+						>Ctrl + S to save</span
+					>
 				</div>
-				<div class="border border-base-300 rounded-2xl overflow-hidden bg-base-100 shadow-sm group focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/20 transition-all">
+				<div
+					class="border border-base-300 rounded-2xl overflow-hidden bg-base-100 shadow-sm group focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/20 transition-all"
+				>
 					{#if editor}
-						<div class="bg-base-200/50 border-b border-base-300 p-1 flex gap-1 opacity-60 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+						<div
+							class="bg-base-200/50 border-b border-base-300 p-1 flex gap-1 opacity-60 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+						>
 							{#each menuItems as item (item.name)}
 								<button
 									type="button"
-									class="btn btn-ghost btn-xs btn-square {item.active() ? 'btn-active text-primary' : ''}"
+									class="btn btn-ghost btn-xs btn-square {item.active()
+										? 'btn-active text-primary'
+										: ''}"
 									onclick={item.command}
 									title={item.name}
 								>
@@ -960,12 +1066,14 @@
 				{#if questionType === QUESTION_TYPES.FILL_IN_THE_BLANK}
 					<div class="space-y-4">
 						<div class="flex items-center justify-between mb-2">
-							<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60">Accepted Answers</div>
+							<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+								Accepted Answers
+							</div>
 							<button
 								class="btn btn-xs btn-ghost gap-1"
 								onclick={generateAIOptions}
 								disabled={!canGenerateAI()}
-								title={canGenerateAI() ? 'Generate explanation with AI' : 'Add stem and answer first'}
+								title={canGenerateAI() ? 'Generate rationale with AI' : 'Add stem and answer first'}
 							>
 								{#if isGeneratingAI}
 									<Loader2 size={12} class="animate-spin" />
@@ -975,17 +1083,24 @@
 								<span class="hidden sm:inline">AI</span>
 							</button>
 						</div>
-						<div class="card bg-base-100 border border-base-300 shadow-sm rounded-3xl overflow-hidden">
+						<div
+							class="card bg-base-100 border border-base-300 shadow-sm rounded-3xl overflow-hidden"
+						>
 							<div class="card-body p-4 gap-4">
 								{#each fitbAnswers as row, index (index)}
 									<div class="flex flex-col sm:flex-row gap-3 items-start">
 										<div class="flex-1 w-full">
 											<div class="flex items-center gap-2 mb-1">
-												<span class="badge badge-sm {index === 0 ? 'badge-success' : 'badge-ghost'}">
+												<span
+													class="badge badge-sm {index === 0 ? 'badge-success' : 'badge-ghost'}"
+												>
 													{index === 0 ? 'Primary' : 'Alt'}
 												</span>
 												{#if fitbAnswers.length > 1}
-													<button class="btn btn-ghost btn-xs text-error ml-auto sm:hidden" onclick={() => removeFitbRow(index)}>
+													<button
+														class="btn btn-ghost btn-xs text-error ml-auto sm:hidden"
+														onclick={() => removeFitbRow(index)}
+													>
 														<X size={14} />
 													</button>
 												{/if}
@@ -1008,16 +1123,22 @@
 													<option value={mode}>{label}</option>
 												{/each}
 											</select>
-											<div class="flex items-center rounded-full border border-base-300 p-0.5 gap-0.5">
+											<div
+												class="flex items-center rounded-full border border-base-300 p-0.5 gap-0.5"
+											>
 												<button
-													class="btn btn-sm rounded-full border-0 {row.flags.ignorePunct ? 'btn-active' : 'btn-ghost'}"
+													class="btn btn-sm rounded-full border-0 {row.flags.ignorePunct
+														? 'btn-active'
+														: 'btn-ghost'}"
 													onclick={() => toggleFitbFlag(index, 'ignorePunct')}
 													title="Ignore Punctuation"
 												>
 													Punct
 												</button>
-												<button 
-													class="btn btn-sm rounded-full border-0 {row.flags.normalizeWs ? 'btn-active' : 'btn-ghost'}"
+												<button
+													class="btn btn-sm rounded-full border-0 {row.flags.normalizeWs
+														? 'btn-active'
+														: 'btn-ghost'}"
 													onclick={() => toggleFitbFlag(index, 'normalizeWs')}
 													title="Normalize Whitespace"
 												>
@@ -1025,7 +1146,10 @@
 												</button>
 											</div>
 											{#if fitbAnswers.length > 1}
-												<button class="btn btn-ghost btn-sm btn-square text-error hidden sm:flex" onclick={() => removeFitbRow(index)}>
+												<button
+													class="btn btn-ghost btn-sm btn-square text-error hidden sm:flex"
+													onclick={() => removeFitbRow(index)}
+												>
 													<X size={16} />
 												</button>
 											{/if}
@@ -1043,10 +1167,11 @@
 							</div>
 						</div>
 					</div>
-
 				{:else if questionType === QUESTION_TYPES.MATCHING}
 					<div class="space-y-4">
-						<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-2">Matching Pairs</div>
+						<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-2">
+							Matching Pairs
+						</div>
 						<div class="space-y-3">
 							{#each Array(Math.max(matchingPrompts.length, matchingAnswers.length)) as _, i (i)}
 								<div class="flex flex-col sm:flex-row items-center gap-2 sm:gap-4">
@@ -1070,17 +1195,24 @@
 												</button>
 											{/if}
 										{:else}
-											<div class="h-12 w-full rounded-3xl border border-dashed border-base-300 bg-base-100/50 flex items-center justify-center text-xs text-base-content/30 italic">
+											<div
+												class="h-12 w-full rounded-3xl border border-dashed border-base-300 bg-base-100/50 flex items-center justify-center text-xs text-base-content/30 italic"
+											>
 												Distractor (No Prompt)
 											</div>
 										{/if}
 									</div>
-									
+
 									<!-- Center: Arrow -->
 									<div class="text-base-content/30 rotate-90 sm:rotate-0 w-5 flex justify-center">
 										{#if i < matchingPrompts.length && i < matchingAnswers.length}
 											<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width="2"
+													d="M13 7l5 5m0 0l-5 5m5-5H6"
+												/>
 											</svg>
 										{/if}
 									</div>
@@ -1105,7 +1237,9 @@
 												</button>
 											{/if}
 										{:else}
-											<div class="h-12 w-full rounded-3xl border border-dashed border-base-300 bg-base-100/50 flex items-center justify-center text-xs text-base-content/30 italic">
+											<div
+												class="h-12 w-full rounded-3xl border border-dashed border-base-300 bg-base-100/50 flex items-center justify-center text-xs text-base-content/30 italic"
+											>
 												No Answer
 											</div>
 										{/if}
@@ -1113,28 +1247,37 @@
 								</div>
 							{/each}
 						</div>
-						
+
 						<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
 							<div class="flex justify-center sm:justify-start">
-								<button class="btn btn-sm btn-outline gap-2 w-full sm:w-auto" onclick={addMatchingPrompt}>
+								<button
+									class="btn btn-sm btn-outline gap-2 w-full sm:w-auto"
+									onclick={addMatchingPrompt}
+								>
 									<Plus size={14} /> Add Prompt
 								</button>
 							</div>
 							<div class="flex justify-center sm:justify-end">
-								<button class="btn btn-sm btn-outline gap-2 w-full sm:w-auto" onclick={addMatchingAnswer}>
+								<button
+									class="btn btn-sm btn-outline gap-2 w-full sm:w-auto"
+									onclick={addMatchingAnswer}
+								>
 									<Plus size={14} /> Add Answer
 								</button>
 							</div>
 						</div>
 					</div>
-
 				{:else}
 					<!-- Multiple Choice / True False -->
 					<div class="space-y-4">
 						<div class="flex items-center justify-between">
 							<div class="flex items-center gap-3">
-								<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60">Options</div>
-								<span class="text-[10px] text-base-content/40 font-medium hidden sm:inline">Ctrl + Enter to toggle correct</span>
+								<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+									Options
+								</div>
+								<span class="text-[10px] text-base-content/40 font-medium hidden sm:inline"
+									>Ctrl + Enter to toggle correct</span
+								>
 							</div>
 							<div class="flex items-center gap-1">
 								{#if questionType === QUESTION_TYPES.MULTIPLE_CHOICE}
@@ -1142,7 +1285,9 @@
 										class="btn btn-xs btn-ghost gap-1"
 										onclick={generateAIOptions}
 										disabled={!canGenerateAI()}
-										title={canGenerateAI() ? 'Generate distractor options with AI' : 'Add stem and correct answer first'}
+										title={canGenerateAI()
+											? 'Generate distractor options with AI'
+											: 'Add stem and correct answer first'}
 									>
 										{#if isGeneratingAI}
 											<Loader2 size={12} class="animate-spin" />
@@ -1161,15 +1306,25 @@
 						<div class="space-y-3">
 							{#each options as option, index (index)}
 								<div class="relative group">
-									<div class="flex items-center rounded-full border-2 transition-colors bg-base-100 pl-3 pr-2 py-1 {correctAnswers.includes(index.toString()) ? 'border-success bg-success/5' : 'border-base-300 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20'}">
+									<div
+										class="flex items-center rounded-full border-2 transition-colors bg-base-100 pl-3 pr-2 py-1 {correctAnswers.includes(
+											index.toString()
+										)
+											? 'border-success bg-success/5'
+											: 'border-base-300 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20'}"
+									>
 										<input
 											type="checkbox"
-											class="checkbox checkbox-sm {correctAnswers.includes(index.toString()) ? 'checkbox-success' : 'checkbox-primary'}"
+											class="checkbox checkbox-sm {correctAnswers.includes(index.toString())
+												? 'checkbox-success'
+												: 'checkbox-primary'}"
 											checked={correctAnswers.includes(index.toString())}
 											onclick={() => toggleCorrectAnswer(index)}
 											tabindex={-1}
 										/>
-										<span class="font-semibold text-sm ml-3 text-base-content/50 select-none w-6">{String.fromCharCode(65 + index)}.</span>
+										<span class="font-semibold text-sm ml-3 text-base-content/50 select-none w-6"
+											>{String.fromCharCode(65 + index)}.</span
+										>
 										<input
 											type="text"
 											class="flex-1 bg-transparent border-none focus:ring-0 text-sm px-2 h-9"
@@ -1185,10 +1340,10 @@
 											}}
 										/>
 										{#if options.length > 2 && questionType !== QUESTION_TYPES.TRUE_FALSE}
-											<button 
-												type="button" 
-												class="btn btn-ghost btn-xs btn-circle text-base-content/30 hover:text-error ml-1" 
-												tabindex={-1} 
+											<button
+												type="button"
+												class="btn btn-ghost btn-xs btn-circle text-base-content/30 hover:text-error ml-1"
+												tabindex={-1}
 												onclick={() => removeOption(index)}
 											>
 												<X size={14} />
@@ -1202,7 +1357,10 @@
 						</div>
 
 						{#if questionType === QUESTION_TYPES.MULTIPLE_CHOICE}
-							<button class="btn btn-sm btn-ghost gap-2 w-full border-2 border-dashed border-base-300 hover:border-primary hover:text-primary mt-2" onclick={addOption}>
+							<button
+								class="btn btn-sm btn-ghost gap-2 w-full border-2 border-dashed border-base-300 hover:border-primary hover:text-primary mt-2"
+								onclick={addOption}
+							>
 								<Plus size={14} /> Add Option
 							</button>
 						{/if}
@@ -1210,18 +1368,24 @@
 				{/if}
 			</div>
 
-			<!-- Explanation & Attachments -->
+			<!-- Rationale & Attachments -->
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-4 border-t border-base-200">
 				<div>
-					<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-1 flex items-center gap-2">
-						<MessageSquare size={14} /> Explanation
+					<div
+						class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-1 flex items-center gap-2"
+					>
+						<MessageSquare size={14} /> Rationale
 					</div>
-					<p class="text-[10px] text-base-content/40 mb-2">Add notes or context here to guide AI-generated explanations</p>
+					<p class="text-[10px] text-base-content/40 mb-2">
+						Add notes or context here to guide AI-generated rationales
+					</p>
 					<div class="border border-base-300 rounded-2xl overflow-hidden bg-base-100 group">
-						{#if explanationEditor}
-							<EditorContent editor={$explanationEditor} />
-							<div class="bg-base-200/50 border-t border-base-300 p-1 flex gap-1 opacity-50 group-hover:opacity-100 transition-opacity">
-								{#each expMenuItems as item (item.name)}
+						{#if rationaleEditor}
+							<EditorContent editor={$rationaleEditor} />
+							<div
+								class="bg-base-200/50 border-t border-base-300 p-1 flex gap-1 opacity-50 group-hover:opacity-100 transition-opacity"
+							>
+								{#each rationaleMenuItems as item (item.name)}
 									<button
 										type="button"
 										class="btn btn-ghost btn-xs btn-square {item.active() ? 'btn-active' : ''}"
@@ -1237,10 +1401,12 @@
 				</div>
 
 				<div>
-					<div class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-2 flex items-center gap-2">
+					<div
+						class="text-xs font-semibold uppercase tracking-wide text-base-content/60 mb-2 flex items-center gap-2"
+					>
 						<ImageIcon size={14} /> Attachments
 					</div>
-					
+
 					<div class="space-y-3">
 						{#if existingMedia.length > 0 || queuedMedia.length > 0}
 							<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -1249,7 +1415,7 @@
 									<div class="border border-base-300 rounded-2xl overflow-hidden bg-base-100">
 										<div class="relative group">
 											<img src={m.url} alt={m.altText} class="w-full h-32 object-cover" />
-											<button 
+											<button
 												class="absolute top-1 right-1 btn btn-circle btn-xs btn-error opacity-0 group-hover:opacity-100 transition-opacity"
 												onclick={() => removeExistingMedia(m._id)}
 											>
@@ -1261,34 +1427,54 @@
 												class="input input-bordered input-sm w-full"
 												placeholder="Alt text"
 												bind:value={m.altText}
-												oninput={() => handleExistingMediaChange(m._id, m.altText, m.caption || '', m.showOnSolution)}
+												oninput={() =>
+													handleExistingMediaChange(
+														m._id,
+														m.altText,
+														m.caption || '',
+														m.showOnSolution
+													)}
 											/>
 											<input
 												class="input input-bordered input-sm w-full"
 												placeholder="Caption (optional)"
 												bind:value={m.caption}
-												oninput={() => handleExistingMediaChange(m._id, m.altText, m.caption || '', m.showOnSolution)}
+												oninput={() =>
+													handleExistingMediaChange(
+														m._id,
+														m.altText,
+														m.caption || '',
+														m.showOnSolution
+													)}
 											/>
 											<label class="label cursor-pointer gap-2 text-xs p-0 justify-start">
 												<input
 													type="checkbox"
 													class="checkbox checkbox-xs"
 													bind:checked={m.showOnSolution}
-													onchange={() => handleExistingMediaChange(m._id, m.altText, m.caption || '', m.showOnSolution)}
+													onchange={() =>
+														handleExistingMediaChange(
+															m._id,
+															m.altText,
+															m.caption || '',
+															m.showOnSolution
+														)}
 												/>
 												<span>Show on rationale</span>
 											</label>
 										</div>
 									</div>
 								{/each}
-								
+
 								<!-- Queued Media -->
 								{#each queuedMedia as m, idx (idx)}
-									<div class="border border-primary/50 rounded-2xl overflow-hidden bg-base-100 relative">
+									<div
+										class="border border-primary/50 rounded-2xl overflow-hidden bg-base-100 relative"
+									>
 										<div class="absolute top-2 left-2 badge badge-primary badge-xs z-10">New</div>
 										<div class="relative">
 											<img src={m.url} alt={m.name} class="w-full h-32 object-cover" />
-											<button 
+											<button
 												class="absolute top-1 right-1 btn btn-circle btn-xs btn-error z-10"
 												onclick={() => removeQueuedMedia(idx)}
 											>
@@ -1325,12 +1511,16 @@
 
 						<div class="relative">
 							{#if isPasteUploading}
-								<div class="border-2 border-dashed border-primary rounded-2xl p-6 flex flex-col items-center justify-center h-32 bg-base-100/50">
+								<div
+									class="border-2 border-dashed border-primary rounded-2xl p-6 flex flex-col items-center justify-center h-32 bg-base-100/50"
+								>
 									<span class="loading loading-spinner text-primary mb-2"></span>
 									<span class="text-xs text-primary font-medium">Processing pasted image...</span>
 								</div>
 							{:else}
-								<div class="group relative h-36 w-full border-2 border-dashed border-base-300 rounded-xl hover:border-primary transition-colors bg-base-100/50 flex flex-col items-center justify-center text-center overflow-hidden">
+								<div
+									class="group relative h-36 w-full border-2 border-dashed border-base-300 rounded-xl hover:border-primary transition-colors bg-base-100/50 flex flex-col items-center justify-center text-center overflow-hidden"
+								>
 									<!-- The Dropzone covers everything but is invisible -->
 									<div class="absolute inset-0 z-10 opacity-0 cursor-pointer">
 										<UploadDropzone
@@ -1344,10 +1534,14 @@
 											}}
 										/>
 									</div>
-									
+
 									<!-- Visible Content -->
-									<div class="flex flex-col items-center gap-2 p-4 text-base-content/60 group-hover:text-primary transition-colors">
-										<div class="p-3 bg-base-200 rounded-full group-hover:bg-primary/10 transition-colors">
+									<div
+										class="flex flex-col items-center gap-2 p-4 text-base-content/60 group-hover:text-primary transition-colors"
+									>
+										<div
+											class="p-3 bg-base-200 rounded-full group-hover:bg-primary/10 transition-colors"
+										>
 											<ImageIcon size={24} />
 										</div>
 										<div class="flex flex-col gap-0.5">

--- a/src/lib/admin/QuestionGeneration.svelte
+++ b/src/lib/admin/QuestionGeneration.svelte
@@ -14,6 +14,7 @@
 		defaultProductModelId,
 		productModelOptions
 	} from '$lib/config/generation';
+	import { resolve } from '$app/paths';
 	import ModuleLimitModal from './ModuleLimitModal.svelte';
 
 	export interface Props {
@@ -282,7 +283,8 @@
 							</div>
 						</div>
 						<div class="flex flex-col gap-3 w-full">
-							<a href="/sign-up" target="_blank" class="btn btn-primary btn-block">Upgrade to Pro</a
+							<a href={resolve('/sign-up')} target="_blank" class="btn btn-primary btn-block"
+								>Upgrade to Pro</a
 							>
 							<button class="btn btn-ghost btn-xs" onclick={() => (limitReached = false)}
 								>Maybe later</button

--- a/src/lib/admin/QuestionGeneration.svelte
+++ b/src/lib/admin/QuestionGeneration.svelte
@@ -1,6 +1,19 @@
 <script lang="ts">
-	import { Check, Trash2, Zap, ChevronDown, Settings, FileText, Sparkles, CheckCircle } from 'lucide-svelte';
-	import { resolveProduct, defaultProductModelId, productModelOptions } from '$lib/config/generation';
+	import {
+		Check,
+		Trash2,
+		Zap,
+		ChevronDown,
+		Settings,
+		FileText,
+		Sparkles,
+		CheckCircle
+	} from 'lucide-svelte';
+	import {
+		resolveProduct,
+		defaultProductModelId,
+		productModelOptions
+	} from '$lib/config/generation';
 	import ModuleLimitModal from './ModuleLimitModal.svelte';
 
 	export interface Props {
@@ -37,7 +50,7 @@
 		stem: string;
 		options: { text: string }[];
 		correctAnswers: string[];
-		explanation: string;
+		rationale: string;
 		aiGenerated: boolean;
 		status: string;
 		order: number;
@@ -114,7 +127,10 @@
 			selected = new Set();
 		} catch (error: any) {
 			console.error('Failed to add questions:', error);
-			if (error.message?.includes('Module limit reached') || error.toString().includes('Module limit reached')) {
+			if (
+				error.message?.includes('Module limit reached') ||
+				error.toString().includes('Module limit reached')
+			) {
 				isLimitModalOpen = true;
 			}
 		} finally {
@@ -140,11 +156,7 @@
 			</div>
 
 			{#if generated.length === 0}
-				<button
-					class="btn btn-primary btn-sm gap-2"
-					disabled={isDisabled}
-					onclick={generate}
-				>
+				<button class="btn btn-primary btn-sm gap-2" disabled={isDisabled} onclick={generate}>
 					{#if isGenerating}
 						<span class="loading loading-spinner loading-xs"></span>
 						Generating...
@@ -158,7 +170,10 @@
 					<button
 						class="btn btn-ghost btn-sm"
 						disabled={isGenerating || isAdding}
-						onclick={() => { generated = []; selected = new Set(); }}
+						onclick={() => {
+							generated = [];
+							selected = new Set();
+						}}
 					>
 						Discard
 					</button>
@@ -228,37 +243,50 @@
 							<Sparkles size={32} class="text-primary" />
 						{/if}
 					</div>
-					
+
 					{#if limitType === 'pro'}
 						<h3 class="card-title text-xl font-bold mb-2">Wow, that's a lot of questions!</h3>
 						<p class="text-sm text-base-content/70 mb-6">
-							You've hit the daily Pro limit. That is some serious dedication to studying! To keep things running smoothly for everyone, we'll reset your limit tomorrow.
+							You've hit the daily Pro limit. That is some serious dedication to studying! To keep
+							things running smoothly for everyone, we'll reset your limit tomorrow.
 						</p>
 						<div class="flex flex-col gap-3 w-full">
-							<button class="btn btn-primary btn-block" onclick={() => limitReached = false}>Take a break</button>
+							<button class="btn btn-primary btn-block" onclick={() => (limitReached = false)}
+								>Take a break</button
+							>
 						</div>
 					{:else}
 						<h3 class="card-title text-xl font-bold mb-2">Daily Limit Reached</h3>
 						<p class="text-sm text-base-content/70 mb-6">
-							You've hit the limit for today, but don't stop learning! Upgrading to Pro unlocks the full power of LearnTerms AI.
+							You've hit the limit for today, but don't stop learning! Upgrading to Pro unlocks the
+							full power of LearnTerms AI.
 						</p>
 						<div class="text-left w-full space-y-3 mb-6 bg-base-200/50 p-4 rounded-2xl">
 							<div class="flex items-start gap-3">
 								<CheckCircle class="text-success mt-0.5 shrink-0" size={16} />
-								<span class="text-xs"><strong>Unlimited Generation:</strong> Create as many practice questions as you need.</span>
+								<span class="text-xs"
+									><strong>Unlimited Generation:</strong> Create as many practice questions as you need.</span
+								>
 							</div>
 							<div class="flex items-start gap-3">
 								<CheckCircle class="text-success mt-0.5 shrink-0" size={16} />
-								<span class="text-xs"><strong>Deeper Understanding:</strong> Get detailed explanations for every answer.</span>
+								<span class="text-xs"
+									><strong>Deeper Understanding:</strong> Get detailed rationales for every answer.</span
+								>
 							</div>
 							<div class="flex items-start gap-3">
 								<CheckCircle class="text-success mt-0.5 shrink-0" size={16} />
-								<span class="text-xs"><strong>Custom Tailored:</strong> Questions specific to your exact curriculum.</span>
+								<span class="text-xs"
+									><strong>Custom Tailored:</strong> Questions specific to your exact curriculum.</span
+								>
 							</div>
 						</div>
 						<div class="flex flex-col gap-3 w-full">
-							<a href="/sign-up" target="_blank" class="btn btn-primary btn-block">Upgrade to Pro</a>
-							<button class="btn btn-ghost btn-xs" onclick={() => limitReached = false}>Maybe later</button>
+							<a href="/sign-up" target="_blank" class="btn btn-primary btn-block">Upgrade to Pro</a
+							>
+							<button class="btn btn-ghost btn-xs" onclick={() => (limitReached = false)}
+								>Maybe later</button
+							>
 						</div>
 					{/if}
 				</div>
@@ -275,7 +303,9 @@
 		{#if generated.length === 0}
 			<div class="mb-4">
 				<details class="group">
-					<summary class="flex items-center gap-2 text-xs text-base-content/60 cursor-pointer hover:text-base-content/80">
+					<summary
+						class="flex items-center gap-2 text-xs text-base-content/60 cursor-pointer hover:text-base-content/80"
+					>
 						<Settings size={12} />
 						<span>Advanced options</span>
 						<ChevronDown size={12} class="group-open:rotate-180 transition-transform" />
@@ -283,7 +313,11 @@
 					<div class="mt-3 p-3 bg-base-200/50 rounded-2xl space-y-3">
 						<div>
 							<label class="text-xs font-medium mb-1 block" for="model-select">AI Model</label>
-							<select id="model-select" class="select select-sm select-bordered w-full" bind:value={productModelId}>
+							<select
+								id="model-select"
+								class="select select-sm select-bordered w-full"
+								bind:value={productModelId}
+							>
 								{#each productModelOptions as o (o.value)}
 									<option value={o.value}>{o.label}</option>
 								{/each}
@@ -291,7 +325,9 @@
 							<p class="text-xs text-base-content/50 mt-1">Focus: {resolved.focus}</p>
 						</div>
 						<div>
-							<label class="text-xs font-medium mb-1 block" for="custom-prompt">Custom instructions</label>
+							<label class="text-xs font-medium mb-1 block" for="custom-prompt"
+								>Custom instructions</label
+							>
 							<textarea
 								id="custom-prompt"
 								class="textarea textarea-bordered textarea-sm w-full"
@@ -321,12 +357,15 @@
 				</div>
 				<div class="bg-base-200/50 rounded-2xl p-4 max-h-[50vh] overflow-auto">
 					{#if material}
-						<pre class="text-sm whitespace-pre-wrap break-words text-base-content/80">{material}</pre>
+						<pre
+							class="text-sm whitespace-pre-wrap break-words text-base-content/80">{material}</pre>
 					{:else}
 						<div class="flex flex-col items-center justify-center py-12 text-center">
 							<FileText size={40} class="text-base-content/20 mb-3" />
 							<p class="text-sm text-base-content/50">No content selected</p>
-							<p class="text-xs text-base-content/40 mt-1">Select chunks from the document browser</p>
+							<p class="text-xs text-base-content/40 mt-1">
+								Select chunks from the document browser
+							</p>
 						</div>
 					{/if}
 				</div>
@@ -381,7 +420,9 @@
 												? 'bg-success/10 text-success'
 												: 'bg-base-200/50'}"
 										>
-											<span class="w-5 h-5 rounded-full bg-base-300 flex items-center justify-center font-mono text-xs flex-shrink-0">
+											<span
+												class="w-5 h-5 rounded-full bg-base-300 flex items-center justify-center font-mono text-xs flex-shrink-0"
+											>
 												{String.fromCharCode('A'.charCodeAt(0) + oi)}
 											</span>
 											<span class="flex-1">{opt.text}</span>
@@ -392,12 +433,12 @@
 									{/each}
 								</div>
 
-								{#if q.explanation?.trim()}
+								{#if q.rationale?.trim()}
 									<details class="text-xs">
 										<summary class="text-base-content/50 cursor-pointer hover:text-base-content/70">
-											Show explanation
+											Show rationale
 										</summary>
-										<p class="mt-2 p-2 bg-info/10 rounded text-base-content/70">{q.explanation}</p>
+										<p class="mt-2 p-2 bg-info/10 rounded text-base-content/70">{q.rationale}</p>
 									</details>
 								{/if}
 							</div>
@@ -408,5 +449,5 @@
 		{/if}
 	</div>
 
-	<ModuleLimitModal isOpen={isLimitModalOpen} onClose={() => isLimitModalOpen = false} />
+	<ModuleLimitModal isOpen={isLimitModalOpen} onClose={() => (isLimitModalOpen = false)} />
 </div>

--- a/src/lib/analytics/posthogClient.ts
+++ b/src/lib/analytics/posthogClient.ts
@@ -1,4 +1,4 @@
-import { browser } from '$app/environment';
+import { browser, dev } from '$app/environment';
 import type { PostHog } from 'posthog-js';
 
 const POSTHOG_API_KEY = 'phc_3eXFYO1aHVEWM75fi3wXFE6OiJZiDNvI5pcl67S19fK';
@@ -6,7 +6,7 @@ const POSTHOG_API_KEY = 'phc_3eXFYO1aHVEWM75fi3wXFE6OiJZiDNvI5pcl67S19fK';
 let posthogPromise: Promise<PostHog | null> | null = null;
 
 export async function getPostHog(): Promise<PostHog | null> {
-	if (!browser) return null;
+	if (!browser || dev) return null;
 
 	if (!posthogPromise) {
 		posthogPromise = import('posthog-js')

--- a/src/lib/archive/blog/LearnTerms v2/+page.svelte
+++ b/src/lib/archive/blog/LearnTerms v2/+page.svelte
@@ -48,11 +48,11 @@
 			<section>
 				<h2 class="mb-6 text-4xl font-bold /90">Introduction</h2>
 				<p class="text-lg leading-relaxed">
-					Welcome to the launch of <strong>LearnTerms v2</strong> – a revolutionary upgrade designed
-					to transform your exam preparation. With smarter study tools and an AI-powered backend, LearnTerms
-					v2 is set to become the go-to platform for our class. In this post, we'll walk you through
-					the evolution of the platform, explain the technology behind the upgrade, and show you how
-					these changes will make your study sessions more efficient and effective.
+					Welcome to the launch of <strong>LearnTerms v2</strong> – a revolutionary upgrade designed to
+					transform your exam preparation. With smarter study tools and an AI-powered backend, LearnTerms
+					v2 is set to become the go-to platform for our class. In this post, we'll walk you through the
+					evolution of the platform, explain the technology behind the upgrade, and show you how these
+					changes will make your study sessions more efficient and effective.
 				</p>
 			</section>
 
@@ -75,8 +75,8 @@
 						restricted its potential.
 					</li>
 					<li class="leading-relaxed">
-						<strong>Manual Verification:</strong> A significant amount of manual effort was required
-						to verify terms and maintain accuracy, consuming countless hours.
+						<strong>Manual Verification:</strong> A significant amount of manual effort was required to
+						verify terms and maintain accuracy, consuming countless hours.
 					</li>
 					<li class="leading-relaxed">
 						<strong>Scalability Challenges:</strong> The system needed to evolve to accommodate a broader
@@ -107,8 +107,8 @@
 						accurate study questions quickly.
 					</li>
 					<li class="leading-relaxed">
-						<strong>Personalized Learning:</strong> Maintain domain-specific expertise to ensure the
-						content is tailored to your course and study habits.
+						<strong>Personalized Learning:</strong> Maintain domain-specific expertise to ensure the content
+						is tailored to your course and study habits.
 					</li>
 				</ul>
 				<p class="mb-8 text-lg leading-relaxed">
@@ -188,8 +188,8 @@
 						<strong>Lean and Lightweight:</strong> The library is now 61% smaller and dependency-free.
 					</li>
 					<li class="leading-relaxed">
-						<strong>Enhanced Aesthetics:</strong> A cleaner, more mature look that still retains the
-						playful essence of the original design.
+						<strong>Enhanced Aesthetics:</strong> A cleaner, more mature look that still retains the playful
+						essence of the original design.
 					</li>
 					<li class="leading-relaxed">
 						<strong>Quick Deployment:</strong> Simplifies the process of building and deploying new features,
@@ -222,8 +222,7 @@
 				</p>
 				<ul class="mb-8 ml-6 space-y-3 text-lg">
 					<li class="leading-relaxed">
-						<strong>Faster Builds:</strong> Both full and incremental build times have significantly
-						decreased.
+						<strong>Faster Builds:</strong> Both full and incremental build times have significantly decreased.
 					</li>
 					<li class="leading-relaxed">
 						<strong>Optimized Styling:</strong> The high-performance engine ensures our custom styles
@@ -281,10 +280,9 @@
 
 				<h3 class="mb-4 mt-8 text-2xl font-semibold">Introduction to AI Integration</h3>
 				<p class="mb-8 text-lg leading-relaxed">
-					LearnTerms v2 leverages advanced <strong>Large Language Models (LLMs)</strong> to generate
-					personalized study questions quickly and accurately. By fine-tuning these models and utilizing
-					effective prompt engineering, we ensure that every generated question is both relevant and
-					accurate.
+					LearnTerms v2 leverages advanced <strong>Large Language Models (LLMs)</strong> to generate personalized
+					study questions quickly and accurately. By fine-tuning these models and utilizing effective
+					prompt engineering, we ensure that every generated question is both relevant and accurate.
 				</p>
 
 				<h3 class="mb-4 mt-10 text-2xl font-semibold">The AI Workflow</h3>
@@ -305,9 +303,7 @@
 						<ul class="mb-4 ml-6 space-y-2">
 							<li>A numbered question format</li>
 							<li>Multiple-choice options</li>
-							<li>
-								An explanation section that details why certain options are correct or incorrect
-							</li>
+							<li>A rationale section that details why certain options are correct or incorrect</li>
 						</ul>
 						<p class="mb-2 italic">Example Prompt Block:</p>
 						<pre class="bg-base-300 p-6 rounded-lg text-sm overflow-x-auto mb-4">
@@ -345,9 +341,9 @@ multiple answers."
 
 				<h3 class="mb-4 mt-8 text-2xl font-semibold">Overview of the Exam Module</h3>
 				<p class="mb-8 text-lg leading-relaxed">
-					The <strong>Exam Module</strong> is designed to replicate the experience of ExamSoft while
-					integrating modern features inspired by user feedback. This module is at the heart of LearnTerms
-					v2 and is built to provide a comprehensive exam preparation experience.
+					The <strong>Exam Module</strong> is designed to replicate the experience of ExamSoft while integrating
+					modern features inspired by user feedback. This module is at the heart of LearnTerms v2 and
+					is built to provide a comprehensive exam preparation experience.
 				</p>
 
 				<h3 class="mb-4 mt-10 text-2xl font-semibold">Core Features</h3>
@@ -369,8 +365,8 @@ multiple answers."
 						seamless cross-device study sessions.
 					</li>
 					<li class="leading-relaxed">
-						<strong>Keyboard Shortcuts:</strong> Use intuitive shortcuts (like Tab for solutions and
-						arrow keys for navigation) to speed up your study sessions.
+						<strong>Keyboard Shortcuts:</strong> Use intuitive shortcuts (like Tab for solutions and arrow
+						keys for navigation) to speed up your study sessions.
 					</li>
 				</ul>
 
@@ -402,8 +398,8 @@ multiple answers."
 						can boost your confidence on test day.
 					</li>
 					<li class="leading-relaxed">
-						<strong>Improved Performance:</strong> Regular practice with tailored questions leads to
-						deeper understanding and better exam results.
+						<strong>Improved Performance:</strong> Regular practice with tailored questions leads to deeper
+						understanding and better exam results.
 					</li>
 					<li class="leading-relaxed">
 						<strong>Reduced Anxiety:</strong> With tools like progress tracking and the ability to reset
@@ -489,9 +485,9 @@ multiple answers."
 			<li class="flex gap-3 items-start">
 				<span class="text-primary mt-1">✨</span>
 				<span class="text-base-content/90"
-					>Thanks to <span class="font-medium">Colby and Austin</span> for case testing the platform
-					in real time during the beta period. This natural interaction helped me dial in the typical
-					user interaction.</span
+					>Thanks to <span class="font-medium">Colby and Austin</span> for case testing the platform in
+					real time during the beta period. This natural interaction helped me dial in the typical user
+					interaction.</span
 				>
 			</li>
 

--- a/src/lib/components/MobileMenu.svelte
+++ b/src/lib/components/MobileMenu.svelte
@@ -24,6 +24,7 @@
 	import { QUESTION_TYPES } from '$lib/utils/questionType';
 	import { captureQuestionAnswered } from '$lib/analytics/questionAnswered';
 	import { getRationale, hasRationale } from '$lib/utils/rationale';
+	import { sanitizeHtml } from '$lib/utils/sanitizeHtml';
 
 	const clerk = useClerkContext();
 	const clerkUser = $derived(clerk.user);
@@ -53,6 +54,7 @@
 	});
 
 	const canShowRationale = $derived.by(() => hasRationale(currentlySelected));
+	const sanitizedRationale = $derived(sanitizeHtml(getRationale(currentlySelected)));
 
 	$effect(() => {
 		if (!qs.showSolution || !canShowRationale) {
@@ -285,7 +287,7 @@
 			</form>
 			<h3 class="text-lg font-bold">Rationale</h3>
 			{#if canShowRationale}
-				<div class="py-4 tiptap-content">{@html getRationale(currentlySelected)}</div>
+				<div class="py-4 tiptap-content">{@html sanitizedRationale}</div>
 			{/if}
 		</div>
 	</dialog>

--- a/src/lib/components/MobileMenu.svelte
+++ b/src/lib/components/MobileMenu.svelte
@@ -23,6 +23,7 @@
 	import type { Doc, Id } from '../../convex/_generated/dataModel';
 	import { QUESTION_TYPES } from '$lib/utils/questionType';
 	import { captureQuestionAnswered } from '$lib/analytics/questionAnswered';
+	import { getRationale, hasRationale } from '$lib/utils/rationale';
 
 	const clerk = useClerkContext();
 	const clerkUser = $derived(clerk.user);
@@ -51,15 +52,10 @@
 		error: mediaQuery.error
 	});
 
-	const hasRationale = $derived.by(() => {
-		const explanation = currentlySelected?.explanation;
-		if (typeof explanation !== 'string') return false;
-		const normalized = explanation.trim().toLowerCase();
-		return normalized.length > 0 && normalized !== 'undefined' && normalized !== 'null';
-	});
+	const canShowRationale = $derived.by(() => hasRationale(currentlySelected));
 
 	$effect(() => {
-		if (!qs.showSolution || !hasRationale) {
+		if (!qs.showSolution || !canShowRationale) {
 			qs.isModalOpen = false;
 		}
 	});
@@ -228,9 +224,13 @@
 		</ul>
 	</div>
 	<button class="btn btn-outline btn-sm rounded-full" onclick={handleClear}>Clear</button>
-	<button class="btn btn-outline btn-success btn-sm btn-circle" onclick={handleCheck}><Check size={18} /></button>
+	<button class="btn btn-outline btn-success btn-sm btn-circle" onclick={handleCheck}
+		><Check size={18} /></button
+	>
 	<button
-		class="btn btn-sm btn-circle {qs.currentQuestionFlagged ? 'btn-warning' : 'btn-warning btn-soft'}"
+		class="btn btn-sm btn-circle {qs.currentQuestionFlagged
+			? 'btn-warning'
+			: 'btn-warning btn-soft'}"
 		aria-label={qs.currentQuestionFlagged ? 'Remove flag' : 'Flag question'}
 		onclick={handleFlag}
 	>
@@ -272,7 +272,10 @@
 		<ArrowRight size={20} />
 	</button>
 
-	<dialog class="modal modal-bottom sm:modal-middle max-w-full p-0 sm:p-4" class:modal-open={qs.isModalOpen}>
+	<dialog
+		class="modal modal-bottom sm:modal-middle max-w-full p-0 sm:p-4"
+		class:modal-open={qs.isModalOpen}
+	>
 		<div class="modal-box rounded-t-3xl sm:rounded-2xl max-h-[65vh]">
 			<form method="dialog">
 				<button
@@ -281,8 +284,8 @@
 				>
 			</form>
 			<h3 class="text-lg font-bold">Rationale</h3>
-			{#if hasRationale}
-				<div class="py-4 tiptap-content">{@html currentlySelected.explanation}</div>
+			{#if canShowRationale}
+				<div class="py-4 tiptap-content">{@html getRationale(currentlySelected)}</div>
 			{/if}
 		</div>
 	</dialog>
@@ -358,7 +361,7 @@
 	<SettingsModal bind:qs bind:isOpen={isSettingsModalOpen} />
 </div>
 
-{#if qs.showSolution && hasRationale && !qs.isModalOpen}
+{#if qs.showSolution && canShowRationale && !qs.isModalOpen}
 	<button
 		class="fixed right-4 z-[60] md:hidden btn btn-sm btn-soft rounded-full border border-base-300/70 bg-base-100/85 backdrop-blur-sm normal-case shadow-sm"
 		style="bottom: calc(env(safe-area-inset-bottom, 0px) + 6.25rem);"

--- a/src/lib/components/QuizSideBar.svelte
+++ b/src/lib/components/QuizSideBar.svelte
@@ -3,12 +3,14 @@
 	import SettingsModal from '$lib/components/SettingsModal.svelte';
 	import QuestionAttachmentsSidebar from '$lib/components/QuestionAttachmentsSidebar.svelte';
 	import { getRationale, hasRationale } from '$lib/utils/rationale';
+	import { sanitizeHtml } from '$lib/utils/sanitizeHtml';
 
 	let { qs = $bindable(), module, currentlySelected, userId, moduleId, client, classId } = $props();
 	let hideSidebar = $state(false);
 	let isInfoModalOpen = $state(false);
 	let isSolutionModalOpen = $state(false);
 	let isSettingsModalOpen = $state(false);
+	const sanitizedRationale = $derived(sanitizeHtml(getRationale(currentlySelected)));
 
 	async function handleReset() {
 		if (userId && moduleId && client) {
@@ -88,7 +90,7 @@
 						<div
 							class={`mt-2 break-words hyphens-auto transition-all duration-300 tiptap-content ${qs.showSolution ? 'blur-none' : 'blur-sm'}`}
 						>
-							{@html getRationale(currentlySelected)}
+							{@html sanitizedRationale}
 						</div>
 					</div>
 				</div>
@@ -183,7 +185,7 @@
 		</form>
 		<h3 class="text-lg font-bold">Rationale</h3>
 		{#if hasRationale(currentlySelected)}
-			<div class="py-4 tiptap-content">{@html getRationale(currentlySelected)}</div>
+			<div class="py-4 tiptap-content">{@html sanitizedRationale}</div>
 		{/if}
 	</div>
 </dialog>

--- a/src/lib/components/QuizSideBar.svelte
+++ b/src/lib/components/QuizSideBar.svelte
@@ -2,6 +2,7 @@
 	import { PanelRight, Eye, Info, ChevronLeft, Settings } from 'lucide-svelte';
 	import SettingsModal from '$lib/components/SettingsModal.svelte';
 	import QuestionAttachmentsSidebar from '$lib/components/QuestionAttachmentsSidebar.svelte';
+	import { getRationale, hasRationale } from '$lib/utils/rationale';
 
 	let { qs = $bindable(), module, currentlySelected, userId, moduleId, client, classId } = $props();
 	let hideSidebar = $state(false);
@@ -15,7 +16,6 @@
 			qs.isResetModalOpen = false;
 		}
 	}
-
 </script>
 
 <div
@@ -46,10 +46,7 @@
 	{#if !hideSidebar}
 		<div class="p-4 md:p-5 lg:p-6 pt-12 mt-8">
 			<h4 class="font-bold text-sm tracking-wide text-secondary -ms-6">
-				<a
-					class="btn btn-ghost font-bold rounded-full"
-					href={`/classes?classId=${classId}`}
-				>
+				<a class="btn btn-ghost font-bold rounded-full" href={`/classes?classId=${classId}`}>
 					<ChevronLeft size={16} /> MODULE {module.data.order + 1}
 				</a>
 			</h4>
@@ -76,10 +73,7 @@
 				solutionOnlyBehavior="blur"
 			/>
 
-			{#if typeof currentlySelected.explanation === 'string' && (() => {
-					const t = currentlySelected.explanation.trim().toLowerCase();
-					return t.length > 0 && t !== 'undefined' && t !== 'null';
-				})()}
+			{#if hasRationale(currentlySelected)}
 				<div class="card bg-base-100 shadow-xl mt-6 rounded-2xl">
 					<div class="card-body">
 						<div class="flex flex-row flex-wrap justify-between border-b pb-2">
@@ -94,14 +88,17 @@
 						<div
 							class={`mt-2 break-words hyphens-auto transition-all duration-300 tiptap-content ${qs.showSolution ? 'blur-none' : 'blur-sm'}`}
 						>
-							{@html currentlySelected.explanation}
+							{@html getRationale(currentlySelected)}
 						</div>
 					</div>
 				</div>
 			{/if}
 
 			<div class="flex flex-row mt-6 justify-center">
-				<button class="btn btn-soft btn-sm rounded-full" onclick={() => (isSettingsModalOpen = true)}>
+				<button
+					class="btn btn-soft btn-sm rounded-full"
+					onclick={() => (isSettingsModalOpen = true)}
+				>
 					<Settings size={16} />
 					<span class="ml-1 hidden sm:inline">Settings</span>
 				</button>
@@ -156,10 +153,7 @@
 			</button>
 		</div>
 	{/if}
-
 </div>
-
- 
 
 <dialog class="modal max-w-full p-4" class:modal-open={isInfoModalOpen}>
 	<div class="modal-box rounded-2xl">
@@ -188,8 +182,8 @@
 			>
 		</form>
 		<h3 class="text-lg font-bold">Rationale</h3>
-		{#if typeof currentlySelected.explanation === 'string' && currentlySelected.explanation.trim().length > 0}
-			<div class="py-4 tiptap-content">{@html currentlySelected.explanation}</div>
+		{#if hasRationale(currentlySelected)}
+			<div class="py-4 tiptap-content">{@html getRationale(currentlySelected)}</div>
 		{/if}
 	</div>
 </dialog>

--- a/src/lib/components/landing/LandingPage.svelte
+++ b/src/lib/components/landing/LandingPage.svelte
@@ -494,7 +494,7 @@
 					</div>
 					<h3 class="text-xl font-semibold">Rationale-first questions</h3>
 					<p class="mt-2 text-sm text-base-content/75">
-						Every question is built with an explanation baked in — AI-generated or hand-written.
+						Every question is built with a rationale baked in — AI-generated or hand-written.
 						Students don't just get answers, they get the why.
 					</p>
 

--- a/src/lib/components/landing/QuizPreviewReplica.svelte
+++ b/src/lib/components/landing/QuizPreviewReplica.svelte
@@ -19,7 +19,7 @@
 		stem: string;
 		options: Option[];
 		correctAnswers: string[];
-		explanation: string;
+		rationale: string;
 	};
 
 	const questions: Question[] = [
@@ -33,7 +33,7 @@
 				{ id: 'D', text: 'Optic neuritis' }
 			],
 			correctAnswers: ['A'],
-			explanation:
+			rationale:
 				'Keratoconus causes progressive corneal thinning and cone-like protrusion, creating irregular astigmatism and worsening myopia, often first seen on corneal topography.'
 		},
 		{
@@ -46,7 +46,7 @@
 				{ id: 'D', text: 'Hypopyon in the anterior chamber' }
 			],
 			correctAnswers: ['A'],
-			explanation:
+			rationale:
 				'Anterior blepharitis often presents with inflamed lid margins and lash debris or collarettes. Targeting lid hygiene and inflammation control is central to treatment.'
 		},
 		{
@@ -59,7 +59,7 @@
 				{ id: 'D', text: 'Epiretinal membrane' }
 			],
 			correctAnswers: ['A'],
-			explanation:
+			rationale:
 				'Macular disease commonly distorts central vision and straight lines. Metamorphopsia should raise concern for AMD or other macular pathology.'
 		},
 		{
@@ -72,7 +72,7 @@
 				{ id: 'D', text: 'Use plus cylinder at 90 degrees for all cases' }
 			],
 			correctAnswers: ['A'],
-			explanation:
+			rationale:
 				'Astigmatism correction requires cylindrical power aligned to the refractive axis. Myopic astigmatism specifically needs minus-cylinder correction in the appropriate meridian.'
 		},
 		{
@@ -85,7 +85,7 @@
 				{ id: 'D', text: 'A cylindrical lens only' }
 			],
 			correctAnswers: ['A'],
-			explanation:
+			rationale:
 				'Aphakia removes the natural positive lens power of the eye, so correction requires strong plus power from an intraocular lens or external convex lens.'
 		},
 		{
@@ -98,7 +98,7 @@
 				{ id: 'D', text: 'Blepharitis' }
 			],
 			correctAnswers: ['B'],
-			explanation:
+			rationale:
 				'Diabetic retinopathy frequently shows microvascular retinal damage, including microaneurysms, hemorrhages, and cotton-wool spots on fundus exam.'
 		}
 	];
@@ -106,7 +106,8 @@
 	const moduleInfo = {
 		emoji: '👁️',
 		title: 'Ocular Pathology & Optics',
-		description: 'Focused question reps for astigmatism, anterior blepharitis, retina, and corneal disease.',
+		description:
+			'Focused question reps for astigmatism, anterior blepharitis, retina, and corneal disease.',
 		order: 2
 	};
 
@@ -282,7 +283,7 @@
 							<div
 								class={`tiptap-content mt-2 transition-all duration-300 ${showSolution ? 'blur-none' : 'blur-sm'}`}
 							>
-								{currentQuestion.explanation}
+								{currentQuestion.rationale}
 							</div>
 						</div>
 					</div>

--- a/src/lib/utils/questionExport.ts
+++ b/src/lib/utils/questionExport.ts
@@ -350,7 +350,8 @@ export function exportAsJson(
  * Export questions as CSV (simple format for spreadsheets)
  * Dynamically handles any number of options
  */
-export function exportAsCsv(questions: ExportableQuestion[], moduleTitle: string): string {
+export function exportAsCsv(questions: ExportableQuestion[], options: ExportOptions = {}): string {
+	const { includeRationales = true } = options;
 	const rows: string[] = [];
 
 	// Find max options across all questions (for multiple choice)
@@ -366,13 +367,15 @@ export function exportAsCsv(questions: ExportableQuestion[], moduleTitle: string
 		String.fromCharCode('A'.charCodeAt(0) + i)
 	).map((letter) => `Option ${letter}`);
 
-	rows.push(
-		['Question #', 'Type', 'Question', ...optionHeaders, 'Correct Answer(s)', 'Rationale'].join(',')
-	);
+	const header = ['Question #', 'Type', 'Question', ...optionHeaders, 'Correct Answer(s)'];
+	if (includeRationales) {
+		header.push('Rationale');
+	}
+	rows.push(header.join(','));
 
 	questions.forEach((q, index) => {
 		const stem = escapeCsv(q.stem);
-		const rationale = getRationale(q) ? escapeCsv(getRationale(q)) : '';
+		const rationale = includeRationales && getRationale(q) ? escapeCsv(getRationale(q)) : '';
 
 		let optionValues: string[];
 		let correctAnswerStr: string;
@@ -399,7 +402,10 @@ export function exportAsCsv(questions: ExportableQuestion[], moduleTitle: string
 		// Pad options to match header
 		while (optionValues.length < maxOptions) optionValues.push('');
 
-		const row = [index + 1, q.type, stem, ...optionValues, correctAnswerStr, rationale];
+		const row = [index + 1, q.type, stem, ...optionValues, correctAnswerStr];
+		if (includeRationales) {
+			row.push(rationale);
+		}
 
 		rows.push(row.join(','));
 	});
@@ -461,7 +467,7 @@ export function exportModuleQuestions(
 			mimeType = 'application/json';
 			break;
 		case 'csv':
-			content = exportAsCsv(questions, moduleTitle);
+			content = exportAsCsv(questions, options);
 			filename = `${baseFilename}-questions-${timestamp}.csv`;
 			mimeType = 'text/csv';
 			break;

--- a/src/lib/utils/questionExport.ts
+++ b/src/lib/utils/questionExport.ts
@@ -12,12 +12,15 @@
  * - Special characters and newlines
  */
 
+import { getRationale } from './rationale';
+
 export interface ExportableQuestion {
 	_id?: string;
 	type: string;
 	stem: string;
 	options: Array<{ id?: string; text: string }>;
 	correctAnswers: string[];
+	rationale?: string | null;
 	explanation?: string | null;
 	status?: string;
 	order?: number;
@@ -29,7 +32,7 @@ export interface ExportableQuestion {
 export interface ExportOptions {
 	includeMetadata?: boolean;
 	includeIds?: boolean;
-	includeExplanations?: boolean;
+	includeRationales?: boolean;
 }
 
 /**
@@ -190,7 +193,7 @@ export function exportAsText(
 	moduleTitle: string,
 	options: ExportOptions = {}
 ): string {
-	const { includeExplanations = true } = options;
+	const { includeRationales = true } = options;
 	const lines: string[] = [];
 
 	lines.push('='.repeat(60));
@@ -252,10 +255,11 @@ export function exportAsText(
 			lines.push(`Correct Answer(s): ${correctLetters.join(', ')}`);
 		}
 
-		if (includeExplanations && q.explanation) {
+		const rationale = getRationale(q);
+		if (includeRationales && rationale) {
 			lines.push('');
-			lines.push('Explanation:');
-			lines.push(stripHtml(q.explanation));
+			lines.push('Rationale:');
+			lines.push(stripHtml(rationale));
 		}
 
 		lines.push('');
@@ -277,7 +281,7 @@ export function exportAsJson(
 	moduleTitle: string,
 	options: ExportOptions = {}
 ): string {
-	const { includeMetadata = false, includeIds = false, includeExplanations = true } = options;
+	const { includeMetadata = false, includeIds = false, includeRationales = true } = options;
 
 	const exportData = {
 		module: moduleTitle,
@@ -317,8 +321,9 @@ export function exportAsJson(
 				questionData.correctAnswerLetters = correctLetters;
 			}
 
-			if (includeExplanations && q.explanation) {
-				questionData.explanation = stripHtml(q.explanation);
+			const rationale = getRationale(q);
+			if (includeRationales && rationale) {
+				questionData.rationale = stripHtml(rationale);
 			}
 
 			if (includeMetadata) {
@@ -345,10 +350,7 @@ export function exportAsJson(
  * Export questions as CSV (simple format for spreadsheets)
  * Dynamically handles any number of options
  */
-export function exportAsCsv(
-	questions: ExportableQuestion[],
-	moduleTitle: string
-): string {
+export function exportAsCsv(questions: ExportableQuestion[], moduleTitle: string): string {
 	const rows: string[] = [];
 
 	// Find max options across all questions (for multiple choice)
@@ -365,14 +367,12 @@ export function exportAsCsv(
 	).map((letter) => `Option ${letter}`);
 
 	rows.push(
-		['Question #', 'Type', 'Question', ...optionHeaders, 'Correct Answer(s)', 'Explanation'].join(
-			','
-		)
+		['Question #', 'Type', 'Question', ...optionHeaders, 'Correct Answer(s)', 'Rationale'].join(',')
 	);
 
 	questions.forEach((q, index) => {
 		const stem = escapeCsv(q.stem);
-		const explanation = q.explanation ? escapeCsv(q.explanation) : '';
+		const rationale = getRationale(q) ? escapeCsv(getRationale(q)) : '';
 
 		let optionValues: string[];
 		let correctAnswerStr: string;
@@ -399,14 +399,7 @@ export function exportAsCsv(
 		// Pad options to match header
 		while (optionValues.length < maxOptions) optionValues.push('');
 
-		const row = [
-			index + 1,
-			q.type,
-			stem,
-			...optionValues,
-			correctAnswerStr,
-			explanation
-		];
+		const row = [index + 1, q.type, stem, ...optionValues, correctAnswerStr, rationale];
 
 		rows.push(row.join(','));
 	});

--- a/src/lib/utils/rationale.ts
+++ b/src/lib/utils/rationale.ts
@@ -1,0 +1,16 @@
+export type WithLegacyRationale = {
+	rationale?: string | null;
+	explanation?: string | null;
+};
+
+export function getRationale(value?: WithLegacyRationale | null): string {
+	if (!value) return '';
+	if (typeof value.rationale === 'string') return value.rationale;
+	if (typeof value.explanation === 'string') return value.explanation;
+	return '';
+}
+
+export function hasRationale(value?: WithLegacyRationale | null): boolean {
+	const normalized = getRationale(value).trim().toLowerCase();
+	return normalized.length > 0 && normalized !== 'undefined' && normalized !== 'null';
+}

--- a/src/lib/utils/rationale.ts
+++ b/src/lib/utils/rationale.ts
@@ -3,14 +3,20 @@ export type WithLegacyRationale = {
 	explanation?: string | null;
 };
 
+function normalizeRationaleValue(value: string | null | undefined): string {
+	if (typeof value !== 'string') return '';
+	const trimmed = value.trim();
+	if (!trimmed) return '';
+	const normalized = trimmed.toLowerCase();
+	if (normalized === 'undefined' || normalized === 'null') return '';
+	return trimmed;
+}
+
 export function getRationale(value?: WithLegacyRationale | null): string {
 	if (!value) return '';
-	if (typeof value.rationale === 'string') return value.rationale;
-	if (typeof value.explanation === 'string') return value.explanation;
-	return '';
+	return normalizeRationaleValue(value.rationale) || normalizeRationaleValue(value.explanation);
 }
 
 export function hasRationale(value?: WithLegacyRationale | null): boolean {
-	const normalized = getRationale(value).trim().toLowerCase();
-	return normalized.length > 0 && normalized !== 'undefined' && normalized !== 'null';
+	return getRationale(value).length > 0;
 }

--- a/src/lib/utils/sanitizeHtml.ts
+++ b/src/lib/utils/sanitizeHtml.ts
@@ -1,0 +1,17 @@
+import { browser } from '$app/environment';
+import createDOMPurify from 'dompurify';
+
+let domPurify: ReturnType<typeof createDOMPurify> | null = null;
+
+export function sanitizeHtml(value: string | undefined | null): string {
+	const raw = String(value ?? '');
+	if (!browser) {
+		return raw
+			.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+			.replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, '')
+			.replace(/\son[a-z]+\s*=\s*(["'])[\s\S]*?\1/gi, '')
+			.replace(/\s(href|src)\s*=\s*(["'])\s*javascript:[\s\S]*?\2/gi, ' $1="#"');
+	}
+	domPurify ??= createDOMPurify(window);
+	return domPurify.sanitize(raw);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,15 +12,19 @@
 	import { getPostHog } from '$lib/analytics/posthogClient';
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { browser } from '$app/environment';
+	import { browser, dev } from '$app/environment';
 
 	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
 
-	injectSpeedInsights();
+	if (!dev) {
+		injectSpeedInsights();
+	}
 
 	setupConvex(PUBLIC_CONVEX_URL);
 
-	injectAnalytics();
+	if (!dev) {
+		injectAnalytics();
+	}
 
 	const { data, children } = $props();
 
@@ -189,7 +193,7 @@
 
 					<nav aria-label="Resources" class="flex flex-col space-y-1">
 						<h6 class="footer-title">Resources</h6>
-						<a class="link link-hover" href="/docs">Docs</a>
+						<a class="link link-hover" href="https://docs.learnterms.com/">Docs</a>
 						<a class="link link-hover" href="/blog">Blog</a>
 						<a class="link link-hover" href="/status">Status</a>
 					</nav>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,13 +18,10 @@
 
 	if (!dev) {
 		injectSpeedInsights();
+		injectAnalytics();
 	}
 
 	setupConvex(PUBLIC_CONVEX_URL);
-
-	if (!dev) {
-		injectAnalytics();
-	}
 
 	const { data, children } = $props();
 

--- a/src/routes/admin/[classId]/+page.svelte
+++ b/src/routes/admin/[classId]/+page.svelte
@@ -5,17 +5,7 @@
 	import type { Id, Doc } from '../../../convex/_generated/dataModel';
 	import { api } from '../../../convex/_generated/api.js';
 	import { flip } from 'svelte/animate';
-	import {
-		Pencil,
-		Trash2,
-		Plus,
-		ArrowLeft,
-		GripVertical,
-		Download,
-		FileText,
-		FileJson,
-		FileSpreadsheet
-	} from 'lucide-svelte';
+	import { Pencil, Trash2, Plus, ArrowLeft, GripVertical, Download } from 'lucide-svelte';
 	import { resolve } from '$app/paths';
 	import { exportModuleQuestions, type ExportableQuestion } from '$lib/utils/questionExport';
 	import EditModuleModal from '$lib/admin/EditModuleModal.svelte';
@@ -42,7 +32,6 @@
 	const userDataQuery = useQuery(api.users.getUserById, () =>
 		clerkUser ? { id: clerkUser.id } : 'skip'
 	);
-	const dev = $derived(userDataQuery.data?.role === 'dev');
 	const admin = $derived(
 		userDataQuery.data?.role === 'admin' || userDataQuery.data?.role === 'dev'
 	);

--- a/src/routes/admin/[classId]/+page.svelte
+++ b/src/routes/admin/[classId]/+page.svelte
@@ -5,7 +5,17 @@
 	import type { Id, Doc } from '../../../convex/_generated/dataModel';
 	import { api } from '../../../convex/_generated/api.js';
 	import { flip } from 'svelte/animate';
-	import { Pencil, Trash2, Plus, ArrowLeft, GripVertical, Download, FileText, FileJson, FileSpreadsheet } from 'lucide-svelte';
+	import {
+		Pencil,
+		Trash2,
+		Plus,
+		ArrowLeft,
+		GripVertical,
+		Download,
+		FileText,
+		FileJson,
+		FileSpreadsheet
+	} from 'lucide-svelte';
 	import { resolve } from '$app/paths';
 	import { exportModuleQuestions, type ExportableQuestion } from '$lib/utils/questionExport';
 	import EditModuleModal from '$lib/admin/EditModuleModal.svelte';
@@ -29,20 +39,21 @@
 	const clerk = useClerkContext();
 	const clerkUser = $derived(clerk.user);
 
-	const userDataQuery = useQuery(
-		api.users.getUserById,
-		() => clerkUser ? { id: clerkUser.id } : 'skip'
+	const userDataQuery = useQuery(api.users.getUserById, () =>
+		clerkUser ? { id: clerkUser.id } : 'skip'
 	);
 	const dev = $derived(userDataQuery.data?.role === 'dev');
-	const admin = $derived(userDataQuery.data?.role === 'admin' || userDataQuery.data?.role === 'dev');
+	const admin = $derived(
+		userDataQuery.data?.role === 'admin' || userDataQuery.data?.role === 'dev'
+	);
 	const userData = $derived(userDataQuery.data ?? null);
 
 	// Check Pro status for export gating
 	const subscriptionQuery = useQuery(api.polar.getCurrentUserWithSubscription, {});
 	const isPro = $derived(
 		subscriptionQuery.data?.isPro ||
-		subscriptionQuery.data?.subscription?.status === 'active' ||
-		subscriptionQuery.data?.subscription?.status === 'trialing'
+			subscriptionQuery.data?.subscription?.status === 'active' ||
+			subscriptionQuery.data?.subscription?.status === 'trialing'
 	);
 
 	type ClassItem = Doc<'class'>;
@@ -58,11 +69,11 @@
 	let isDeleteModuleModalOpen = $state(false);
 	let moduleToDelete = $state<ModuleItem | null>(null);
 	let moduleQuestionCount = $state<number>(0);
-	
+
 	// Export state
 	let isExportModalOpen = $state(false);
 	let exportModuleItem = $state<ModuleItem | null>(null);
-	
+
 	// UI State
 	let reorderMode = $state(false);
 
@@ -243,7 +254,7 @@
 			}
 
 			exportModuleQuestions(questions as ExportableQuestion[], exportModuleItem.title, format, {
-				includeExplanations: true,
+				includeRationales: true,
 				includeMetadata: format === 'json'
 			});
 			closeExportModal();
@@ -257,7 +268,8 @@
 </script>
 
 <div class="min-h-screen p-8 max-w-7xl mx-auto">
-	<a class="btn mb-4 btn-ghost rounded-full" href={resolve('/admin')}><ArrowLeft size={16} />Back</a>
+	<a class="btn mb-4 btn-ghost rounded-full" href={resolve('/admin')}><ArrowLeft size={16} />Back</a
+	>
 	<div class="mb-8 flex flex-col gap-2">
 		<div class="flex flex-col gap-4 sm:flex-row sm:justify-between sm:items-center">
 			{#if classInfo.isLoading}
@@ -281,16 +293,17 @@
 				<div>
 					<h1 class="text-xl sm:text-2xl font-bold text-base-content">{classInfo.data.name}</h1>
 					<p class="text-sm sm:text-base text-base-content/70">
-						Manage your learning modules for {classInfo.data.code}. {#if reorderMode}Drag to reorder.{/if}
+						Manage your learning modules for {classInfo.data.code}. {#if reorderMode}Drag to
+							reorder.{/if}
 					</p>
 				</div>
 			{/if}
 
 			<div class="flex items-center gap-2 self-start sm:self-auto">
 				{#if admin}
-					<button 
-						class="btn rounded-full gap-2 {reorderMode ? 'btn-primary' : 'btn-ghost'}" 
-						onclick={() => reorderMode = !reorderMode}
+					<button
+						class="btn rounded-full gap-2 {reorderMode ? 'btn-primary' : 'btn-ghost'}"
+						onclick={() => (reorderMode = !reorderMode)}
 					>
 						<GripVertical size={16} />
 						<span class="hidden sm:inline">{reorderMode ? 'Done' : 'Reorder'}</span>
@@ -371,12 +384,18 @@
 												class="font-semibold text-base-content text-left hover:text-primary transition-colors cursor-pointer block"
 												title={`Go to questions for ${moduleItem.title}`}
 											>
-												<span class="mr-2 text-xl inline-block align-middle">{moduleItem.emoji || '📘'}</span>
+												<span class="mr-2 text-xl inline-block align-middle"
+													>{moduleItem.emoji || '📘'}</span
+												>
 												<span class="align-middle break-words">{moduleItem.title}</span>
 											</a>
 										</div>
 									</div>
-									<div class="text-xs text-base-content/60 flex items-center gap-1 {reorderMode ? 'pl-7' : ''}">
+									<div
+										class="text-xs text-base-content/60 flex items-center gap-1 {reorderMode
+											? 'pl-7'
+											: ''}"
+									>
 										<span>
 											{moduleItem.questionCount} question{moduleItem.questionCount === 1 ? '' : 's'}
 										</span>
@@ -384,7 +403,9 @@
 									{#if moduleItem.tags && moduleItem.tags.length > 0}
 										<div class="flex flex-wrap items-center gap-2 mt-2">
 											{#each moduleItem.tags.slice(0, 3) as tag (tag._id)}
-												<span class="inline-flex items-center gap-1 rounded-full border border-base-300 px-2 py-0.5 text-xs">
+												<span
+													class="inline-flex items-center gap-1 rounded-full border border-base-300 px-2 py-0.5 text-xs"
+												>
 													<span
 														class="h-2 w-2 rounded-full"
 														style={`background-color: ${tag.color || '#94a3b8'}`}
@@ -406,7 +427,9 @@
 													>
 														<div class="flex flex-col gap-1">
 															{#each moduleItem.tags.slice(3) as tag (tag._id)}
-																<div class="flex items-center gap-2 rounded-md px-2 py-1 text-xs hover:bg-base-200/70">
+																<div
+																	class="flex items-center gap-2 rounded-md px-2 py-1 text-xs hover:bg-base-200/70"
+																>
 																	<span
 																		class="h-2 w-2 rounded-full"
 																		style={`background-color: ${tag.color || '#94a3b8'}`}
@@ -524,7 +547,7 @@
 	questionCount={moduleQuestionCount}
 />
 
-<ExportModuleModal 
+<ExportModuleModal
 	isOpen={isExportModalOpen}
 	onClose={closeExportModal}
 	onExport={handleExport}

--- a/src/routes/admin/library/+page.svelte
+++ b/src/routes/admin/library/+page.svelte
@@ -21,6 +21,7 @@
 	import type { Id, Doc } from '../../../convex/_generated/dataModel';
 	import { useClerkContext } from 'svelte-clerk';
 	import { replaceState } from '$app/navigation';
+	import { resolve } from '$app/paths';
 
 	let { data }: { data: PageData } = $props();
 	const client = useConvexClient();
@@ -51,7 +52,7 @@
 			currentDocView = openId;
 			currentDocument = target;
 			params.delete('open');
-			const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+			const newUrl = `${resolve('/admin/library')}${params.toString() ? `?${params.toString()}` : ''}`;
 			replaceState(newUrl, {});
 		}
 	});

--- a/src/routes/admin/library/+page.svelte
+++ b/src/routes/admin/library/+page.svelte
@@ -20,6 +20,7 @@
 	import { api } from '../../../convex/_generated/api';
 	import type { Id, Doc } from '../../../convex/_generated/dataModel';
 	import { useClerkContext } from 'svelte-clerk';
+	import { replaceState } from '$app/navigation';
 
 	let { data }: { data: PageData } = $props();
 	const client = useConvexClient();
@@ -28,15 +29,15 @@
 	const clerkUser = $derived(clerk.user);
 
 	// useQuery at top level with skip pattern
-	const userDataQuery = useQuery(
-		api.users.getUserById,
-		() => clerkUser ? { id: clerkUser.id } : 'skip'
+	const userDataQuery = useQuery(api.users.getUserById, () =>
+		clerkUser ? { id: clerkUser.id } : 'skip'
 	);
 
 	// useQuery at top level with skip pattern - depends on userDataQuery
-	const userContentLib = useQuery(
-		api.contentLib.getContentLibByCohort,
-		() => userDataQuery.data?.cohortId ? { cohortId: userDataQuery.data.cohortId as Id<'cohort'> } : 'skip'
+	const userContentLib = useQuery(api.contentLib.getContentLibByCohort, () =>
+		userDataQuery.data?.cohortId
+			? { cohortId: userDataQuery.data.cohortId as Id<'cohort'> }
+			: 'skip'
 	);
 
 	$effect(() => {
@@ -51,7 +52,7 @@
 			currentDocument = target;
 			params.delete('open');
 			const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-			history.replaceState({}, '', newUrl);
+			replaceState(newUrl, {});
 		}
 	});
 
@@ -188,16 +189,21 @@
 					<div class="space-y-0.5">
 						<h1 class="font-semibold text-2xl">My Documents</h1>
 						<p class="text-base-content/70 text-sm">
-							{totalDocs} {totalDocs === 1 ? 'item' : 'items'} in your library
+							{totalDocs}
+							{totalDocs === 1 ? 'item' : 'items'} in your library
 						</p>
 					</div>
 					<div class="flex flex-wrap gap-2">
-						<button class="btn btn-primary btn-sm rounded-full" onclick={openAddModal}><Plus size={16} /> Add Document</button>
+						<button class="btn btn-primary btn-sm rounded-full" onclick={openAddModal}
+							><Plus size={16} /> Add Document</button
+						>
 					</div>
 				</div>
 
 				<div>
-					<label class="input input-bordered input-sm rounded-full flex items-center gap-2 max-w-md">
+					<label
+						class="input input-bordered input-sm rounded-full flex items-center gap-2 max-w-md"
+					>
 						<Search size={14} class="text-base-content/60" />
 						<input
 							type="text"
@@ -228,7 +234,9 @@
 						<span>Unable to load your library right now.</span>
 					</div>
 				{:else if !userContentLib.data || userContentLib.data.length === 0}
-					<div class="rounded-2xl border-2 border-dashed border-base-300 bg-base-100 p-12 text-center space-y-4">
+					<div
+						class="rounded-2xl border-2 border-dashed border-base-300 bg-base-100 p-12 text-center space-y-4"
+					>
 						<div class="flex items-center justify-center">
 							<div class="p-3 rounded-full bg-primary/10">
 								<File size={24} class="text-primary" />
@@ -240,17 +248,25 @@
 								Start building your library by uploading your first document
 							</p>
 						</div>
-						<button class="btn btn-primary btn-sm rounded-full" onclick={openAddModal}><Plus size={16} /> Add your first document</button>
+						<button class="btn btn-primary btn-sm rounded-full" onclick={openAddModal}
+							><Plus size={16} /> Add your first document</button
+						>
 					</div>
 				{:else if filteredDocs.length === 0}
-					<div class="rounded-2xl border border-base-300 bg-base-100 p-6 flex flex-col sm:flex-row items-center justify-between gap-3">
+					<div
+						class="rounded-2xl border border-base-300 bg-base-100 p-6 flex flex-col sm:flex-row items-center justify-between gap-3"
+					>
 						<div>
 							<p class="font-semibold">No matching documents</p>
 							<p class="text-sm text-base-content/70">Try adjusting your search terms</p>
 						</div>
-						<button class="btn btn-ghost btn-sm" type="button" onclick={() => {
-							searchTerm = '';
-						}}>Clear search</button>
+						<button
+							class="btn btn-ghost btn-sm"
+							type="button"
+							onclick={() => {
+								searchTerm = '';
+							}}>Clear search</button
+						>
 					</div>
 				{:else}
 					<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
@@ -267,13 +283,17 @@
 								tabindex="0"
 								role="button"
 							>
-								<div class="absolute inset-0 pointer-events-none rounded-2xl border border-white/10"></div>
+								<div
+									class="absolute inset-0 pointer-events-none rounded-2xl border border-white/10"
+								></div>
 								<div class="card-body p-4 space-y-3">
 									<div class="flex items-start justify-between gap-2">
 										<div class="flex-1 min-w-0 space-y-1.5">
 											<div class="flex items-center gap-1.5 text-base-content">
 												<File size={14} class="shrink-0" />
-												<span class="text-base font-semibold leading-tight truncate">{doc.title}</span>
+												<span class="text-base font-semibold leading-tight truncate"
+													>{doc.title}</span
+												>
 											</div>
 											<p class="text-xs text-base-content/70 line-clamp-2">
 												{doc.description ? doc.description : 'No description'}
@@ -288,7 +308,10 @@
 											>
 												<MoreVertical size={14} />
 											</button>
-											<ul role="menu" class="dropdown-content menu bg-base-100 rounded-2xl w-40 p-1.5 shadow-lg border border-base-300 z-10">
+											<ul
+												role="menu"
+												class="dropdown-content menu bg-base-100 rounded-2xl w-40 p-1.5 shadow-lg border border-base-300 z-10"
+											>
 												<li>
 													<button
 														class="btn btn-xs btn-ghost w-full justify-start"
@@ -323,11 +346,19 @@
 									<div class="mt-auto pt-2 border-t border-base-300/50">
 										<div class="flex items-center gap-1.5 text-xs text-base-content/60">
 											<Clock3 size={12} />
-											<span class="truncate">{doc.updatedAt ? new Date(doc.updatedAt).toLocaleDateString() : 'No date'}</span>
+											<span class="truncate"
+												>{doc.updatedAt
+													? new Date(doc.updatedAt).toLocaleDateString()
+													: 'No date'}</span
+											>
 										</div>
 									</div>
 
-									<div class="text-[10px] uppercase tracking-wider text-base-content/50 font-medium">Click to open</div>
+									<div
+										class="text-[10px] uppercase tracking-wider text-base-content/50 font-medium"
+									>
+										Click to open
+									</div>
 								</div>
 							</div>
 						{/each}
@@ -338,7 +369,12 @@
 
 		<AddDocumentModal {isAddModalOpen} {closeAddModal} userData={userDataQuery.data} />
 
-		<EditDocumentModal {isEditModalOpen} {closeEditModal} {editingDocument} userData={userDataQuery.data} />
+		<EditDocumentModal
+			{isEditModalOpen}
+			{closeEditModal}
+			{editingDocument}
+			userData={userDataQuery.data}
+		/>
 
 		<DeleteConfirmationModal
 			{isDeleteModalOpen}

--- a/src/routes/admin/question-studio/+page.svelte
+++ b/src/routes/admin/question-studio/+page.svelte
@@ -24,24 +24,18 @@
 	const clerk = useClerkContext();
 	const clerkUser = $derived(clerk.user);
 
-	const convexUser = useQuery(
-		api.users.getUserById,
-		() => clerkUser ? { id: clerkUser.id } : 'skip'
+	const convexUser = useQuery(api.users.getUserById, () =>
+		clerkUser ? { id: clerkUser.id } : 'skip'
 	);
 
-	const semesters = useQuery(
-		api.semester.getAllSemesters,
-		() => clerkUser ? {} : 'skip'
+	const semesters = useQuery(api.semester.getAllSemesters, () => (clerkUser ? {} : 'skip'));
+
+	const classes = useQuery(api.class.getUserClasses, () =>
+		convexUser.data?.cohortId ? { id: convexUser.data.cohortId as Id<'cohort'> } : 'skip'
 	);
 
-	const classes = useQuery(
-		api.class.getUserClasses,
-		() => convexUser.data?.cohortId ? { id: convexUser.data.cohortId as Id<'cohort'> } : 'skip'
-	);
-
-	const modules = useQuery(
-		api.module.getClassModules,
-		() => selectedClass ? { id: selectedClass._id } : 'skip'
+	const modules = useQuery(api.module.getClassModules, () =>
+		selectedClass ? { id: selectedClass._id } : 'skip'
 	);
 	let currentSemester = $state('');
 	let classSearch = $state('');
@@ -54,7 +48,7 @@
 		stem: string;
 		options: { text: string }[];
 		correctAnswers: string[];
-		explanation: string;
+		rationale: string;
 		aiGenerated: boolean;
 		status: string;
 		order: number;
@@ -107,18 +101,17 @@
 	const searchedClasses = $derived(
 		!filteredClasses
 			? []
-			: filteredClasses.filter((c) =>
-				c.name.toLowerCase().includes(classSearch.toLowerCase()) ||
-				(c.code?.toLowerCase().includes(classSearch.toLowerCase()) ?? false)
-			)
+			: filteredClasses.filter(
+					(c) =>
+						c.name.toLowerCase().includes(classSearch.toLowerCase()) ||
+						(c.code?.toLowerCase().includes(classSearch.toLowerCase()) ?? false)
+				)
 	);
 
 	const searchedModules = $derived(
 		!modules.data
 			? []
-			: modules.data.filter((m) =>
-				m.title.toLowerCase().includes(moduleSearch.toLowerCase())
-			)
+			: modules.data.filter((m) => m.title.toLowerCase().includes(moduleSearch.toLowerCase()))
 	);
 
 	const isReady = $derived(selectedClass && selectedModuleId);
@@ -134,11 +127,15 @@
 			<div class="h-6 w-px bg-base-300"></div>
 			<div>
 				<h1 class="text-xl font-semibold">Question Studio</h1>
-				<p class="text-xs text-base-content/60 hidden sm:block">Generate questions from your content</p>
+				<p class="text-xs text-base-content/60 hidden sm:block">
+					Generate questions from your content
+				</p>
 			</div>
 		</div>
 
-		<div class="flex flex-wrap items-center gap-2 mb-6 p-3 bg-base-100 rounded-2xl border border-base-300">
+		<div
+			class="flex flex-wrap items-center gap-2 mb-6 p-3 bg-base-100 rounded-2xl border border-base-300"
+		>
 			<div class="dropdown">
 				<div tabindex="0" role="button" class="btn btn-sm btn-ghost rounded-full gap-2">
 					<FolderOpen size={14} class="text-base-content/60" />
@@ -146,7 +143,10 @@
 					<ChevronDown size={12} />
 				</div>
 				{#if semesters.data}
-					<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-2xl z-10 w-56 p-1 shadow-lg border border-base-300">
+					<ul
+						tabindex="0"
+						class="dropdown-content menu bg-base-100 rounded-2xl z-10 w-56 p-1 shadow-lg border border-base-300"
+					>
 						{#each semesters.data as semester (semester._id)}
 							<li>
 								<button
@@ -174,15 +174,26 @@
 					type="button"
 					class="btn btn-sm btn-ghost rounded-full gap-2"
 					class:btn-disabled={!currentSemester}
-					onclick={() => { classOpen = !classOpen; classSearch = ''; }}
+					onclick={() => {
+						classOpen = !classOpen;
+						classSearch = '';
+					}}
 				>
 					<BookOpen size={14} class="text-base-content/60" />
 					<span class="text-sm truncate max-w-[140px]">{selectedClass?.name || 'Class'}</span>
 					<ChevronDown size={12} />
 				</button>
 				{#if classOpen && filteredClasses && filteredClasses.length > 0}
-					<div class="fixed inset-0 z-10" onclick={() => { classOpen = false; }} role="none"></div>
-					<div class="absolute top-full left-0 mt-1 z-20 w-64 bg-base-100 rounded-2xl shadow-lg border border-base-300 p-2">
+					<div
+						class="fixed inset-0 z-10"
+						onclick={() => {
+							classOpen = false;
+						}}
+						role="none"
+					></div>
+					<div
+						class="absolute top-full left-0 mt-1 z-20 w-64 bg-base-100 rounded-2xl shadow-lg border border-base-300 p-2"
+					>
 						<input
 							type="text"
 							placeholder="Search classes..."
@@ -226,15 +237,26 @@
 					type="button"
 					class="btn btn-sm btn-ghost rounded-full gap-2"
 					class:btn-disabled={!selectedClass}
-					onclick={() => { moduleOpen = !moduleOpen; moduleSearch = ''; }}
+					onclick={() => {
+						moduleOpen = !moduleOpen;
+						moduleSearch = '';
+					}}
 				>
 					<Layers size={14} class="text-base-content/60" />
 					<span class="text-sm truncate max-w-[140px]">{selectedModuleTitle || 'Module'}</span>
 					<ChevronDown size={12} />
 				</button>
 				{#if moduleOpen && modules.data && modules.data.length > 0}
-					<div class="fixed inset-0 z-10" onclick={() => { moduleOpen = false; }} role="none"></div>
-					<div class="absolute top-full left-0 mt-1 z-20 w-64 bg-base-100 rounded-2xl shadow-lg border border-base-300 p-2">
+					<div
+						class="fixed inset-0 z-10"
+						onclick={() => {
+							moduleOpen = false;
+						}}
+						role="none"
+					></div>
+					<div
+						class="absolute top-full left-0 mt-1 z-20 w-64 bg-base-100 rounded-2xl shadow-lg border border-base-300 p-2"
+					>
 						<input
 							type="text"
 							placeholder="Search modules..."
@@ -281,7 +303,9 @@
 
 		<div class="grid grid-cols-1 xl:grid-cols-12 gap-4">
 			<div class="xl:col-span-4 2xl:col-span-3">
-				<div class="bg-base-100 rounded-2xl border border-base-300 h-[calc(100vh-220px)] overflow-hidden">
+				<div
+					class="bg-base-100 rounded-2xl border border-base-300 h-[calc(100vh-220px)] overflow-hidden"
+				>
 					{#if convexUser.isLoading}
 						<div class="p-4 space-y-2">
 							{#each Array(5) as _}
@@ -306,7 +330,9 @@
 			</div>
 
 			<div class="xl:col-span-8 2xl:col-span-9">
-				<div class="bg-base-100 rounded-2xl border border-base-300 h-[calc(100vh-220px)] overflow-hidden">
+				<div
+					class="bg-base-100 rounded-2xl border border-base-300 h-[calc(100vh-220px)] overflow-hidden"
+				>
 					<QuestionsGeneration
 						material={selectedText}
 						{wordCount}

--- a/src/routes/classes/+page.svelte
+++ b/src/routes/classes/+page.svelte
@@ -593,7 +593,7 @@
 
 				<div class="mt-6 flex items-center justify-between gap-3">
 					<a
-						href="/changelog"
+						href={resolve('/changelog')}
 						class="text-xs text-base-content/40 hover:text-primary transition-colors duration-150"
 						onclick={dismissFeatureSpotlight}
 					>

--- a/src/routes/classes/+page.svelte
+++ b/src/routes/classes/+page.svelte
@@ -19,7 +19,7 @@
 		X
 	} from 'lucide-svelte';
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { goto, replaceState } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import ModuleCard from '../../lib/components/ModuleCard.svelte';
 	import Sidebar from '../../lib/components/Sidebar.svelte';
@@ -61,7 +61,8 @@
 
 	function checkScroll() {
 		if (!jumpBackScroller) return;
-		canScrollRight = jumpBackScroller.scrollLeft + jumpBackScroller.clientWidth < jumpBackScroller.scrollWidth - 4;
+		canScrollRight =
+			jumpBackScroller.scrollLeft + jumpBackScroller.clientWidth < jumpBackScroller.scrollWidth - 4;
 	}
 
 	function scrollRight() {
@@ -76,14 +77,12 @@
 		return () => ro.disconnect();
 	});
 
-	const classesQuery = useQuery(
-		api.class.getUserClasses,
-		() => userData?.cohortId ? { id: userData.cohortId as Id<'cohort'> } : 'skip'
+	const classesQuery = useQuery(api.class.getUserClasses, () =>
+		userData?.cohortId ? { id: userData.cohortId as Id<'cohort'> } : 'skip'
 	);
 
-	const featureAnnouncementQuery = useQuery(
-		api.featureAnnouncements.getCurrentForViewer,
-		() => userData?.cohortId ? {} : 'skip'
+	const featureAnnouncementQuery = useQuery(api.featureAnnouncements.getCurrentForViewer, () =>
+		userData?.cohortId ? {} : 'skip'
 	);
 
 	const classes = $derived({
@@ -119,9 +118,8 @@
 		progress: number;
 	};
 
-	const recentModuleActivityQuery = useQuery(
-		api.progress.getRecentModuleActivity,
-		() => (currentView === 'classes' && userData?.cohortId) ? { limit: 4 } : 'skip'
+	const recentModuleActivityQuery = useQuery(api.progress.getRecentModuleActivity, () =>
+		currentView === 'classes' && userData?.cohortId ? { limit: 4 } : 'skip'
 	);
 
 	const recentModuleIds = $derived.by(() => {
@@ -129,9 +127,10 @@
 		return activity.map((item) => item.moduleId);
 	});
 
-	const recentModuleProgressQuery = useQuery(
-		api.progress.getRecentModulesProgress,
-		() => (currentView === 'classes' && recentModuleIds.length > 0) ? { moduleIds: recentModuleIds } : 'skip'
+	const recentModuleProgressQuery = useQuery(api.progress.getRecentModulesProgress, () =>
+		currentView === 'classes' && recentModuleIds.length > 0
+			? { moduleIds: recentModuleIds }
+			: 'skip'
 	);
 
 	const recentModules = $derived.by(() => {
@@ -156,9 +155,8 @@
 		recentModuleActivityQuery.error ?? recentModuleProgressQuery.error
 	);
 
-	const modulesQuery = useQuery(
-		api.module.getClassModules,
-		() => (selectedClass && currentView === 'modules') ? { id: selectedClass._id } : 'skip'
+	const modulesQuery = useQuery(api.module.getClassModules, () =>
+		selectedClass && currentView === 'modules' ? { id: selectedClass._id } : 'skip'
 	);
 
 	const modules = $derived({
@@ -192,7 +190,7 @@
 		if (classItem != null) {
 			const classesUrl = new URL(resolve('/classes'), page.url.origin);
 			classesUrl.searchParams.set('classId', classItem._id);
-			window.history.replaceState(window.history.state, '', classesUrl.toString());
+			replaceState(classesUrl, page.state);
 		}
 	}
 
@@ -223,9 +221,7 @@
 		if (item.href === '/cohort') return resolve('/cohort');
 		if (item.title === 'Build your own test') {
 			const classId = selectedClass?._id ?? firstClassId;
-			return classId
-				? resolve('/classes/[classId]/tests/new', { classId })
-				: resolve('/classes');
+			return classId ? resolve('/classes/[classId]/tests/new', { classId }) : resolve('/classes');
 		}
 		if (item.title === 'Pick up where you left off') {
 			return resolve('/classes');
@@ -242,7 +238,7 @@
 		featureSpotlightAcknowledging = true;
 		featureSpotlightError = null;
 		try {
-				await client.mutation(api.featureAnnouncements.markSeen, {
+			await client.mutation(api.featureAnnouncements.markSeen, {
 				announcementId: announcement.id
 			});
 			featureSpotlightSeenLocal = true;
@@ -261,8 +257,7 @@
 		openedAnnouncementId = announcement.id;
 		featureSpotlightOpen = true;
 	});
-
-	</script>
+</script>
 
 <main class="min-h-screen p-6 sm:p-8 mb-56">
 	<div class="mb-8 flex flex-col gap-2">
@@ -280,7 +275,9 @@
 		{:else}
 			<div class="flex flex-row gap-5 items-center">
 				<div class="avatar hidden xl:block">
-					<div class="ring-primary ring-offset-base-100 w-14 rounded-full ring ring-offset-2 transition-shadow duration-300 hover:shadow-md hover:shadow-primary/10">
+					<div
+						class="ring-primary ring-offset-base-100 w-14 rounded-full ring ring-offset-2 transition-shadow duration-300 hover:shadow-md hover:shadow-primary/10"
+					>
 						<img src={user.imageUrl} alt="user profile" />
 					</div>
 				</div>
@@ -292,12 +289,12 @@
 					{#if userData === null}
 						<div class="skeleton h-4 w-72 rounded-full"></div>
 					{:else}
-							<p class="text-base-content/60 text-sm">{userSchoolName}</p>
-							{#if userData && !classes.isLoading}
-								<div class="flex flex-wrap gap-1.5 mt-2">
-									<div class="badge badge-primary rounded-full badge-soft">
-										{userCohortName}
-									</div>
+						<p class="text-base-content/60 text-sm">{userSchoolName}</p>
+						{#if userData && !classes.isLoading}
+							<div class="flex flex-wrap gap-1.5 mt-2">
+								<div class="badge badge-primary rounded-full badge-soft">
+									{userCohortName}
+								</div>
 								{#if dev}
 									<div class="badge badge-error rounded-full badge-soft">
 										<ShieldCheckIcon size={14} /> Dev
@@ -330,7 +327,9 @@
 						<div class="overflow-x-auto pb-1">
 							<div class="flex min-w-max gap-2">
 								{#each Array(3), i (i)}
-									<div class="rounded-xl border border-base-300 bg-base-100 px-3 py-2.5 animate-pulse min-w-[19rem]">
+									<div
+										class="rounded-xl border border-base-300 bg-base-100 px-3 py-2.5 animate-pulse min-w-[19rem]"
+									>
 										<div class="flex items-center gap-3">
 											<div class="skeleton h-5 w-5 rounded"></div>
 											<div class="skeleton h-3.5 w-32"></div>
@@ -350,17 +349,26 @@
 					<div in:fade={{ duration: 300, easing: cubicOut }} class="mb-10">
 						<div class="flex items-center justify-between mb-3">
 							<div class="flex items-center gap-2">
-								<h3 class="text-sm font-semibold text-base-content/70">Pick up where you left off</h3>
+								<h3 class="text-sm font-semibold text-base-content/70">
+									Pick up where you left off
+								</h3>
 							</div>
 							{#if canScrollRight}
-								<button onclick={scrollRight} class="flex items-center gap-0.5 text-xs text-base-content/40 hover:text-primary transition-colors duration-150">
+								<button
+									onclick={scrollRight}
+									class="flex items-center gap-0.5 text-xs text-base-content/40 hover:text-primary transition-colors duration-150"
+								>
 									<span>More</span>
 									<ChevronRight size={14} />
 								</button>
 							{/if}
 						</div>
 						<div class="relative">
-							<div bind:this={jumpBackScroller} onscroll={checkScroll} class="overflow-x-auto scrollbar-none">
+							<div
+								bind:this={jumpBackScroller}
+								onscroll={checkScroll}
+								class="overflow-x-auto scrollbar-none"
+							>
 								<div class="flex min-w-max gap-2">
 									{#each recentModules as recentModule (recentModule.moduleId)}
 										<a
@@ -370,14 +378,21 @@
 											})}
 											class="group flex items-center gap-2.5 rounded-xl bg-base-100 border border-base-300 pl-3 pr-4 py-2 transition-colors duration-150 hover:border-primary/40"
 										>
-											<span class="text-base leading-none shrink-0">{recentModule.moduleEmoji || '📘'}</span>
+											<span class="text-base leading-none shrink-0"
+												>{recentModule.moduleEmoji || '📘'}</span
+											>
 											<div class="min-w-0 flex flex-col gap-0.5">
-												<span class="font-medium text-xs text-base-content truncate max-w-40 leading-tight group-hover:text-primary transition-colors duration-150">
+												<span
+													class="font-medium text-xs text-base-content truncate max-w-40 leading-tight group-hover:text-primary transition-colors duration-150"
+												>
 													{recentModule.moduleTitle}
 												</span>
-												<span class="flex items-center gap-1.5 text-[11px] text-base-content/45 leading-tight">
+												<span
+													class="flex items-center gap-1.5 text-[11px] text-base-content/45 leading-tight"
+												>
 													<span>{recentModule.classCode}</span>
-													<span class="inline-block w-0.5 h-0.5 rounded-full bg-base-content/25"></span>
+													<span class="inline-block w-0.5 h-0.5 rounded-full bg-base-content/25"
+													></span>
 													<span>{recentModule.progress}%</span>
 												</span>
 											</div>
@@ -394,7 +409,9 @@
 								</div>
 							</div>
 							{#if canScrollRight}
-								<div class="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-base-200/80 to-transparent rounded-r-xl"></div>
+								<div
+									class="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-base-200/80 to-transparent rounded-r-xl"
+								></div>
 							{/if}
 						</div>
 					</div>
@@ -404,29 +421,39 @@
 			{:else if currentView === 'modules' && selectedClass}
 				<div in:fade={{ duration: 400, easing: cubicOut }} class="w-full">
 					<div class="flex items-center gap-3 mb-4">
-						<button onclick={goBackToClasses} class="btn btn-sm btn-ghost rounded-full hover:bg-base-200 transition-colors duration-200">
+						<button
+							onclick={goBackToClasses}
+							class="btn btn-sm btn-ghost rounded-full hover:bg-base-200 transition-colors duration-200"
+						>
 							<ArrowLeft size={16} />
 						</button>
 						<div class="flex items-center gap-2 min-w-0">
 							<h3 class="text-lg font-semibold text-base-content truncate">{selectedClass.name}</h3>
-							<span class="badge badge-soft badge-sm rounded-full font-mono opacity-60 shrink-0">{selectedClass.code}</span>
+							<span class="badge badge-soft badge-sm rounded-full font-mono opacity-60 shrink-0"
+								>{selectedClass.code}</span
+							>
 						</div>
 					</div>
 
-						<a
-							href={resolve('/classes/[classId]/tests/new', { classId: selectedClass._id })}
-							class="group flex items-center gap-4 rounded-2xl border border-primary/20 bg-primary/5 p-4 mb-6 transition-all duration-200 hover:border-primary/40 hover:bg-primary/10 hover:shadow-md hover:-translate-y-0.5"
+					<a
+						href={resolve('/classes/[classId]/tests/new', { classId: selectedClass._id })}
+						class="group flex items-center gap-4 rounded-2xl border border-primary/20 bg-primary/5 p-4 mb-6 transition-all duration-200 hover:border-primary/40 hover:bg-primary/10 hover:shadow-md hover:-translate-y-0.5"
+					>
+						<div
+							class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/15 text-primary shrink-0 transition-transform duration-200 group-hover:scale-110"
 						>
-						<div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/15 text-primary shrink-0 transition-transform duration-200 group-hover:scale-110">
 							<ClipboardCheck size={22} />
 						</div>
 						<div class="flex-1 min-w-0">
 							<div class="font-semibold text-sm text-base-content">Test yourself</div>
 							<p class="text-xs text-base-content/50 mt-0.5">
-								Build a timed, scored practice test from any combination of modules. See exactly where you stand.
+								Build a timed, scored practice test from any combination of modules. See exactly
+								where you stand.
 							</p>
 						</div>
-						<div class="text-primary shrink-0 transition-transform duration-200 group-hover:translate-x-1">
+						<div
+							class="text-primary shrink-0 transition-transform duration-200 group-hover:translate-x-1"
+						>
 							<ArrowRightIcon size={18} />
 						</div>
 					</a>
@@ -487,7 +514,9 @@
 
 {#if featureAnnouncement}
 	<dialog class="modal max-w-full p-4 z-[1000]" class:modal-open={featureSpotlightOpen}>
-		<div class="modal-box max-w-2xl rounded-4xl border border-base-300 p-0 overflow-hidden shadow-2xl backdrop-blur-md">
+		<div
+			class="modal-box max-w-2xl rounded-4xl border border-base-300 p-0 overflow-hidden shadow-2xl backdrop-blur-md"
+		>
 			<!-- Header -->
 			<div class="relative p-6 sm:p-8 pb-5">
 				<button
@@ -500,7 +529,9 @@
 				</button>
 
 				<div class="flex items-center gap-3 mb-4">
-					<div class="w-10 h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0">
+					<div
+						class="w-10 h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0"
+					>
 						<Sparkles size={20} />
 					</div>
 					<div class="badge badge-primary badge-soft rounded-full text-xs">
@@ -528,7 +559,9 @@
 							}}
 						>
 							<div class="flex items-center gap-4">
-								<div class="w-10 h-10 rounded-xl bg-base-200 text-base-content/60 flex items-center justify-center shrink-0 group-hover:bg-primary/15 group-hover:text-primary transition-all duration-200 group-hover:scale-110">
+								<div
+									class="w-10 h-10 rounded-xl bg-base-200 text-base-content/60 flex items-center justify-center shrink-0 group-hover:bg-primary/15 group-hover:text-primary transition-all duration-200 group-hover:scale-110"
+								>
 									<Icon size={18} />
 								</div>
 								<div class="min-w-0 flex-1">
@@ -542,7 +575,9 @@
 										{item.description}
 									</p>
 								</div>
-								<div class="text-base-content/20 shrink-0 transition-all duration-200 group-hover:text-primary group-hover:translate-x-1">
+								<div
+									class="text-base-content/20 shrink-0 transition-all duration-200 group-hover:text-primary group-hover:translate-x-1"
+								>
 									<ArrowRightIcon size={16} />
 								</div>
 							</div>
@@ -557,7 +592,11 @@
 				{/if}
 
 				<div class="mt-6 flex items-center justify-between gap-3">
-					<a href="/changelog" class="text-xs text-base-content/40 hover:text-primary transition-colors duration-150" onclick={dismissFeatureSpotlight}>
+					<a
+						href="/changelog"
+						class="text-xs text-base-content/40 hover:text-primary transition-colors duration-150"
+						onclick={dismissFeatureSpotlight}
+					>
 						See all updates
 					</a>
 					<div class="flex items-center gap-2">
@@ -615,5 +654,4 @@
 	.scrollbar-none::-webkit-scrollbar {
 		display: none;
 	}
-
 </style>

--- a/src/routes/classes/[classId]/tests/[attemptId]/+page.svelte
+++ b/src/routes/classes/[classId]/tests/[attemptId]/+page.svelte
@@ -137,7 +137,9 @@
 	}
 
 	function matchingRole(text: string): 'prompt' | 'answer' | null {
-		const normalized = String(text ?? '').trimStart().toLowerCase();
+		const normalized = String(text ?? '')
+			.trimStart()
+			.toLowerCase();
 		if (normalized.startsWith('prompt:')) return 'prompt';
 		if (normalized.startsWith('answer:')) return 'answer';
 		return null;
@@ -320,12 +322,11 @@
 			set selectedAnswers(next: string[]) {
 				const current = getCurrentItem();
 				if (!current) return;
-				const textValue =
-					isFitb(current.question.type) ? String((next ?? [])[0] ?? '') : undefined;
+				const textValue = isFitb(current.question.type) ? String((next ?? [])[0] ?? '') : undefined;
 				setResponse(current._id, (prev) => ({
 					...prev,
 					selectedOptions: [...(next ?? [])],
-					textResponse: isFitb(current.question.type) ? (textValue || undefined) : prev.textResponse
+					textResponse: isFitb(current.question.type) ? textValue || undefined : prev.textResponse
 				}));
 			},
 			get eliminatedAnswers() {
@@ -396,7 +397,9 @@
 			},
 			isOptionEliminated(_optionId: string) {
 				const current = getCurrentItem();
-				return current ? (responses[current._id]?.eliminatedOptions ?? []).includes(_optionId) : false;
+				return current
+					? (responses[current._id]?.eliminatedOptions ?? []).includes(_optionId)
+					: false;
 			},
 			isCorrect(_optionId: string) {
 				return false;
@@ -426,41 +429,41 @@
 			return;
 		}
 
-			const ids = Array.from(dirtyItemIds);
+		const ids = Array.from(dirtyItemIds);
 
-			syncStatus = 'syncing';
+		syncStatus = 'syncing';
 		syncError = null;
 		syncInFlight = true;
 
 		try {
 			const changes = ids
-					.map((id) => {
-						const r = responses[id];
-						if (!r) return null;
-						return {
-							itemId: id as Id<'quizAttemptItems'>,
-							selectedOptions: r.selectedOptions,
-							textResponse: r.textResponse ?? '',
-							isFlagged: r.isFlagged,
+				.map((id) => {
+					const r = responses[id];
+					if (!r) return null;
+					return {
+						itemId: id as Id<'quizAttemptItems'>,
+						selectedOptions: r.selectedOptions,
+						textResponse: r.textResponse ?? '',
+						isFlagged: r.isFlagged,
 						markVisited: r.visited,
 						timeSpentDeltaMs: pendingTimeDeltas[id] ?? 0
 					};
-					})
-					.filter(
-						(
-							change
-						): change is {
-							itemId: Id<'quizAttemptItems'>;
-							selectedOptions: string[];
-							textResponse: string;
-							isFlagged: boolean;
-							markVisited: boolean;
-							timeSpentDeltaMs: number;
-						} => change !== null
-					);
+				})
+				.filter(
+					(
+						change
+					): change is {
+						itemId: Id<'quizAttemptItems'>;
+						selectedOptions: string[];
+						textResponse: string;
+						isFlagged: boolean;
+						markVisited: boolean;
+						timeSpentDeltaMs: number;
+					} => change !== null
+				);
 
 			if (changes.length > 0 || force) {
-					await client.mutation(api.customQuiz.patchAttemptResponses, {
+				await client.mutation(api.customQuiz.patchAttemptResponses, {
 					attemptId,
 					elapsedMs: elapsedMsLocal,
 					changes
@@ -506,30 +509,33 @@
 		let nextElapsedMs = Math.max(bundle.attempt.elapsedMs ?? 0, 0);
 
 		if (cached) {
-			nextCurrentIndex = Math.min(Math.max(0, cached.currentIndex ?? 0), Math.max(bundle.items.length - 1, 0));
+			nextCurrentIndex = Math.min(
+				Math.max(0, cached.currentIndex ?? 0),
+				Math.max(bundle.items.length - 1, 0)
+			);
 			nextElapsedMs = Math.max(nextElapsedMs, cached.elapsedMs ?? 0);
 			nextPendingDeltas = cached.pendingTimeDeltas ?? {};
 
 			for (const [itemId, localResponse] of Object.entries(cached.responses ?? {})) {
 				if (!serverResponses[itemId]) continue;
-					const server = serverResponses[itemId];
-					const localSelected = localResponse.selectedOptions ?? [];
-					const serverSelected = server.selectedOptions ?? [];
-					const selectedOptions = localSelected.length > 0 ? localSelected : serverSelected;
-						mergedResponses[itemId] = {
-							...server,
-							selectedOptions: [...selectedOptions],
-							eliminatedOptions: [...(localResponse.eliminatedOptions ?? [])],
-							textResponse:
-								(localResponse.textResponse ?? '').trim().length > 0
-									? localResponse.textResponse
-								: server.textResponse,
-						isFlagged: localResponse.isFlagged ?? server.isFlagged,
-						visited: localResponse.visited || server.visited,
-						timeSpentMs: Math.max(server.timeSpentMs ?? 0, localResponse.timeSpentMs ?? 0)
-					};
-					dirtyItemIds.add(itemId);
-				}
+				const server = serverResponses[itemId];
+				const localSelected = localResponse.selectedOptions ?? [];
+				const serverSelected = server.selectedOptions ?? [];
+				const selectedOptions = localSelected.length > 0 ? localSelected : serverSelected;
+				mergedResponses[itemId] = {
+					...server,
+					selectedOptions: [...selectedOptions],
+					eliminatedOptions: [...(localResponse.eliminatedOptions ?? [])],
+					textResponse:
+						(localResponse.textResponse ?? '').trim().length > 0
+							? localResponse.textResponse
+							: server.textResponse,
+					isFlagged: localResponse.isFlagged ?? server.isFlagged,
+					visited: localResponse.visited || server.visited,
+					timeSpentMs: Math.max(server.timeSpentMs ?? 0, localResponse.timeSpentMs ?? 0)
+				};
+				dirtyItemIds.add(itemId);
+			}
 		}
 
 		responses = mergedResponses;
@@ -570,7 +576,7 @@
 		isSubmitting = true;
 		try {
 			await flushSync(true);
-				await client.mutation(api.customQuiz.submitAttempt, {
+			await client.mutation(api.customQuiz.submitAttempt, {
 				attemptId,
 				elapsedMs: elapsedMsLocal
 			});
@@ -578,19 +584,23 @@
 				window.localStorage.removeItem(cacheKey(String(attemptId)));
 			}
 			await goto(`/classes/${classId}/tests/${attemptId}/results${auto ? '?autoSubmit=1' : ''}`);
-			} catch (error: any) {
-				submitError = error?.message ?? 'Something went wrong while submitting. Please try again.';
-			} finally {
-				isSubmitting = false;
-			}
+		} catch (error: any) {
+			submitError = error?.message ?? 'Something went wrong while submitting. Please try again.';
+		} finally {
+			isSubmitting = false;
 		}
+	}
 
 	function promptsForMatching(item: any) {
-		return (item.question.options || []).filter((o: any) => matchingRole(String(o.text)) === 'prompt');
+		return (item.question.options || []).filter(
+			(o: any) => matchingRole(String(o.text)) === 'prompt'
+		);
 	}
 
 	function answersForMatching(item: any) {
-		return (item.question.options || []).filter((o: any) => matchingRole(String(o.text)) === 'answer');
+		return (item.question.options || []).filter(
+			(o: any) => matchingRole(String(o.text)) === 'answer'
+		);
 	}
 
 	function selectedAnswerIdForPrompt(itemId: string, promptId: string) {
@@ -648,21 +658,31 @@
 
 	function syncStatusIcon(status: string) {
 		switch (status) {
-			case 'synced': return 'text-success';
-			case 'syncing': return 'text-info';
-			case 'offline': return 'text-warning';
-			case 'error': return 'text-error';
-			default: return 'text-base-content/40';
+			case 'synced':
+				return 'text-success';
+			case 'syncing':
+				return 'text-info';
+			case 'offline':
+				return 'text-warning';
+			case 'error':
+				return 'text-error';
+			default:
+				return 'text-base-content/40';
 		}
 	}
 
 	function syncStatusLabel(status: string) {
 		switch (status) {
-			case 'synced': return 'Saved';
-			case 'syncing': return 'Saving...';
-			case 'offline': return 'Offline';
-			case 'error': return 'Save failed';
-			default: return 'Ready';
+			case 'synced':
+				return 'Saved';
+			case 'syncing':
+				return 'Saving...';
+			case 'offline':
+				return 'Offline';
+			case 'error':
+				return 'Save failed';
+			default:
+				return 'Ready';
 		}
 	}
 
@@ -769,12 +789,14 @@
 			if (dirtyItemIds.size > 0 || Object.keys(pendingTimeDeltas).length > 0) {
 				void flushSync();
 			}
-				void client.mutation(api.customQuiz.heartbeatAttempt, {
-				attemptId,
-				elapsedMs: elapsedMsLocal
-			}).catch(() => {
-				// no-op
-			});
+			void client
+				.mutation(api.customQuiz.heartbeatAttempt, {
+					attemptId,
+					elapsedMs: elapsedMsLocal
+				})
+				.catch(() => {
+					// no-op
+				});
 		}, 5000);
 
 		return () => {
@@ -788,7 +810,7 @@
 	});
 </script>
 
-	<div class="flex flex-col h-[calc(100vh-4rem)]">
+<div class="flex flex-col h-[calc(100vh-4rem)]">
 	{#if runnerQuery.isLoading}
 		<div class="flex-1 flex items-center justify-center">
 			<div class="text-center">
@@ -809,9 +831,7 @@
 					<div class="card-body text-center">
 						<CheckCircle2 class="mx-auto text-success mb-2" size={48} />
 						<h1 class="card-title justify-center text-xl">Test Complete</h1>
-						<p class="text-sm text-base-content/60 mt-1">
-							This test has already been submitted.
-						</p>
+						<p class="text-sm text-base-content/60 mt-1">This test has already been submitted.</p>
 						<div class="card-actions justify-center mt-4">
 							<a
 								class="btn btn-primary rounded-full"
@@ -851,7 +871,8 @@
 									class="btn btn-ghost font-bold rounded-full"
 									href={`/classes?classId=${classId}`}
 								>
-									<ChevronLeft size={16} /> {runnerQuery.data.attempt.className}
+									<ChevronLeft size={16} />
+									{runnerQuery.data.attempt.className}
 								</a>
 							</h4>
 							<h2 class="font-semibold text-2xl mt-2 flex items-start gap-3 min-w-0">
@@ -876,14 +897,20 @@
 							<div class="grid grid-cols-2 gap-2 text-sm mt-5">
 								<div class="rounded-xl border border-base-300 p-3">
 									<div class="text-xs text-base-content/50">Answered</div>
-									<div class="font-bold text-lg">{answeredCount}<span class="text-base-content/40 text-sm font-normal"> / {runnerQuery.data.items.length}</span></div>
+									<div class="font-bold text-lg">
+										{answeredCount}<span class="text-base-content/40 text-sm font-normal">
+											/ {runnerQuery.data.items.length}</span
+										>
+									</div>
 								</div>
 								<div class="rounded-xl border border-base-300 p-3">
 									<div class="text-xs text-base-content/50 flex items-center gap-1">
 										<Flag size={10} />
 										Flagged
 									</div>
-									<div class="font-bold text-lg {flaggedCount > 0 ? 'text-warning' : ''}">{flaggedCount}</div>
+									<div class="font-bold text-lg {flaggedCount > 0 ? 'text-warning' : ''}">
+										{flaggedCount}
+									</div>
 								</div>
 							</div>
 						</div>
@@ -895,9 +922,15 @@
 										<Clock size={14} class="text-base-content/50" />
 										<span class="text-xs uppercase tracking-wide text-base-content/50">Timer</span>
 									</div>
-									<div class="text-3xl font-bold tabular-nums">{formatDuration(elapsedMsLocal)}</div>
+									<div class="text-3xl font-bold tabular-nums">
+										{formatDuration(elapsedMsLocal)}
+									</div>
 									{#if remainingMs !== null}
-										<div class="text-sm mt-1 {remainingMs <= 60_000 ? 'text-error font-semibold animate-pulse' : 'text-base-content/60'}">
+										<div
+											class="text-sm mt-1 {remainingMs <= 60_000
+												? 'text-error font-semibold animate-pulse'
+												: 'text-base-content/60'}"
+										>
 											{remainingMs <= 60_000 ? 'Hurry! ' : ''}{formatDuration(remainingMs)} remaining
 										</div>
 									{:else}
@@ -912,7 +945,7 @@
 								{:else}
 									<Wifi size={12} class={syncStatusIcon(syncStatus)} />
 								{/if}
-								<span class="{syncStatusIcon(syncStatus)}">{syncStatusLabel(syncStatus)}</span>
+								<span class={syncStatusIcon(syncStatus)}>{syncStatusLabel(syncStatus)}</span>
 							</div>
 							{#if syncError}
 								<div class="text-error text-xs text-center mt-1">{syncError}</div>
@@ -940,13 +973,17 @@
 							<div class="text-center">
 								<div class="text-xs font-bold tabular-nums">{formatDuration(elapsedMsLocal)}</div>
 								{#if remainingMs !== null}
-									<div class="text-[10px] text-base-content/50 tabular-nums">{formatDuration(remainingMs)}</div>
+									<div class="text-[10px] text-base-content/50 tabular-nums">
+										{formatDuration(remainingMs)}
+									</div>
 								{/if}
 							</div>
 
 							<div
 								class="radial-progress text-primary text-xs bg-base-300"
-								style="--value:{Math.round((answeredCount / Math.max(1, runnerQuery.data?.items?.length ?? 1)) * 100)}; --size:3rem; --thickness: 3px;"
+								style="--value:{Math.round(
+									(answeredCount / Math.max(1, runnerQuery.data?.items?.length ?? 1)) * 100
+								)}; --size:3rem; --thickness: 3px;"
 								role="progressbar"
 							>
 								{answeredCount}
@@ -983,7 +1020,11 @@
 							{formatDuration(elapsedMsLocal)}
 						</div>
 						{#if remainingMs !== null}
-							<span class="text-xs {remainingMs <= 60_000 ? 'text-error font-semibold' : 'text-base-content/50'}">
+							<span
+								class="text-xs {remainingMs <= 60_000
+									? 'text-error font-semibold'
+									: 'text-base-content/50'}"
+							>
 								{formatDuration(remainingMs)}
 							</span>
 						{/if}
@@ -991,20 +1032,33 @@
 				</div>
 
 				<!-- Main content area -->
-				<div class="w-full lg:flex-1 lg:min-w-0 flex flex-col max-w-full lg:max-w-none overflow-y-auto flex-grow min-h-0 h-full pb-24 sm:pb-36 lg:pb-48 relative">
-
+				<div
+					class="w-full lg:flex-1 lg:min-w-0 flex flex-col max-w-full lg:max-w-none overflow-y-auto flex-grow min-h-0 h-full pb-24 sm:pb-36 lg:pb-48 relative"
+				>
 					<!-- Horizontal question navigator (matches QuizNavigation style) -->
-					<div class="flex flex-row w-full overflow-x-auto overflow-y-hidden whitespace-nowrap space-x-4 relative items-center border border-base-300 px-6 py-3 rounded-4xl h-20 min-h-20 max-h-20 flex-none">
+					<div
+						class="flex flex-row w-full overflow-x-auto overflow-y-hidden whitespace-nowrap space-x-4 relative items-center border border-base-300 px-6 py-3 rounded-4xl h-20 min-h-20 max-h-20 flex-none"
+					>
 						{#each runnerQuery.data.items as item, index (item._id)}
 							{@const r = responses[item._id]}
-							{@const answered = r ? (isFitb(item.question.type) ? String(r.textResponse ?? r.selectedOptions[0] ?? '').trim().length > 0 : r.selectedOptions.length > 0) : false}
+							{@const answered = r
+								? isFitb(item.question.type)
+									? String(r.textResponse ?? r.selectedOptions[0] ?? '').trim().length > 0
+									: r.selectedOptions.length > 0
+								: false}
 							<div class="indicator">
 								{#if r?.isFlagged}
-										<span class="indicator-item indicator-start badge badge-warning badge-xs -translate-x-1/4 -translate-y-1/4 z-[1]"></span>
+									<span
+										class="indicator-item indicator-start badge badge-warning badge-xs -translate-x-1/4 -translate-y-1/4 z-[1]"
+									></span>
 								{/if}
 								<button
 									bind:this={questionButtons[index]}
-									class="btn btn-circle btn-md btn-soft {index === currentIndex ? 'btn-primary' : answered ? 'btn-accent' : 'btn-outline'}"
+									class="btn btn-circle btn-md btn-soft {index === currentIndex
+										? 'btn-primary'
+										: answered
+											? 'btn-accent'
+											: 'btn-outline'}"
 									onclick={() => jumpToQuestion(index)}
 									title={`Question ${index + 1}`}
 								>
@@ -1023,7 +1077,9 @@
 								</div>
 								<div class="flex items-center gap-2">
 									<button
-										class="btn btn-sm btn-circle {currentResponse?.isFlagged ? 'btn-warning' : 'btn-warning btn-soft'}"
+										class="btn btn-sm btn-circle {currentResponse?.isFlagged
+											? 'btn-warning'
+											: 'btn-warning btn-soft'}"
 										onclick={() => toggleFlag(currentItem)}
 										aria-label={currentResponse?.isFlagged ? 'Remove flag' : 'Flag for review'}
 										title={currentResponse?.isFlagged ? 'Remove flag' : 'Flag for review'}
@@ -1034,8 +1090,10 @@
 							</div>
 
 							{#if !isFitb(currentItem.question.type)}
-								<div class="text-base sm:text-xl leading-tight tiptap-content font-medium ms-2 mt-3">
-										{@html sanitizeHtml(currentItem.question.stem)}
+								<div
+									class="text-base sm:text-xl leading-tight tiptap-content font-medium ms-2 mt-3"
+								>
+									{@html sanitizeHtml(currentItem.question.stem)}
 								</div>
 							{/if}
 
@@ -1065,7 +1123,9 @@
 									{/if}
 								</div>
 							{:else}
-								<div class="text-base-content/60 font-medium text-base sm:text-lg leading-tight my-3 ms-2">
+								<div
+									class="text-base-content/60 font-medium text-base sm:text-lg leading-tight my-3 ms-2"
+								>
 									Select {currentItem.question.correctAnswerCount ?? 'all that apply'}.
 								</div>
 								<div class="text-xs text-base-content/45 ms-2 mb-2">
@@ -1082,7 +1142,6 @@
 									/>
 								{/if}
 							{/if}
-
 						</div>
 
 						{#if submitError}
@@ -1100,13 +1159,19 @@
 			>
 				<button
 					class="btn btn-sm btn-outline rounded-full"
-					onclick={() => { if (currentItem) clearAnswer(currentItem); }}
+					onclick={() => {
+						if (currentItem) clearAnswer(currentItem);
+					}}
 				>
 					Clear
 				</button>
 				<button
-					class="btn btn-sm btn-circle {currentResponse?.isFlagged ? 'btn-warning' : 'btn-warning btn-soft'}"
-					onclick={() => { if (currentItem) toggleFlag(currentItem); }}
+					class="btn btn-sm btn-circle {currentResponse?.isFlagged
+						? 'btn-warning'
+						: 'btn-warning btn-soft'}"
+					onclick={() => {
+						if (currentItem) toggleFlag(currentItem);
+					}}
 					aria-label={currentResponse?.isFlagged ? 'Remove flag' : 'Flag for review'}
 				>
 					<Flag size={18} />
@@ -1130,7 +1195,9 @@
 					<ArrowLeft size={18} />
 				</button>
 				<button
-					class="btn btn-sm btn-outline {currentIndex === (runnerQuery.data?.items?.length ?? 1) - 1 ? 'btn-disabled' : ''}"
+					class="btn btn-sm btn-outline {currentIndex === (runnerQuery.data?.items?.length ?? 1) - 1
+						? 'btn-disabled'
+						: ''}"
 					style="border-radius: 50% 9999px 9999px 50%;"
 					onclick={nextQuestion}
 					disabled={currentIndex === (runnerQuery.data?.items?.length ?? 1) - 1}
@@ -1151,7 +1218,9 @@
 			</div>
 
 			<!-- Mobile bottom bar -->
-			<div class="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-base-100 border-t border-base-300 p-3 flex items-center justify-between gap-2">
+			<div
+				class="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-base-100 border-t border-base-300 p-3 flex items-center justify-between gap-2"
+			>
 				<div class="flex gap-2">
 					<button
 						class="btn btn-sm btn-outline rounded-full"
@@ -1171,13 +1240,19 @@
 				<div class="flex gap-2">
 					<button
 						class="btn btn-sm btn-ghost rounded-full"
-						onclick={() => { if (currentItem) clearAnswer(currentItem); }}
+						onclick={() => {
+							if (currentItem) clearAnswer(currentItem);
+						}}
 					>
 						Clear
 					</button>
 					<button
-						class="btn btn-sm btn-circle {currentResponse?.isFlagged ? 'btn-warning' : 'btn-warning btn-soft'}"
-						onclick={() => { if (currentItem) toggleFlag(currentItem); }}
+						class="btn btn-sm btn-circle {currentResponse?.isFlagged
+							? 'btn-warning'
+							: 'btn-warning btn-soft'}"
+						onclick={() => {
+							if (currentItem) toggleFlag(currentItem);
+						}}
 						aria-label={currentResponse?.isFlagged ? 'Remove flag' : 'Flag for review'}
 					>
 						<Flag size={14} />
@@ -1207,16 +1282,25 @@
 					<h3 class="text-lg font-bold">Submit Your Test?</h3>
 					<div class="py-4 space-y-3">
 						<p class="text-base-content/70">
-							Once submitted, you won't be able to change your answers. You'll be able to review each question with the correct answers and explanations.
+							Once submitted, you won't be able to change your answers. You'll be able to review
+							each question with the correct answers and rationales.
 						</p>
 						<div class="grid grid-cols-2 gap-2 text-sm">
 							<div class="rounded-xl border border-base-300 p-3">
 								<div class="text-xs text-base-content/50">Answered</div>
-								<div class="font-semibold">{answeredCount} / {runnerQuery.data?.items?.length ?? 0}</div>
+								<div class="font-semibold">
+									{answeredCount} / {runnerQuery.data?.items?.length ?? 0}
+								</div>
 							</div>
 							<div class="rounded-xl border border-base-300 p-3">
 								<div class="text-xs text-base-content/50">Unanswered</div>
-								<div class="font-semibold {(runnerQuery.data?.items?.length ?? 0) - answeredCount > 0 ? 'text-warning' : ''}">{(runnerQuery.data?.items?.length ?? 0) - answeredCount}</div>
+								<div
+									class="font-semibold {(runnerQuery.data?.items?.length ?? 0) - answeredCount > 0
+										? 'text-warning'
+										: ''}"
+								>
+									{(runnerQuery.data?.items?.length ?? 0) - answeredCount}
+								</div>
 							</div>
 						</div>
 						{#if (runnerQuery.data?.items?.length ?? 0) - answeredCount > 0}
@@ -1232,7 +1316,10 @@
 						</button>
 						<button
 							class="btn btn-primary rounded-full gap-1"
-							onclick={() => { showSubmitModal = false; void submitAttempt(false); }}
+							onclick={() => {
+								showSubmitModal = false;
+								void submitAttempt(false);
+							}}
 							disabled={isSubmitting}
 						>
 							<Send size={14} />
@@ -1254,7 +1341,6 @@
 					}}
 				></div>
 			</dialog>
-
 		{/if}
 	{/if}
 </div>

--- a/src/routes/classes/[classId]/tests/[attemptId]/+page.svelte
+++ b/src/routes/classes/[classId]/tests/[attemptId]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import { useConvexClient, useQuery } from 'convex-svelte';
 	import { api } from '../../../../../convex/_generated/api';
@@ -519,17 +520,23 @@
 			for (const [itemId, localResponse] of Object.entries(cached.responses ?? {})) {
 				if (!serverResponses[itemId]) continue;
 				const server = serverResponses[itemId];
-				const localSelected = localResponse.selectedOptions ?? [];
+				const hasLocalSelectedOptions = Object.prototype.hasOwnProperty.call(
+					localResponse,
+					'selectedOptions'
+				);
+				const hasLocalTextResponse = Object.prototype.hasOwnProperty.call(
+					localResponse,
+					'textResponse'
+				);
 				const serverSelected = server.selectedOptions ?? [];
-				const selectedOptions = localSelected.length > 0 ? localSelected : serverSelected;
+				const selectedOptions = hasLocalSelectedOptions
+					? (localResponse.selectedOptions ?? [])
+					: serverSelected;
 				mergedResponses[itemId] = {
 					...server,
 					selectedOptions: [...selectedOptions],
 					eliminatedOptions: [...(localResponse.eliminatedOptions ?? [])],
-					textResponse:
-						(localResponse.textResponse ?? '').trim().length > 0
-							? localResponse.textResponse
-							: server.textResponse,
+					textResponse: hasLocalTextResponse ? localResponse.textResponse : server.textResponse,
 					isFlagged: localResponse.isFlagged ?? server.isFlagged,
 					visited: localResponse.visited || server.visited,
 					timeSpentMs: Math.max(server.timeSpentMs ?? 0, localResponse.timeSpentMs ?? 0)
@@ -583,7 +590,9 @@
 			if (typeof window !== 'undefined') {
 				window.localStorage.removeItem(cacheKey(String(attemptId)));
 			}
-			await goto(`/classes/${classId}/tests/${attemptId}/results${auto ? '?autoSubmit=1' : ''}`);
+			await goto(
+				resolve(`/classes/${classId}/tests/${attemptId}/results${auto ? '?autoSubmit=1' : ''}`)
+			);
 		} catch (error: any) {
 			submitError = error?.message ?? 'Something went wrong while submitting. Please try again.';
 		} finally {

--- a/src/routes/classes/[classId]/tests/[attemptId]/results/+page.svelte
+++ b/src/routes/classes/[classId]/tests/[attemptId]/results/+page.svelte
@@ -4,6 +4,7 @@
 	import { api } from '../../../../../../convex/_generated/api';
 	import type { Id } from '../../../../../../convex/_generated/dataModel';
 	import QuestionAttachmentsSidebar from '$lib/components/QuestionAttachmentsSidebar.svelte';
+	import { getRationale, hasRationale } from '$lib/utils/rationale';
 	import { fade, slide } from 'svelte/transition';
 	import { cubicInOut } from 'svelte/easing';
 	import createDOMPurify from 'dompurify';
@@ -619,7 +620,7 @@
 								<span class="break-words hyphens-auto overflow-hidden">Review Mode</span>
 							</h2>
 							<p class="text-base-content/60 mt-2 text-sm">
-								Step through each question to see the correct answer and explanation.
+								Step through each question to see the correct answer and rationale.
 							</p>
 
 							<div class="mt-6">
@@ -1023,19 +1024,19 @@
 							{/if}
 
 							<!-- Rationale -->
-							{#if selectedItem.question.explanation}
+							{#if hasRationale(selectedItem.question)}
 								<div class="card bg-base-100 shadow-xl mt-6 rounded-2xl ms-2">
 									<div class="card-body">
 										<h3 class="card-title text-base">Rationale</h3>
 										<div class="tiptap-content text-sm text-base-content/80">
-											{@html sanitizeHtml(selectedItem.question.explanation)}
+											{@html sanitizeHtml(getRationale(selectedItem.question))}
 										</div>
 									</div>
 								</div>
 							{:else}
 								<div class="rounded-xl border border-base-300 p-4 mt-6 ms-2">
 									<div class="text-sm text-base-content/40">
-										No explanation available for this question.
+										No rationale available for this question.
 									</div>
 								</div>
 							{/if}

--- a/src/routes/docs/students/study-flow/+page.svelte
+++ b/src/routes/docs/students/study-flow/+page.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
-	import { Eye, Flag, Shuffle, ArrowRight, ArrowLeft, BookOpenText, Settings, Check } from 'lucide-svelte';
+	import {
+		Eye,
+		Flag,
+		Shuffle,
+		ArrowRight,
+		ArrowLeft,
+		BookOpenText,
+		Settings,
+		Check
+	} from 'lucide-svelte';
 </script>
 
 <h1>Study Flow</h1>
 
-<p>You’ll move through one question at a time, check your work, and track your progress without losing focus. This page shows you how the study screen works and what each control does.</p>
+<p>
+	You’ll move through one question at a time, check your work, and track your progress without
+	losing focus. This page shows you how the study screen works and what each control does.
+</p>
 
 <h2>Start a module</h2>
 <ol>
@@ -14,7 +26,9 @@
 </ol>
 
 <h2>Answering questions</h2>
-<p>Select your answers, optionally eliminate distractors, then check your result when you’re ready.</p>
+<p>
+	Select your answers, optionally eliminate distractors, then check your result when you’re ready.
+</p>
 
 <h3>Answer options</h3>
 <ul>
@@ -33,7 +47,9 @@
 					<span class="font-semibold mr-2 select-none">A.</span>
 					Option text goes here
 				</span>
-				<button class="btn btn-ghost btn-circle btn-sm mr-4" title="Eliminate"><Eye size={16} /></button>
+				<button class="btn btn-ghost btn-circle btn-sm mr-4" title="Eliminate"
+					><Eye size={16} /></button
+				>
 			</label>
 			<label class="label cursor-pointer rounded-full border-2 p-3 bg-base-200">
 				<input type="checkbox" class="checkbox checkbox-primary checkbox-sm ms-4" />
@@ -41,7 +57,9 @@
 					<span class="font-semibold mr-2 select-none">B.</span>
 					This option has been eliminated
 				</span>
-				<button class="btn btn-ghost btn-circle btn-sm mr-4" title="Eliminate"><Eye size={16} /></button>
+				<button class="btn btn-ghost btn-circle btn-sm mr-4" title="Eliminate"
+					><Eye size={16} /></button
+				>
 			</label>
 		</div>
 	</div>
@@ -66,7 +84,9 @@
 
 <div class="flex flex-row w-full overflow-x-auto space-x-4 border border-base-300 p-4 rounded-xl">
 	<div class="indicator">
-		<span class="indicator-item indicator-start badge badge-warning badge-xs translate-x-[-1/4] translate-y-[-1/4]"></span>
+		<span
+			class="indicator-item indicator-start badge badge-warning badge-xs translate-x-[-1/4] translate-y-[-1/4]"
+		></span>
 		<button class="btn btn-circle btn-soft btn-primary">1</button>
 	</div>
 	<div class="indicator">
@@ -83,10 +103,14 @@
 <h3>Action bar (desktop)</h3>
 <p>Quick controls appear centered near the bottom on larger screens.</p>
 
-<div class="flex flex-wrap items-center gap-2 p-3 rounded-full border border-base-300 shadow bg-base-100">
+<div
+	class="flex flex-wrap items-center gap-2 p-3 rounded-full border border-base-300 shadow bg-base-100"
+>
 	<button class="btn btn-sm btn-outline">Clear</button>
 	<button class="btn btn-sm btn-success btn-soft"><Check size={16} class="mr-1" /> Check</button>
-	<button class="btn btn-sm btn-warning btn-soft" aria-label="flag question"><Flag size={16} class="mr-1" /> Flag</button>
+	<button class="btn btn-sm btn-warning btn-soft" aria-label="flag question"
+		><Flag size={16} class="mr-1" /> Flag</button
+	>
 	<button class="btn btn-sm btn-secondary"><Shuffle size={16} class="mr-1" /> Shuffle</button>
 	<div class="divider divider-horizontal mx-1"></div>
 	<button class="btn btn-sm btn-outline"><ArrowLeft size={16} class="mr-1" /> Prev</button>
@@ -117,24 +141,51 @@
 
 <h2>Why this design works for you</h2>
 <ul>
-	<li><strong>Focus over noise</strong>: One-question-at-a-time keeps your working memory clear so you can think, not hunt UI. This aligns with LearnTerms’ focus-first study flow.</li>
-	<li><strong>Mastery feedback</strong>: Immediate <em>Check</em> results help you course-correct quickly, building mastery through tight feedback loops.</li>
-	<li><strong>Personal pace</strong>: Progress, flags, and elimination tools let you tailor practice to what you need right now.</li>
-	<li><strong>Exam realism</strong>: Shuffle and fast navigation simulate test conditions and reduce order-memory bias.</li>
-	<li><strong>Cohort-aligned</strong>: Questions come from your class’s modules so every rep is relevant to your exams.</li>
+	<li>
+		<strong>Focus over noise</strong>: One-question-at-a-time keeps your working memory clear so you
+		can think, not hunt UI. This aligns with LearnTerms’ focus-first study flow.
+	</li>
+	<li>
+		<strong>Mastery feedback</strong>: Immediate <em>Check</em> results help you course-correct quickly,
+		building mastery through tight feedback loops.
+	</li>
+	<li>
+		<strong>Personal pace</strong>: Progress, flags, and elimination tools let you tailor practice
+		to what you need right now.
+	</li>
+	<li>
+		<strong>Exam realism</strong>: Shuffle and fast navigation simulate test conditions and reduce
+		order-memory bias.
+	</li>
+	<li>
+		<strong>Cohort-aligned</strong>: Questions come from your class’s modules so every rep is
+		relevant to your exams.
+	</li>
 </ul>
 
 <h2>Tips</h2>
 <ul>
-	<li><strong>One-at-a-time</strong>: Focus on the current question while keeping navigation nearby.</li>
+	<li>
+		<strong>One-at-a-time</strong>: Focus on the current question while keeping navigation nearby.
+	</li>
 	<li><strong>Use flags</strong>: Mark tricky questions to revisit before finishing a module.</li>
-	<li><strong>Shuffle</strong>: Mix the order to simulate exam conditions and reduce memorization effects.</li>
+	<li>
+		<strong>Shuffle</strong>: Mix the order to simulate exam conditions and reduce memorization
+		effects.
+	</li>
 	<li><strong>Reset progress</strong>: Start fresh anytime from the sidebar reset control.</li>
 </ul>
 
 <h2>FAQ</h2>
 <ul>
-	<li><strong>Will I lose answers when navigating?</strong> No—your selections are saved as you go.</li>
-	<li><strong>Where’s the rationale?</strong> Use the Rationale control in the sidebar; it reveals the explanation when available.</li>
-	<li><strong>Mobile view?</strong> The layout adapts; controls stay accessible and unobtrusive.</li>
+	<li>
+		<strong>Will I lose answers when navigating?</strong> No—your selections are saved as you go.
+	</li>
+	<li>
+		<strong>Where’s the rationale?</strong> Use the Rationale control in the sidebar; it reveals the rationale
+		when available.
+	</li>
+	<li>
+		<strong>Mobile view?</strong> The layout adapts; controls stay accessible and unobtrusive.
+	</li>
 </ul>

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -12,9 +12,8 @@
 	const productsQuery = useQuery(api.polar.listAllProducts, {});
 
 	// Get current subscription if authenticated curator/admin
-	const subscriptionQuery = useQuery(
-		api.polar.getCurrentUserWithSubscription,
-		() => (data.isCuratorOrAdmin ? {} : 'skip')
+	const subscriptionQuery = useQuery(api.polar.getCurrentUserWithSubscription, () =>
+		data.isCuratorOrAdmin ? {} : 'skip'
 	);
 
 	// Find semester and annual pro products
@@ -85,7 +84,8 @@
 		<div class="text-center mb-12">
 			<h1 class="text-4xl font-bold">How LearnTerms Works</h1>
 			<p class="text-base-content/70 mt-3 text-lg max-w-2xl mx-auto">
-				LearnTerms is a study platform where students access curated question banks created by their program's content curators.
+				LearnTerms is a study platform where students access curated question banks created by their
+				program's content curators.
 			</p>
 		</div>
 
@@ -93,7 +93,9 @@
 			<!-- Students -->
 			<div class="card bg-base-100 border border-base-300">
 				<div class="card-body text-center">
-					<div class="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+					<div
+						class="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4"
+					>
 						<GraduationCap size={32} class="text-primary" />
 					</div>
 					<h2 class="card-title justify-center text-xl">Students</h2>
@@ -113,7 +115,7 @@
 						</li>
 						<li class="flex items-center gap-2">
 							<Check size={16} class="text-success" />
-							View explanations
+							View rationales
 						</li>
 					</ul>
 				</div>
@@ -122,7 +124,9 @@
 			<!-- Curators -->
 			<div class="card bg-base-100 border border-base-300">
 				<div class="card-body text-center">
-					<div class="w-16 h-16 bg-secondary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+					<div
+						class="w-16 h-16 bg-secondary/10 rounded-full flex items-center justify-center mx-auto mb-4"
+					>
 						<Users size={32} class="text-secondary" />
 					</div>
 					<h2 class="card-title justify-center text-xl">Curators</h2>
@@ -151,7 +155,9 @@
 			<!-- Pro -->
 			<div class="card bg-base-100 border border-primary/40">
 				<div class="card-body text-center">
-					<div class="w-16 h-16 bg-gradient-to-br from-primary/20 to-success/20 rounded-full flex items-center justify-center mx-auto mb-4">
+					<div
+						class="w-16 h-16 bg-gradient-to-br from-primary/20 to-success/20 rounded-full flex items-center justify-center mx-auto mb-4"
+					>
 						<Zap size={32} class="text-primary" />
 					</div>
 					<h2 class="card-title justify-center text-xl">Curator Pro</h2>
@@ -184,7 +190,7 @@
 		</div>
 	</div>
 
-<!-- Student View - Not a curator/admin -->
+	<!-- Student View - Not a curator/admin -->
 {:else if !data.isCuratorOrAdmin}
 	<div class="min-h-[70vh] flex items-center justify-center px-4">
 		<div class="max-w-lg text-center">
@@ -211,7 +217,7 @@
 					</li>
 					<li class="flex items-center gap-2">
 						<Check size={16} class="text-success" />
-						View detailed explanations
+						View detailed rationales
 					</li>
 					<li class="flex items-center gap-2">
 						<Check size={16} class="text-success" />
@@ -230,7 +236,7 @@
 		</div>
 	</div>
 
-<!-- Pro User View - Already subscribed -->
+	<!-- Pro User View - Already subscribed -->
 {:else if isPro}
 	<div class="mx-auto max-w-4xl px-4 py-12">
 		<div class="text-center mb-8">
@@ -241,7 +247,9 @@
 			<h1 class="text-3xl font-bold mb-2">You're on Curator Pro</h1>
 			<p class="text-base-content/70">
 				{#if subscriptionQuery.data?.subscription?.currentPeriodEnd}
-					Your subscription renews on {new Date(subscriptionQuery.data.subscription.currentPeriodEnd).toLocaleDateString()}
+					Your subscription renews on {new Date(
+						subscriptionQuery.data.subscription.currentPeriodEnd
+					).toLocaleDateString()}
 				{:else}
 					You have full access to all Pro features.
 				{/if}
@@ -253,7 +261,9 @@
 				<h3 class="font-semibold mb-4">Your Pro Benefits</h3>
 				<div class="grid sm:grid-cols-2 gap-4">
 					<div class="flex items-start gap-3">
-						<div class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0">
+						<div
+							class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0"
+						>
 							<span class="font-bold text-success">300</span>
 						</div>
 						<div>
@@ -262,7 +272,9 @@
 						</div>
 					</div>
 					<div class="flex items-start gap-3">
-						<div class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0">
+						<div
+							class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0"
+						>
 							<span class="font-bold text-success">∞</span>
 						</div>
 						<div>
@@ -271,7 +283,9 @@
 						</div>
 					</div>
 					<div class="flex items-start gap-3">
-						<div class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0">
+						<div
+							class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0"
+						>
 							<Check size={20} class="text-success" />
 						</div>
 						<div>
@@ -280,7 +294,9 @@
 						</div>
 					</div>
 					<div class="flex items-start gap-3">
-						<div class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0">
+						<div
+							class="w-10 h-10 bg-success/10 rounded-lg flex items-center justify-center shrink-0"
+						>
 							<Check size={20} class="text-success" />
 						</div>
 						<div>
@@ -296,20 +312,16 @@
 			<button class="btn btn-outline" onclick={handleManageSubscription}>
 				Manage Subscription
 			</button>
-			<a href="/admin/question-studio" class="btn btn-primary">
-				Open Question Studio
-			</a>
+			<a href="/admin/question-studio" class="btn btn-primary"> Open Question Studio </a>
 		</div>
 	</div>
 
-<!-- Curator/Admin Free View - Can upgrade -->
+	<!-- Curator/Admin Free View - Can upgrade -->
 {:else}
 	<div class="mx-auto max-w-6xl px-4 py-12">
 		<div class="text-center mb-12">
 			<h1 class="text-4xl font-bold">Curator Plans</h1>
-			<p class="text-base-content/70 mt-3 text-lg">
-				Scale your content creation with Pro
-			</p>
+			<p class="text-base-content/70 mt-3 text-lg">Scale your content creation with Pro</p>
 		</div>
 
 		<!-- Billing Toggle -->
@@ -399,7 +411,9 @@
 				</div>
 				<div class="card-body">
 					<h2 class="card-title text-xl">Curator Pro</h2>
-					<p class="text-base-content/70 text-sm">Scale your content creation with expanded limits.</p>
+					<p class="text-base-content/70 text-sm">
+						Scale your content creation with expanded limits.
+					</p>
 
 					<div class="mt-6">
 						{#if productsQuery.isLoading}
@@ -408,7 +422,9 @@
 							<span class="text-4xl font-extrabold">
 								{formatPrice(currentProduct.prices?.[0]?.priceAmount)}
 							</span>
-							<span class="text-base-content/70">/{selectedInterval === 'semester' ? '6 months' : 'year'}</span>
+							<span class="text-base-content/70"
+								>/{selectedInterval === 'semester' ? '6 months' : 'year'}</span
+							>
 						{:else}
 							<span class="text-4xl font-extrabold">$15</span>
 							<span class="text-base-content/70">/6 months</span>
@@ -473,13 +489,21 @@
 				<details class="collapse collapse-arrow bg-base-200">
 					<summary class="collapse-title font-medium text-sm">Can I cancel anytime?</summary>
 					<div class="collapse-content text-sm text-base-content/70">
-						<p>Yes, you can cancel your subscription at any time. You'll retain Pro access until the end of your billing period.</p>
+						<p>
+							Yes, you can cancel your subscription at any time. You'll retain Pro access until the
+							end of your billing period.
+						</p>
 					</div>
 				</details>
 				<details class="collapse collapse-arrow bg-base-200">
-					<summary class="collapse-title font-medium text-sm">What happens when I hit my limits?</summary>
+					<summary class="collapse-title font-medium text-sm"
+						>What happens when I hit my limits?</summary
+					>
 					<div class="collapse-content text-sm text-base-content/70">
-						<p>On the free plan, you'll see a message when you've used your daily AI generations or PDF upload. Limits reset every 24 hours.</p>
+						<p>
+							On the free plan, you'll see a message when you've used your daily AI generations or
+							PDF upload. Limits reset every 24 hours.
+						</p>
 					</div>
 				</details>
 			</div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,46 @@
 {
 	"rewrites": [
 		{
+			"source": "/docs",
+			"has": [
+				{
+					"type": "host",
+					"value": "learnterms.com"
+				}
+			],
+			"destination": "https://learnterms.mintlify.dev/docs"
+		},
+		{
+			"source": "/docs/:match*",
+			"has": [
+				{
+					"type": "host",
+					"value": "learnterms.com"
+				}
+			],
+			"destination": "https://learnterms.mintlify.dev/docs/:match*"
+		},
+		{
+			"source": "/docs",
+			"has": [
+				{
+					"type": "host",
+					"value": "www.learnterms.com"
+				}
+			],
+			"destination": "https://learnterms.mintlify.dev/docs"
+		},
+		{
+			"source": "/docs/:match*",
+			"has": [
+				{
+					"type": "host",
+					"value": "www.learnterms.com"
+				}
+			],
+			"destination": "https://learnterms.mintlify.dev/docs/:match*"
+		},
+		{
 			"source": "/:path*",
 			"has": [
 				{


### PR DESCRIPTION
I’ve renamed the core question field from explanation to rationale throughout the runtime codepath. This touches everything from the schema and Convex mutations to the admin UI, exports, and the local question corpus. Most of the logic changes are centered in src/convex/question.ts, schema.ts, and the export/UI utilities. I also included a compatibility helper and backfill mutations to handle existing data safely, while intentionally leaving the worktree changes in +layout.svelte and vercel.json untouched.

The main driver for this is that "rationale" more accurately describes the field's purpose: justifying the correct answer and its alternatives. In the codebase, "explanation" was becoming a bit of a catch-all for general notes and feedback. Explicitly calling it "rationale" in the schema and actions removes that ambiguity and makes the domain model much easier to work with.

This also brings the code in line with the actual product experience. The study and review UIs already use the term "Rationale," so matching the underlying contract to that language makes the system more consistent. It should make things a lot clearer for anyone working on analytics or AI prompting down the road since the field's intent is now baked into the name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Product Updates**
  * "Explanation" replaced with "Rationale" across question creation, editing, review, previews, and exports.
  * Existing explanations are automatically migrated to the new rationale field.
  * Rationale content is now sanitized for safer HTML rendering.
  * Analytics scripts now run only in production.

* **Documentation**
  * External docs site link updated to https://docs.learnterms.com/
<!-- end of auto-generated comment: release notes by coderabbit.ai -->